### PR TITLE
Bump version to 0.2.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "just"
-version = "0.2.16"
+version = "0.2.18"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "just"
-version     = "0.2.16"
+version     = "0.2.18"
 description = "🤖 Just a command runner"
 authors     = ["Casey Rodarmor <casey@rodarmor.com>"]
 license     = "WTFPL/MIT/Apache-2.0"


### PR DESCRIPTION
Skipped 0.2.17 (which was published but yanked) because publish recipe was wrong