### PR TITLE
Add --verbose flag

### DIFF
--- a/justfile
+++ b/justfile
@@ -113,10 +113,6 @@ create:
 	mkdir -p tmp
 	@echo '{{quine-text}}' > tmp/gen0.c
 
-# clean up
-clean:
-	rm -r tmp
-
 # run all polyglot recipes
 polyglot: python js perl sh ruby
 

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -165,6 +165,18 @@ fn quiet() {
 }
 
 #[test]
+fn verbose() {
+  integration_test(
+    &["--verbose"],
+    "default:\n @echo hello",
+    0,
+    "hello\n",
+    "===> Running recipe `default`...\necho hello\n",
+  )
+}
+
+
+#[test]
 fn order() {
   let text = "
 b: a


### PR DESCRIPTION
Causes all recipe lines to be printed, regardless of --quiet or `@`.
Prints the name of each recipe before running it. Hopefully useful for
diagnosing problems.