### PR TITLE
Fix integration tests when system `sh` is recent bash

### DIFF
--- a/src/integration.rs
+++ b/src/integration.rs
@@ -806,14 +806,16 @@ fn raw_string() {
   integration_test(
     &[],
     r#"
-export exported_variable = '\\\\\\"'
+export exported_variable = '\\\\\\"\n'
 
 recipe:
-  echo {{`echo recipe $exported_variable`}}
+  printf '{{`echo recipe $exported_variable`}}'
 "#,
     0,
-    "recipe \\\"\n",
-    "echo recipe \\\\\\\"\n",
+    r#"recipe \\\"
+"#,
+    r#"printf 'recipe \\\\\\"\n'
+"#,
   );
 }
 
@@ -1225,11 +1227,11 @@ fn use_raw_string_default() {
     r#"
 bar:
 hello baz arg='XYZ\t\"	':
-  echo '{{baz}}...{{arg}}'
+  printf '{{baz}}...{{arg}}'
 "#,
     0,
-    "ABC...XYZ\t\\\"\t\n",
-    "echo 'ABC...XYZ\\t\\\"\t'\n",
+    "ABC...XYZ\t\"\t",
+    "printf 'ABC...XYZ\\t\\\"\t'\n",
   );
 }
 

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -809,12 +809,12 @@ fn raw_string() {
 export exported_variable = '\\\\\\"\n'
 
 recipe:
-  printf '{{`echo recipe $exported_variable`}}'
+  /bin/printf '{{`echo recipe $exported_variable`}}'
 "#,
     0,
     r#"recipe \\\"
 "#,
-    r#"printf 'recipe \\\\\\"\n'
+    r#"/bin/printf 'recipe \\\\\\"\n'
 "#,
   );
 }
@@ -1227,11 +1227,11 @@ fn use_raw_string_default() {
     r#"
 bar:
 hello baz arg='XYZ\t\"	':
-  printf '{{baz}}...{{arg}}'
+  /bin/printf '{{baz}}...{{arg}}'
 "#,
     0,
     "ABC...XYZ\t\"\t",
-    "printf 'ABC...XYZ\\t\\\"\t'\n",
+    "/bin/printf 'ABC...XYZ\\t\\\"\t'\n",
   );
 }
 


### PR DESCRIPTION
My main machine is now a Fedora box. OS X ships with an ancient
version of bash installed as `sh` due to the great GPL purge[0],
so my `sh` is now much more recent.

This broke some tests which were relying on some non-portable
details of the echo builtin. Switched to using printf, which
should be more consistent across platforms.

[0] http://meta.ath0.com/2012/02/05/apples-great-gpl-purge/