### PR TITLE
Resolve dependencies after the first

### DIFF
--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1859,3 +1859,22 @@ BAZ +Z:
     "echo bar: 0\necho foo: 1 2\necho baz: 3 4 5\n",
   );
 }
+
+#[test]
+fn missing_second_dependency() {
+  integration_test(
+    &[],
+    "
+x:
+
+a: x y
+",
+    255,
+    "",
+    "error: Recipe `a` has unknown dependency `y`
+  |
+4 | a: x y
+  |      ^
+",
+  );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,7 +589,7 @@ impl<'a, 'b> Resolver<'a, 'b> {
                 .cloned().collect()
             }));
           }
-          return self.resolve(dependency);
+          self.resolve(dependency)?;
         },
         None => return Err(dependency_token.error(ErrorKind::UnknownDependency {
           recipe:  recipe.name,


### PR DESCRIPTION
The recipe dependency resolver had a bug which caused it to not resolve
dependencies after the first.

This caused the parameter check later in the program to crash.

Added a test and fixed it.

Fixes #148.