### PR TITLE
Add no-op recipe to justfile for testing

### DIFF
--- a/justfile
+++ b/justfile
@@ -42,6 +42,8 @@ install-nightly:
 sloc:
 	@cat src/*.rs | wc -l
 
+nop:
+
 # make a quine, compile it, and verify it
 quine: create
 	cc tmp/gen0.c -o tmp/gen0


### PR DESCRIPTION
Useful for testing using `cargo run -- nop` to make sure that things aren't horribly broken.