### PR TITLE
Add --shell option to specify the shell to use

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6,7 +6,7 @@ extern crate ansi_term;
 use std::{io, fs, env, process, convert, ffi};
 use std::collections::BTreeMap;
 use self::clap::{App, Arg, ArgGroup, AppSettings};
-use super::{Slurp, RunError, RunOptions, compile};
+use super::{Slurp, RunError, RunOptions, compile, DEFAULT_SHELL};
 
 macro_rules! warn {
   ($($arg:tt)*) => {{
@@ -135,6 +135,11 @@ pub fn app() {
          .value_names(&["variable", "value"])
          .multiple(true)
          .help("Sets <variable> to <value>"))
+    .arg(Arg::with_name("shell")
+         .long("shell")
+         .takes_value(true)
+         .default_value(DEFAULT_SHELL)
+         .help("Invoke <shell> to run recipes"))
     .arg(Arg::with_name("show")
          .short("s")
          .long("show")
@@ -333,6 +338,7 @@ pub fn app() {
     evaluate:  matches.is_present("evaluate"),
     overrides: overrides,
     quiet:     matches.is_present("quiet"),
+    shell:     matches.value_of("shell"),
     use_color: use_color,
     verbose:   matches.is_present("verbose"),
   };

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -938,7 +938,7 @@ fn quiet_flag_or_dry_run_flag() {
     "error: The argument '--dry-run' cannot be used with '--quiet'
 
 USAGE:
-    just --color <color> --quiet
+    just --color <color> --quiet --shell <shell>
 
 For more information try --help\n",
   );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ macro_rules! die {
   }};
 }
 
+const DEFAULT_SHELL: &'static str = "sh";
+
 trait Slurp {
   fn slurp(&mut self) -> Result<String, std::io::Error>;
 }
@@ -235,7 +237,7 @@ fn run_backtick<'a>(
   exports: &Set<&'a str>,
   quiet:   bool,
 ) -> Result<String, RunError<'a>> {
-  let mut cmd = process::Command::new("sh");
+  let mut cmd = process::Command::new(DEFAULT_SHELL);
 
   export_env(&mut cmd, scope, exports)?;
 
@@ -440,7 +442,7 @@ impl<'a> Recipe<'a> {
           continue;
         }
 
-        let mut cmd = process::Command::new("sh");
+        let mut cmd = process::Command::new(options.shell.unwrap_or(DEFAULT_SHELL));
 
         cmd.arg("-cu").arg(command);
 
@@ -1155,6 +1157,7 @@ struct RunOptions<'a> {
   evaluate:  bool,
   overrides: Map<&'a str, &'a str>,
   quiet:     bool,
+  shell:     Option<&'a str>,
   use_color: UseColor,
   verbose:   bool,
 }


### PR DESCRIPTION
Mostly for debugging purposes, so I can make sure behavior is
consistent across different shells. Although I suppose this might
also be of use if you've got a mega weird `sh` that you'd like to
avoid.

Defaults to `sh` so current behavior is preserved.