### PR TITLE
Allow path-prefixed first arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ cc main.c foo.c bar.c -o main
 testing... all tests passed!
 ```
 
+If the first argument passed to `just` contains a `/`, then the following occurs:
+
+1. The argument is split at the last `/`.
+2. The part before the last `/` is treated as a directory. Just will start its search for the justfile there, instead of the in current directory.
+3. The part after the last slash is treated as a normal argument, or ignored if it is empty.
+
+This may seem a little strange, but it's useful if you wish to run a command in a justfile that is in a subdirectory.
+
+For example, if you are in a directory which contains a subdirectory named `foo`, which contains justfile with the recipe `build`, which is also the default recipe, the following are all equivalent:
+
+```sh
+$ (cd foo && just build)
+$ just foo/build
+$ just foo/
+```
+
 Assignment, strings, concatination, and substitution with `{{...}}` are supported:
 
 ```make


### PR DESCRIPTION
If the first argument to just contains a `/`, then it will be handled
specially. Everything before the last `/` is treated as a directory, and
just will search for the justfile starting there, instead of in the
current directory.

Fixes #10