### PR TITLE
Add doc comments to recipes

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -13,7 +13,7 @@ tokens
 BACKTICK            = `[^`\n\r]*`
 COLON               = :
 COMMENT             = #([^!].*)?$
-EOL                 = \n|\r\n
+NEWLINE             = \n|\r\n
 EQUALS              = =
 INTERPOLATION_START = {{
 INTERPOLATION_END   = }}
@@ -36,9 +36,12 @@ justfile      : item* EOF
 item          : recipe
               | assignment
               | export
-              | EOL
+              | eol
 
-assignment    : NAME '=' expression EOL
+eol           : NEWLINE
+              | COMMENT NEWLINE
+
+assignment    : NAME '=' expression eol
 
 export        : 'export' assignment
 
@@ -58,7 +61,7 @@ dependencies  : NAME+
 
 body          : INDENT line+ DEDENT
 
-line          : LINE (TEXT | interpolation)+ EOL
+line          : LINE (TEXT | interpolation)+ eol
 
 interpolation : '{{' expression '}}'
 ```

--- a/justfile
+++ b/justfile
@@ -5,9 +5,7 @@ test: build
 filter PATTERN: build
 	cargo test --lib {{PATTERN}}
 
-test-quine:
-	cargo run -- quine clean
-
+# test with backtrace
 backtrace:
 	RUST_BACKTRACE=1 cargo test --lib
 
@@ -22,6 +20,7 @@ watch COMMAND='test':
 
 version = `sed -En 's/version[[:space:]]*=[[:space:]]*"([^"]+)"/v\1/p' Cargo.toml`
 
+# publish to crates.io
 publish: lint clippy test
 	git branch | grep '* master'
 	git diff --no-ext-diff --quiet --exit-code
@@ -33,6 +32,7 @@ publish: lint clippy test
 	git push origin --tags
 	@echo 'Remember to merge the {{version}} branch on GitHub!'
 
+# clean up feature branch BRANCH
 done BRANCH:
 	git checkout {{BRANCH}}
 	git pull --rebase github master
@@ -40,9 +40,11 @@ done BRANCH:
 	git pull --rebase github master
 	git branch -d {{BRANCH}}
 
+# install just from crates.io
 install:
 	cargo install -f just
 
+# install development dependencies
 install-dev-deps:
 	rustup install nightly
 	rustup update nightly
@@ -50,14 +52,18 @@ install-dev-deps:
 	cargo install -f cargo-watch
 	cargo install -f cargo-check
 
+# everyone's favorite animate paper clip
 clippy:
 	rustup run nightly cargo clippy
 
+# count non-empty lines of code
 sloc:
-	@cat src/*.rs | wc -l
+	@cat src/*.rs | sed '/^\s*$/d' | wc -l
 
 lint:
+	echo Checking for FIXME/TODO...
 	! grep --color -En 'FIXME|TODO' src/*.rs
+	echo Checking for long lines...
 	! grep --color -En '.{100}' src/*.rs
 
 nop:
@@ -67,6 +73,9 @@ fail:
 
 backtick-fail:
 	echo {{`exit 1`}}
+
+test-quine:
+	cargo run -- quine clean
 
 # make a quine, compile it, and verify it
 quine: create

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1004,13 +1004,15 @@ recipe:
 #[test]
 fn dump() {
   let text ="
+# this recipe does something
 recipe:
  @exit 100";
   integration_test(
     &["--dump"],
     text,
     0,
-    "recipe:
+    "# this recipe does something
+recipe:
     @exit 100
 ",
     "",
@@ -1096,15 +1098,19 @@ fn list() {
   integration_test(
     &["--list"],
     r#"
+
+# this does a thing
 hello a b='B	' c='C':
   echo {{a}} {{b}} {{c}}
+
+# this comment will be ignored
 
 a Z="\t z":
 "#,
     0,
     r"Available recipes:
     a Z='\t z'
-    hello a b='B\t' c='C'
+    hello a b='B\t' c='C' # this does a thing
 ",
     "",
   );

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -90,36 +90,38 @@ fn parse_error(text: &str, expected: CompileError) {
 #[test]
 fn tokanize_strings() {
   tokenize_success(
-    r#"a = "'a'" + '"b"' + "'c'" + '"d"'"#,
-    r#"N="+'+"+'."#
+    r#"a = "'a'" + '"b"' + "'c'" + '"d"'#echo hello"#,
+    r#"N="+'+"+'#."#
   );
 }
 
 #[test]
 fn tokenize_recipe_interpolation_eol() {
-  let text = "foo:
+  let text = "foo: # some comment
  {{hello}}
 ";
-  tokenize_success(text, "N:$>^{N}$<.");
+  tokenize_success(text, "N:#$>^{N}$<.");
 }
 
 #[test]
 fn tokenize_recipe_interpolation_eof() {
-  let text = "foo:
- {{hello}}";
-  tokenize_success(text, "N:$>^{N}<.");
+  let text = "foo: # more comments
+ {{hello}}
+# another comment
+";
+  tokenize_success(text, "N:#$>^{N}$<#$.");
 }
 
 #[test]
 fn tokenize_recipe_complex_interpolation_expression() {
-  let text = "foo:\n {{a + b + \"z\" + blarg}}";
-  tokenize_success(text, "N:$>^{N+N+\"+N}<.");
+  let text = "foo: #lol\n {{a + b + \"z\" + blarg}}";
+  tokenize_success(text, "N:#$>^{N+N+\"+N}<.");
 }
 
 #[test]
 fn tokenize_recipe_multiple_interpolations() {
-  let text = "foo:\n {{a}}0{{b}}1{{c}}";
-  tokenize_success(text, "N:$>^{N}_{N}_{N}<.");
+  let text = "foo:#ok\n {{a}}0{{b}}1{{c}}";
+  tokenize_success(text, "N:#$>^{N}_{N}_{N}<.");
 }
 
 #[test]
@@ -134,16 +136,19 @@ hello blah blah blah : a b c #whatever
 #[test]
 fn tokenize_empty_lines() {
   let text = "
+# this does something
 hello:
   asdf
   bsdf
 
   csdf
 
-  dsdf
+  dsdf # whatever
+
+# yolo
   ";
 
-  tokenize_success(text, "$N:$>^_$^_$$^_$$^_$<.");
+  tokenize_success(text, "$#$N:$>^_$^_$$^_$$^_$$<#$.");
 }
 
 #[test]
@@ -173,11 +178,12 @@ hello:
 
   d
 
+# hello
 bob:
   frank
   ";
 
-  tokenize_success(text, "$N:$>^_$^_$$^_$$^_$$<N:$>^_$<.");
+  tokenize_success(text, "$N:$>^_$^_$$^_$$^_$$<#$N:$>^_$<.");
 }
 
 


### PR DESCRIPTION
If a `#...` comment appears on the line immediately before a recipe, it
is considered to be a doc comment for that recipe.

Doc comments will be printed when recipes are `--list`ed or `--dump`ed.

Also adds some color to the `--list`ing.

Fixes #84