### PR TITLE
🔥 Disallow names that start with '-'

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -17,7 +17,7 @@ NEWLINE             = \n|\r\n
 EQUALS              = =
 INTERPOLATION_START = {{
 INTERPOLATION_END   = }}
-NAME                = [a-zA-Z_-][a-zA-Z0-9_-]*
+NAME                = [a-zA-Z_][a-zA-Z0-9_-]*
 PLUS                = +
 RAW_STRING          = '[^'\r\n]*'
 STRING              = "[^"]*" # also processes \n \r \t \" \\ escapes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1530,7 +1530,7 @@ fn tokenize(text: &str) -> Result<Vec<Token>, CompileError> {
     static ref EQUALS:                    Regex = token(r"="                         );
     static ref INTERPOLATION_END:         Regex = token(r"[}][}]"                    );
     static ref INTERPOLATION_START_TOKEN: Regex = token(r"[{][{]"                    );
-    static ref NAME:                      Regex = token(r"([a-zA-Z_-][a-zA-Z0-9_-]*)");
+    static ref NAME:                      Regex = token(r"([a-zA-Z_][a-zA-Z0-9_-]*)" );
     static ref PLUS:                      Regex = token(r"[+]"                       );
     static ref STRING:                    Regex = token("\""                         );
     static ref RAW_STRING:                Regex = token(r#"'[^']*'"#                 );


### PR DESCRIPTION
This is done for two reasons:

1. Such names cannot be given on the command line, since clap will
intercept them and wrongly interpret them as flags.

2. The name '---' can conflict with yaml document delimiters. Kind of
speculative, but I was thinking that it would be nice to make sure that
'---' and '...' are illegal in a justfile, so that that one can be
included in a yaml document stream. Is this silly? I am really not sure.

This is backwards incompatible, but I don't think anyone will notice,
since names that start with '-' are likely to be rare.