### PR TITLE
Args now follow '--', to allow for multiple recipes on the command line

### DIFF
--- a/just
+++ b/just
@@ -18,7 +18,7 @@ fi
 
 declare -a RECIPES
 
-# export arguments after '--' uso they can be used in recipes
+# export arguments after '--' so they can be used in recipes
 I=0
 RECIPE_END=false
 for ARG in "$@"; do

--- a/just
+++ b/just
@@ -1,27 +1,38 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-# find the justfile
-while [ ! -e justfile ]; do
-  if [ "$PWD" = "/"  ] || [ "$PWD" = "$JUSTSTOP" ] || [ -e juststop ]; then
-    echo "No justfile found."
+# cd upwards to the justfile
+while [[ ! -e justfile ]]; do
+  if [[ $PWD = / ]] || [[ $PWD = $JUSTSTOP ]] || [[ -e juststop ]]; then
+    echo 'No justfile found.'
     exit 1
   fi
   cd ..
 done
 
-# use gmake if it exists
+# prefer gmake if it exists
 if command -v gmake > /dev/null; then
   MAKE=gmake
 else
   MAKE=make
 fi
 
-# export arguments so they can be used in recipes
+declare -a RECIPES
+
+# export arguments after '--' uso they can be used in recipes
 I=0
+RECIPE_END=false
 for ARG in "$@"; do
-  export ARG$I=$ARG
-  I=$((I + 1))
+  if [[ $RECIPE_END = true ]]; then
+    export ARG$I=$ARG
+    I=$((I + 1))
+  else
+    if [ $ARG = "--" ]; then
+      RECIPE_END=true
+    else
+      RECIPES+=($ARG)
+    fi
+  fi
 done
 
 # go!
-exec $MAKE --always-make --no-print-directory -f justfile $1 MAKEFLAGS=''
+exec $MAKE MAKEFLAGS='' --always-make --no-print-directory -f justfile ${RECIPES[*]}


### PR DESCRIPTION
@aoeu: What do you think about this?

I've been finding that I want to run multiple recipes in one go far more often than I need to pass arguments to a recipe.

This changes it so that multiple recipes are allowed, and arguments only start after a '--'.

As far as I can tell, there is no way to do this sanely in the bourne shell, so it introduces a dependency on bash.