### PR TITLE
Allow justfile to be named `Justfile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ just
 
 `just` is a handy way to save and run commands.
 
-Commands are stored in a file called `justfile` with syntax inspired by `make`:
+Commands are stored in a file called `justfile` or `Justfile` with syntax inspired by `make`:
 
 ```make
 test-all: build


### PR DESCRIPTION
Priority is given to `justfile` to match the behavior of GNU make.

Based on @jerenept's code in #13, but with some added tests.