### PR TITLE
Allow line continuations in plain recipes with '\'

### DIFF
--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1157,3 +1157,51 @@ a Z="\t z":
     "error: Justfile does not contain recipe `hell`.\nDid you mean `hello`?\n",
   );
 }
+
+#[test]
+fn line_continuation_with_space() {
+  integration_test(
+    &[],
+    r#"
+foo:
+  echo a\
+         b  \
+             c
+"#,
+    0,
+    "a b c\n",
+    "echo a       b             c\n",
+  );
+}
+
+#[test]
+fn line_continuation_with_quoted_space() {
+  integration_test(
+    &[],
+    r#"
+foo:
+  echo 'a\
+         b  \
+             c'
+"#,
+    0,
+    "a       b             c\n",
+    "echo 'a       b             c'\n",
+  );
+}
+
+#[test]
+fn line_continuation_no_space() {
+  integration_test(
+    &[],
+    r#"
+foo:
+  echo a\
+  b\
+  c
+"#,
+    0,
+    "abc\n",
+    "echo abc\n",
+  );
+}

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -721,8 +721,6 @@ fn unknown_recipes() {
 
 #[test]
 fn extra_whitespace() {
-  // we might want to make extra leading whitespace a line continuation in the future,
-  // so make it a error for now
   let text = "a:\n blah\n  blarg";
   parse_error(text, CompileError {
     text:   text,


### PR DESCRIPTION
Some ugly code, but not as bad as I thought.

Elected not to go with indentation based line continuations. Too many
weird edge cases and feels like a gratuitious incompatibility with make.

Fixes #9