### PR TITLE
Fix off by one error in backtick error message

### DIFF
--- a/src/integration.rs
+++ b/src/integration.rs
@@ -372,6 +372,21 @@ fn backtick_code_interpolation() {
 }
 
 #[test]
+fn backtick_code_long() {
+  integration_test(
+    &[],
+    "\n\n\n\n\n\nb = a\na = `echo hello`\nbar:\n echo '{{`exit 200`}}'",
+    200,
+    "",
+    "backtick failed with exit code 200
+   |
+10 |  echo '{{`exit 200`}}'
+   |          ^^^^^^^^^^
+",
+  );
+}
+
+#[test]
 fn shebang_backtick_failure() {
   integration_test(
     &[],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1068,9 +1068,10 @@ impl<'a> Display for RunError<'a> {
         try!(write!(f, "backtick failed with exit code {}\n", code));
         match token.text.lines().nth(token.line) {
           Some(line) => {
-            let line_number_width = token.line.to_string().len();
+            let displayed_line = token.line + 1;
+            let line_number_width = displayed_line.to_string().len();
             try!(write!(f, "{0:1$} |\n", "", line_number_width));
-            try!(write!(f, "{} | {}\n", token.line + 1, line));
+            try!(write!(f, "{} | {}\n", displayed_line, line));
             try!(write!(f, "{0:1$} |", "", line_number_width));
             try!(write!(f, " {0:1$}{2:^<3$}", "",
                         token.column + token.prefix.len(), "", token.lexeme.len()));


### PR DESCRIPTION
I was using the width of the index of the line, not the displayed line
number, which is the index + 1, which could cause the error message to
be misaligned.

Fixed it, and added a test that checks for this.