### PR TITLE
Report line number in recipe failure messages

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -61,7 +61,8 @@ dependencies  : NAME+
 
 body          : INDENT line+ DEDENT
 
-line          : LINE (TEXT | interpolation)+ eol
+line          : LINE (TEXT | interpolation)+ NEWLINE
+              | NEWLINE
 
 interpolation : '{{' expression '}}'
 ```

--- a/justfile
+++ b/justfile
@@ -46,6 +46,11 @@ push GITHUB-BRANCH:
 	git diff --no-ext-diff --quiet --exit-code
 	git push github master:refs/heads/{{GITHUB-BRANCH}}
 
+push-f GITHUB-BRANCH:
+	git branch | grep '* master'
+	git diff --no-ext-diff --quiet --exit-code
+	git push github -f master:refs/heads/{{GITHUB-BRANCH}}
+
 # install just from crates.io
 install:
 	cargo install -f just

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -283,14 +283,17 @@ recipe:
 fn status_passthrough() {
   let text = 
 "
+
+hello:
+
 recipe:
- @exit 100";
+  @exit 100";
   integration_test(
-    &[],
+    &["recipe"],
     text,
     100,
     "",
-    "error: Recipe `recipe` failed with exit code 100\n",
+    "error: Recipe `recipe` failed on line 6 with exit code 100\n",
   );
 }
 
@@ -1022,13 +1025,14 @@ fn color_auto() {
 fn colors_no_context() {
   let text ="
 recipe:
- @exit 100";
+  @exit 100";
   integration_test(
     &["--color=always"],
     text,
     100,
     "",
-    "\u{1b}[1;31merror:\u{1b}[0m \u{1b}[1mRecipe `recipe` failed with exit code 100\u{1b}[0m\n",
+    "\u{1b}[1;31merror:\u{1b}[0m \u{1b}[1m\
+Recipe `recipe` failed on line 3 with exit code 100\u{1b}[0m\n",
   );
 }
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -862,9 +862,10 @@ a:
 ";
 
   match parse_success(text).run(&["a"], &Default::default()).unwrap_err() {
-    RunError::Code{recipe, code} => {
+    RunError::Code{recipe, line_number, code} => {
       assert_eq!(recipe, "a");
       assert_eq!(code, 200);
+      assert_eq!(line_number, None);
     },
     other => panic!("expected an code run error, but got: {}", other),
   }
@@ -874,9 +875,10 @@ a:
 fn code_error() {
   match parse_success("fail:\n @exit 100")
     .run(&["fail"], &Default::default()).unwrap_err() {
-    RunError::Code{recipe, code} => {
+    RunError::Code{recipe, line_number, code} => {
       assert_eq!(recipe, "fail");
       assert_eq!(code, 100);
+      assert_eq!(line_number, Some(2));
     },
     other => panic!("expected a code run error, but got: {}", other),
   }
@@ -889,9 +891,10 @@ a return code:
  @x() { {{return}} {{code + "0"}}; }; x"#;
 
   match parse_success(text).run(&["a", "return", "15"], &Default::default()).unwrap_err() {
-    RunError::Code{recipe, code} => {
+    RunError::Code{recipe, line_number, code} => {
       assert_eq!(recipe, "a");
       assert_eq!(code, 150);
+      assert_eq!(line_number, Some(3));
     },
     other => panic!("expected an code run error, but got: {}", other),
   }
@@ -1017,8 +1020,9 @@ wut:
   };
 
   match parse_success(text).run(&["wut"], &options).unwrap_err() {
-    RunError::Code{code: _, recipe} => {
+    RunError::Code{code: _, line_number, recipe} => {
       assert_eq!(recipe, "wut");
+      assert_eq!(line_number, Some(8));
     },
     other => panic!("expected a recipe code errror, but got: {}", other),
   }


### PR DESCRIPTION
Also, for correctness, the grammar now permits blank lines in recipes.

Note that inside of recipes, the token `NEWLINE` is used instead of the
non-terminal `eol`. This is because an `eol` optionally includes a
comment, whereas inside recipes bodies comments get no special
treatment.