### PR TITLE
Lift limitations on recipes that take parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ build target:
     cd {{target}} && make
 ```
 
-Recipes with parameters have limitations. Other recipes may not depend on them, and only one recipe with parameters may be given on the command line.
+Other recipes may not depend on a recipe with parameters.
 
 To pass arguments, put them after the recipe name:
 

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -911,7 +911,7 @@ foo A B:
     ",
     255,
     "",
-    "error: Recipe `foo` got 3 arguments but only takes 2\n",
+    "error: Justfile does not contain recipe `THREE`.\n",
   );
 }
 
@@ -939,7 +939,7 @@ foo A B='B':
     ",
     255,
     "",
-    "error: Recipe `foo` got 3 arguments but takes at most 2\n",
+    "error: Justfile does not contain recipe `THREE`.\n",
   );
 }
 
@@ -1535,5 +1535,25 @@ a x y +z:
     255,
     "",
     "error: Recipe `a` got 2 arguments but takes at least 3\n",
+  );
+}
+
+#[test]
+fn argument_grouping() {
+  integration_test(
+    &["BAR", "0", "FOO", "1", "2", "BAZ", "3", "4", "5"],
+    "
+FOO A B='blarg':
+  echo foo: {{A}} {{B}}
+
+BAR X:
+  echo bar: {{X}}
+
+BAZ +Z:
+  echo baz: {{Z}}
+",
+    0,
+    "bar: 0\nfoo: 1 2\nbaz: 3 4 5\n",
+    "echo bar: 0\necho foo: 1 2\necho baz: 3 4 5\n",
   );
 }


### PR DESCRIPTION
Previously, only one recipe with parameters could be passed on the
command line. This was to avoid confusion in case the number of
parameters a recipe took changed, and wound up using as an argument was
was once a recipe.

However, I don't think this is actually particularly confusing in
practice, and could be a slightly annoying limitation.

Now, any number of recipes with parameters may be given on the command
line.

Fixes #70