### PR TITLE
Fix line numbers

### DIFF
--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1275,6 +1275,41 @@ fn quiet_shebang_recipe() {
 }
 
 #[test]
+fn shebang_line_numbers() {
+  integration_test(
+    &[],
+    r#"
+quiet:
+  #!/usr/bin/env cat
+
+  a
+
+  b
+
+
+  c
+
+
+"#,
+    0,
+    "#!/usr/bin/env cat
+
+
+
+a
+
+b
+
+
+c
+
+
+",
+    "",
+  );
+}
+
+#[test]
 fn complex_dependencies() {
   integration_test(
     &["b"],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,6 +394,11 @@ impl<'a> Recipe<'a> {
         if quiet_command {
           command = &command[1..];
         }
+
+        if command == "" {
+          continue;
+        }
+
         if options.dry_run
           || options.verbose
           || !((quiet_command ^ self.quiet) || options.quiet) {
@@ -1318,7 +1323,7 @@ impl<'a> Display for RunError<'a> {
         write!(f, "Recipe `{}` failed with exit code {}", recipe, code)?;
       },
       Signal{recipe, signal} => {
-        write!(f, "Recipe `{}` wast terminated by signal {}", recipe, signal)?;
+        write!(f, "Recipe `{}` was terminated by signal {}", recipe, signal)?;
       }
       UnknownFailure{recipe} => {
         write!(f, "Recipe `{}` failed for an unknown reason", recipe)?;
@@ -1886,6 +1891,7 @@ impl<'a> Parser<'a> {
     if self.accepted(Indent) {
       while !self.accepted(Dedent) {
         if self.accepted(Eol) {
+          lines.push(vec![]);
           continue;
         }
         if let Some(token) = self.expect(Line) {


### PR DESCRIPTION
Blank lines were being ignored by the parser, so lines would be reported
incorrectly in error messages from shebang recipes. Blank lines are now
included by the parser, so shebang recipes expand to have the non-blank
lines in the expected place in the file.