### PR TITLE
Add variadic parameters

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -4,7 +4,7 @@ justfile grammar
 Justfiles are processed by a mildly context-sensitive tokenizer
 and a recursive descent parser. The grammar is mostly LL(1),
 although an extra token of lookahead is used to distinguish between
-export assignments and recipes with arguments.
+export assignments and recipes with parameters.
 
 tokens
 ------
@@ -51,9 +51,9 @@ expression    : STRING
               | BACKTICK
               | expression '+' expression
 
-recipe        : '@'? NAME argument* ':' dependencies? body?
+recipe        : '@'? NAME parameter* ('+' parameter)? ':' dependencies? body?
 
-argument      : NAME
+parameter     : NAME
               | NAME '=' STRING
               | NAME '=' RAW_STRING
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,22 @@ Testing server:unit...
 ./test --tests unit server
 ```
 
+The last parameter to a recipe may be variadic, indicated with a `+` before the argument name:
+
+```make
+backup +FILES:
+  scp {{FILES}} me@server.com:
+```
+
+Variadic parameters accept one or more arguments and expand to a string containing those arguments separated by spaces:
+
+```sh
+$ just backup FAQ.md GRAMMAR.md
+scp FAQ.md GRAMMAR.md me@server.com:
+FAQ.md                  100% 1831     1.8KB/s   00:00
+GRAMMAR.md              100% 1666     1.6KB/s   00:00
+```
+
 Variables can be exported to recipes as environment variables:
 
 ```make

--- a/notes
+++ b/notes
@@ -1,2 +1,8 @@
 todo
 ====
+
+- variadic parameters work
+- variadic paramters are displayed in --dump correctly
+- they require one or more arguments
+- they expand to space separated string
+- an argument after a variadic one will complain

--- a/notes
+++ b/notes
@@ -1,8 +1,2 @@
 todo
 ====
-
-- variadic parameters work
-- variadic paramters are displayed in --dump correctly
-- they require one or more arguments
-- they expand to space separated string
-- an argument after a variadic one will complain

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1038,16 +1038,16 @@ Recipe `recipe` failed on line 3 with exit code 100\u{1b}[0m\n",
 
 #[test]
 fn dump() {
-  let text ="
+  let text = r#"
 # this recipe does something
-recipe:
- @exit 100";
+recipe a b +d:
+ @exit 100"#;
   integration_test(
     &["--dump"],
     text,
     0,
     "# this recipe does something
-recipe:
+recipe a b +d:
     @exit 100
 ",
     "",
@@ -1479,5 +1479,61 @@ a b=":
 2 | a b=":
   |     ^
 "#,
+  );
+}
+
+#[test]
+fn variadic_recipe() {
+  integration_test(
+    &["a", "0", "1", "2", "3", " 4 "],
+    "
+a x y +z:
+  echo {{x}} {{y}} {{z}}
+",
+    0,
+    "0 1 2 3 4\n",
+    "echo 0 1 2 3  4 \n",
+  );
+}
+
+#[test]
+fn variadic_ignore_default() {
+  integration_test(
+    &["a", "0", "1", "2", "3", " 4 "],
+    "
+a x y +z='HELLO':
+  echo {{x}} {{y}} {{z}}
+",
+    0,
+    "0 1 2 3 4\n",
+    "echo 0 1 2 3  4 \n",
+  );
+}
+
+#[test]
+fn variadic_use_default() {
+  integration_test(
+    &["a", "0", "1"],
+    "
+a x y +z='HELLO':
+  echo {{x}} {{y}} {{z}}
+",
+    0,
+    "0 1 HELLO\n",
+    "echo 0 1 HELLO\n",
+  );
+}
+
+#[test]
+fn variadic_too_few() {
+  integration_test(
+    &["a", "0", "1"],
+    "
+a x y +z:
+  echo {{x}} {{y}} {{z}}
+",
+    255,
+    "",
+    "error: Recipe `a` got 2 arguments but takes at least 3\n",
   );
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -400,7 +400,7 @@ fn missing_colon() {
     line:   0,
     column: 5,
     width:  Some(1),
-    kind:   ErrorKind::UnexpectedToken{expected: vec![Name, Colon], found: Eol},
+    kind:   ErrorKind::UnexpectedToken{expected: vec![Name, Plus, Colon], found: Eol},
   });
 }
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -278,6 +278,26 @@ foo a="b\t":
 }
 
 #[test]
+fn parse_variadic() {
+  parse_summary(r#"
+
+foo +a:
+
+
+  "#, r#"foo +a:"#);
+}
+
+#[test]
+fn parse_variadic_string_default() {
+  parse_summary(r#"
+
+foo +a="Hello":
+
+
+  "#, r#"foo +a='Hello':"#);
+}
+
+#[test]
 fn parse_raw_string_default() {
   parse_summary(r#"
 
@@ -453,6 +473,19 @@ fn missing_default_backtick() {
     column: 10,
     width:  Some(7),
     kind:   ErrorKind::UnexpectedToken{expected: vec![StringToken, RawString], found: Backtick},
+  });
+}
+
+#[test]
+fn parameter_after_variadic() {
+  let text = "foo +a bbb:";
+  parse_error(text, CompileError {
+    text:   text,
+    index:  7,
+    line:   0,
+    column: 7,
+    width:  Some(3),
+    kind:   ErrorKind::ParameterFollowsVariadicParameter{parameter: "bbb"}
   });
 }
 
@@ -826,6 +859,19 @@ fn unknown_second_interpolation_variable() {
 }
 
 #[test]
+fn plus_following_parameter() {
+  let text = "a b c+:";
+  parse_error(text, CompileError {
+    text:   text,
+    index:  5,
+    line:   0,
+    column: 5,
+    width:  Some(1),
+    kind:   ErrorKind::UnexpectedToken{expected: vec![Name], found: Plus},
+  });
+}
+
+#[test]
 fn tokenize_order() {
   let text = r"
 b: a
@@ -908,6 +954,19 @@ fn missing_some_arguments() {
       assert_eq!(found, 2);
       assert_eq!(min, 3);
       assert_eq!(max, 3);
+    },
+    other => panic!("expected an code run error, but got: {}", other),
+  }
+}
+
+#[test]
+fn missing_some_arguments_variadic() {
+  match parse_success("a b c +d:").run(&["a", "B", "C"], &Default::default()).unwrap_err() {
+    RunError::ArgumentCountMismatch{recipe, found, min, max} => {
+      assert_eq!(recipe, "a");
+      assert_eq!(found, 2);
+      assert_eq!(min, 3);
+      assert_eq!(max, super::std::usize::MAX - 1);
     },
     other => panic!("expected an code run error, but got: {}", other),
   }


### PR DESCRIPTION
Recipes may now have a final variadic parameter:

```make
foo bar+:
  @echo {{bar}}
```

Variadic parameters accept one or more arguments, and expand to a string containing those arguments separated by spaces:

```sh
$ just foo a b c d e
a b c d e
```

I elected to accept one or more arguments instead of zero or more arguments since unexpectedly empty arguments can sometimes be dangerous. 

```make
clean dir:
  rm -rf {{dir}}/bin
```

If `dir` is empty in the above recipe, you'll delete `/bin`, which is probably not what was intended.