### PR TITLE
Fix spurious circular dependency error

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,6 +40,12 @@ done BRANCH:
 	git pull --rebase github master
 	git branch -d {{BRANCH}}
 
+# push master to github as branch GITHUB-BRANCH
+push GITHUB-BRANCH:
+	git branch | grep '* master'
+	git diff --no-ext-diff --quiet --exit-code
+	git push github master:refs/heads/{{GITHUB-BRANCH}}
+
 # install just from crates.io
 install:
 	cargo install -f just

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1242,3 +1242,33 @@ fn quiet_shebang_recipe() {
     "#!/bin/sh\necho hello\n",
   );
 }
+
+#[test]
+fn complex_dependencies() {
+  integration_test(
+    &["b"],
+    r#"
+a: b
+b:
+c: b a
+"#,
+    0,
+    "",
+    ""
+  );
+}
+
+#[test]
+fn long_circular_recipe_dependency() {
+  integration_test(
+    &["a"],
+    "a: b\nb: c\nc: d\nd: a",
+    255,
+    "",
+    "error: recipe `d` has circular dependency `a -> b -> c -> d -> a`
+  |
+4 | d: a
+  |    ^
+",
+  );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,6 +473,7 @@ fn resolve_recipes<'a>(
   
   for recipe in recipes.values() {
     resolver.resolve(recipe)?;
+    resolver.seen = empty();
   }
 
   for recipe in recipes.values() {


### PR DESCRIPTION
The resolver.seen() needs to be cleared between recipes.

Also add push recipe for creating branches on github without needing to
create one locally.