### PR TITLE
Renames: Parser::file and just::parse

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6,7 +6,7 @@ extern crate ansi_term;
 use std::{io, fs, env, process, convert, ffi};
 use std::collections::BTreeMap;
 use self::clap::{App, Arg, ArgGroup, AppSettings};
-use super::{Slurp, RunError};
+use super::{Slurp, RunError, RunOptions, compile};
 
 macro_rules! warn {
   ($($arg:tt)*) => {{
@@ -199,7 +199,7 @@ pub fn app() {
       .unwrap_or_else(|error| die!("Error reading justfile: {}", error));
   }
 
-  let justfile = super::parse(&text).unwrap_or_else(|error|
+  let justfile = compile(&text).unwrap_or_else(|error|
     if use_color.should_color_stream(atty::Stream::Stderr) {
       die!("{:#}", error);
     } else {
@@ -287,7 +287,7 @@ pub fn app() {
     die!("Justfile contains no recipes");
   };
 
-  let options = super::RunOptions {
+  let options = RunOptions {
     dry_run:   matches.is_present("dry-run"),
     evaluate:  matches.is_present("evaluate"),
     overrides: overrides,

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -3,7 +3,7 @@ extern crate brev;
 extern crate regex;
 
 use tempdir::TempDir;
-use super::std::{fs, path, process};
+use std::{env, fs, path, process, str};
 
 fn integration_test(
   args:            &[&str],
@@ -18,7 +18,7 @@ fn integration_test(
   let mut path = tmp.path().to_path_buf();
   path.push("justfile");
   brev::dump(path, justfile);
-  let mut binary = super::std::env::current_dir().unwrap();
+  let mut binary = env::current_dir().unwrap();
   binary.push("./target/debug/just");
   let output = process::Command::new(binary)
     .current_dir(tmp.path())
@@ -34,13 +34,13 @@ fn integration_test(
     failure = true;
   }
 
-  let stdout = super::std::str::from_utf8(&output.stdout).unwrap();
+  let stdout = str::from_utf8(&output.stdout).unwrap();
   if stdout != expected_stdout {
     println!("bad stdout:\ngot:\n{}\n\nexpected:\n{}", stdout, expected_stdout);
     failure = true;
   }
 
-  let stderr = super::std::str::from_utf8(&output.stderr).unwrap();
+  let stderr = str::from_utf8(&output.stderr).unwrap();
   if stderr != expected_stderr {
     println!("bad stderr:\ngot:\n{}\n\nexpected:\n{}", stderr, expected_stderr);
     failure = true;
@@ -52,7 +52,7 @@ fn integration_test(
 }
 
 fn search_test<P: AsRef<path::Path>>(path: P) {
-  let mut binary = super::std::env::current_dir().unwrap();
+  let mut binary = env::current_dir().unwrap();
   binary.push("./target/debug/just");
   let output = process::Command::new(binary)
     .current_dir(path)
@@ -61,10 +61,10 @@ fn search_test<P: AsRef<path::Path>>(path: P) {
 
   assert_eq!(output.status.code().unwrap(), 0);
 
-  let stdout = super::std::str::from_utf8(&output.stdout).unwrap();
+  let stdout = str::from_utf8(&output.stdout).unwrap();
   assert_eq!(stdout, "ok\n");
 
-  let stderr = super::std::str::from_utf8(&output.stderr).unwrap();
+  let stderr = str::from_utf8(&output.stderr).unwrap();
   assert_eq!(stderr, "echo ok\n");
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1717,7 +1717,7 @@ fn tokenize(text: &str) -> Result<Vec<Token>, CompileError> {
   Ok(tokens)
 }
 
-fn parse(text: &str) -> Result<Justfile, CompileError> {
+fn compile(text: &str) -> Result<Justfile, CompileError> {
   let tokens = tokenize(text)?;
   let parser = Parser {
     text:              text,
@@ -1727,7 +1727,7 @@ fn parse(text: &str) -> Result<Justfile, CompileError> {
     assignment_tokens: empty(),
     exports:           empty(),
   };
-  parser.file()
+  parser.justfile()
 }
 
 struct Parser<'a> {
@@ -1976,7 +1976,7 @@ impl<'a> Parser<'a> {
     Ok(())
   }
 
-  fn file(mut self) -> Result<Justfile<'a>, CompileError<'a>> {
+  fn justfile(mut self) -> Result<Justfile<'a>, CompileError<'a>> {
     let mut doc = None;
     loop {
       match self.tokens.next() {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,11 +1,16 @@
 extern crate tempdir;
 extern crate brev;
 
-use super::{Token, CompileError, ErrorKind, Justfile, RunError, RunOptions};
+use super::{
+  And, CompileError, ErrorKind, Justfile, Or,
+  RunError, RunOptions, Token, compile, contains,
+  tokenize
+};
+
 use super::TokenKind::*;
 
 fn tokenize_success(text: &str, expected_summary: &str) {
-  let tokens = super::tokenize(text).unwrap();
+  let tokens = tokenize(text).unwrap();
   let roundtrip = tokens.iter().map(|t| {
     let mut s = String::new();
     s += t.prefix;
@@ -20,7 +25,7 @@ fn tokenize_success(text: &str, expected_summary: &str) {
 }
 
 fn tokenize_error(text: &str, expected: CompileError) {
-  if let Err(error) = super::tokenize(text) {
+  if let Err(error) = tokenize(text) {
     assert_eq!(error.text,   expected.text);
     assert_eq!(error.index,  expected.index);
     assert_eq!(error.line,   expected.line);
@@ -57,7 +62,7 @@ fn token_summary(tokens: &[Token]) -> String {
 }
 
 fn parse_success(text: &str) -> Justfile {
-  match super::parse(text) {
+  match compile(text) {
     Ok(justfile) => justfile,
     Err(error) => panic!("Expected successful parse but got error:\n{}", error),
   }
@@ -74,7 +79,7 @@ fn parse_summary(input: &str, output: &str) {
 }
 
 fn parse_error(text: &str, expected: CompileError) {
-  if let Err(error) = super::parse(text) {
+  if let Err(error) = compile(text) {
     assert_eq!(error.text,   expected.text);
     assert_eq!(error.index,  expected.index);
     assert_eq!(error.line,   expected.line);
@@ -705,27 +710,27 @@ fn mixed_leading_whitespace() {
 
 #[test]
 fn conjoin_or() {
-  assert_eq!("1",             super::Or(&[1      ]).to_string());
-  assert_eq!("1 or 2",        super::Or(&[1,2    ]).to_string());
-  assert_eq!("1, 2, or 3",    super::Or(&[1,2,3  ]).to_string());
-  assert_eq!("1, 2, 3, or 4", super::Or(&[1,2,3,4]).to_string());
+  assert_eq!("1",             Or(&[1      ]).to_string());
+  assert_eq!("1 or 2",        Or(&[1,2    ]).to_string());
+  assert_eq!("1, 2, or 3",    Or(&[1,2,3  ]).to_string());
+  assert_eq!("1, 2, 3, or 4", Or(&[1,2,3,4]).to_string());
 }
 
 #[test]
 fn conjoin_and() {
-  assert_eq!("1",             super::And(&[1      ]).to_string());
-  assert_eq!("1 and 2",        super::And(&[1,2    ]).to_string());
-  assert_eq!("1, 2, and 3",    super::And(&[1,2,3  ]).to_string());
-  assert_eq!("1, 2, 3, and 4", super::And(&[1,2,3,4]).to_string());
+  assert_eq!("1",              And(&[1      ]).to_string());
+  assert_eq!("1 and 2",        And(&[1,2    ]).to_string());
+  assert_eq!("1, 2, and 3",    And(&[1,2,3  ]).to_string());
+  assert_eq!("1, 2, 3, and 4", And(&[1,2,3,4]).to_string());
 }
 
 #[test]
 fn range() {
-  assert!(super::contains(&(0..1), 0));
-  assert!(super::contains(&(10..20), 15));
-  assert!(!super::contains(&(0..0), 0));
-  assert!(!super::contains(&(1..10), 0));
-  assert!(!super::contains(&(1..10), 10));
+  assert!(contains(&(0..1), 0));
+  assert!(contains(&(10..20), 15));
+  assert!(!contains(&(0..0), 0));
+  assert!(!contains(&(1..10), 0));
+  assert!(!contains(&(1..10), 10));
 }
 
 #[test]


### PR DESCRIPTION
Parser::file -> Parser::justfile
just::parse -> just::compile

Also get rid of super::, super::std