### PR TITLE
Make `--list` print recipes with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,12 @@ Hello from ruby!
 
 ```sh
 $ just --list
-js perl polyglot python ruby
+Available recipes:
+  js
+  perl
+  polyglot
+  python
+  ruby
 $ just --show perl
 perl:
     #!/usr/bin/env perl

--- a/justfile
+++ b/justfile
@@ -17,8 +17,8 @@ build:
 check:
 	cargo check
 
-watch command='test':
-	cargo watch {{command}}
+watch COMMAND='test':
+	cargo watch {{COMMAND}}
 
 version = `sed -En 's/version[[:space:]]*=[[:space:]]*"([^"]+)"/v\1/p' Cargo.toml`
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -57,13 +57,15 @@ pub fn app() {
     .arg(Arg::with_name("list")
          .short("l")
          .long("list")
-         .help("Lists available recipes")
+         .help("Lists available recipes and their arguments")
          .conflicts_with("dump")
-         .conflicts_with("show"))
+         .conflicts_with("show")
+         .conflicts_with("summary"))
     .arg(Arg::with_name("dump")
          .long("dump")
          .help("Prints entire justfile")
          .conflicts_with("show")
+         .conflicts_with("summary")
          .conflicts_with("list"))
     .arg(Arg::with_name("show")
          .short("s")
@@ -72,6 +74,13 @@ pub fn app() {
          .value_name("recipe")
          .help("Shows information about <recipe>")
          .conflicts_with("dump")
+         .conflicts_with("summary")
+         .conflicts_with("list"))
+    .arg(Arg::with_name("summary")
+         .long("summary")
+         .help("Lists names of available recipes")
+         .conflicts_with("dump")
+         .conflicts_with("show")
          .conflicts_with("list"))
     .arg(Arg::with_name("quiet")
          .short("q")
@@ -170,9 +179,9 @@ pub fn app() {
     }
   );
 
-  if matches.is_present("list") {
+  if matches.is_present("summary") {
     if justfile.count() == 0 {
-      warn!("Justfile contains no recipes");
+      warn!("Justfile contains no recipes.");
     } else {
       println!("{}", justfile.recipes().join(" "));
     }
@@ -184,8 +193,20 @@ pub fn app() {
     process::exit(0);
   }
 
+  if matches.is_present("list") {
+    println!("Available recipes:");
+    for (name, recipe) in &justfile.recipes {
+      print!("    {}", name);
+      for parameter in &recipe.parameters {
+        print!(" {}", parameter);
+      }
+      println!("");
+    }
+    process::exit(0);
+  }
+
   if let Some(name) = matches.value_of("show") {
-    match justfile.get(name) {
+    match justfile.recipes.get(name) {
       Some(recipe) => {
         println!("{}", recipe);
         process::exit(0);

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -193,14 +193,14 @@ c: b
 }
 
 #[test]
-fn list() {
+fn summary() {
   let text = 
 "b: a
 a:
 d: c
 c: b";
   integration_test(
-    &["--list"],
+    &["--summary"],
     text,
     0,
     "a b c d\n",
@@ -1072,5 +1072,24 @@ hello a b='B' c='C':
     0,
     "0 1 2\n",
     "echo 0 1 2\n",
+  );
+}
+
+#[test]
+fn list() {
+  integration_test(
+    &["--list"],
+    r#"
+hello a b='B	' c='C':
+  echo {{a}} {{b}} {{c}}
+
+a Z="\t z":
+"#,
+    0,
+    r"Available recipes:
+    a Z='\t z'
+    hello a b='B\t' c='C'
+",
+    "",
   );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,8 @@ impl<'a> Display for Parameter<'a> {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     write!(f, "{}", self.name)?;
     if let Some(ref default) = self.default {
-      write!(f, r#"="{}""#, default)?;
+      let escaped = default.chars().flat_map(char::escape_default).collect::<String>();;
+      write!(f, r#"='{}'"#, escaped)?;
     }
     Ok(())
   }
@@ -1140,10 +1141,6 @@ impl<'a, 'b> Justfile<'a> where 'a: 'b {
     recipe.run(arguments, scope, &self.exports, options)?;
     ran.insert(recipe.name);
     Ok(())
-  }
-
-  fn get(&self, name: &str) -> Option<&Recipe<'a>> {
-    self.recipes.get(name)
   }
 }
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -262,7 +262,7 @@ fn parse_string_default() {
 foo a="b\t":
 
 
-  "#, r#"foo a="b	":"#);
+  "#, r#"foo a='b\t':"#);
 }
 
 #[test]
@@ -272,7 +272,7 @@ fn parse_raw_string_default() {
 foo a='b\t':
 
 
-  "#, r#"foo a="b\t":"#);
+  "#, r#"foo a='b\\t':"#);
 }
 
 #[test]


### PR DESCRIPTION
Added `--summary` which just prints recipe names, like `--list` previous
to this change.

Fixes #75