### PR TITLE
Use version from env! macro

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,14 +21,13 @@ version = `sed -En 's/version = "([^"]+)"/\1/p' Cargo.toml`
 publish: clippy build
 	git branch | grep '* master'
 	git diff --no-ext-diff --quiet --exit-code
-	grep 'version("{{version}}")' src/app.rs
 	git co -b v{{version}}
 	git push github
 	cargo publish
 	git tag -a "v{{version}}" -m "v{{version}}"
 	git push github --tags
 	git push origin --tags
-	@echo 'Remember to merge v{{version}} branch on GitHub!'
+	@echo 'Remember to merge the v{{version}} branch on GitHub!'
 
 clippy:
 	rustup run nightly cargo clippy

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,7 +23,7 @@ macro_rules! die {
 
 pub fn app() {
   let matches = App::new("just")
-    .version("0.2.16")
+    .version(concat!("v", env!("CARGO_PKG_VERSION")))
     .author("Casey Rodarmor <casey@rodarmor.com>")
     .about("Just a command runner - https://github.com/casey/just")
     .setting(AppSettings::ColoredHelp)


### PR DESCRIPTION
This saves us from having to manually keep the version string in app.rs
up to date, so we can also drop that check from the publish recipe.

Fixes #36