### PR TITLE
Start args at ARG1, remove ARG0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Adding one argument specifies the recipe:
 
 `just compile`
 
-Arguments after '--' are exported as ARG0, ARG1, ... ARGN, which can be used in the justfile. To run recipe "compile" and export ARG0=bar and ARG1=baz:
+Arguments after '--' are exported as ARG1, ARG2, ... ARGN, which can be used in the justfile. To run recipe "compile" and export ARG1=foo and ARG2=bar:
 
-`just compile -- bar baz`
+`just compile -- foo bar`
 
 You might want to alias `just` to `j`, so that it's even easier to run.
 

--- a/just
+++ b/just
@@ -19,7 +19,7 @@ fi
 declare -a RECIPES
 
 # export arguments after '--' so they can be used in recipes
-I=0
+I=1
 RECIPE_END=false
 for ARG in "$@"; do
   if [[ $RECIPE_END = true ]]; then
@@ -28,6 +28,7 @@ for ARG in "$@"; do
   else
     if [ $ARG = "--" ]; then
       RECIPE_END=true
+      shift
     else
       RECIPES+=($ARG)
     fi

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ clean:
 
 # demonstrate the use of positional arguments
 args:
-	@echo "I got some arguments: ARG0=$$ARG0 ARG1=$$ARG1 ARG2=$$ARG2"
+	@echo "I got some arguments: ARG1=$$ARG1 ARG2=$$ARG2 ARG3=$$ARG3"
 
 # put symlinks to just into ~/bin
 install:


### PR DESCRIPTION
I reason we could have introduced a bug (or maybe an inconsistency, or maybe neither) with argument numbering.  My mistake for not catching that and bringing it up during review! I tried out multiple recipes with one just command, but not multiple args, which is, ironically, the entire point of the change in the first-place: we aren't using args as much.

What I'm wondering about is whether argument ordering could stand to start at ARG1 instead of ARG0 for a few reasons:
- Backwards compatibility with older recipes (This is not a priority for me.)
- bash function args start at $1
- I don't know if it is ubiquitous in Un*x, but the "zeroeth" argument is the program name in some things, and it used to be the recipe name in the case of just.

On that last point, I don't know what's the most correct thing to do with ARG0 - maybe leaving everything as is best: all args are just args, including the zeroeth arg. Thoughts?