### PR TITLE
Create platform module

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,6 @@ extern crate ansi_term;
 extern crate atty;
 extern crate clap;
 extern crate libc;
-extern crate regex;
 
 use ::prelude::*;
 use std::{convert, ffi};
@@ -179,7 +178,7 @@ pub fn app() {
     }
   }
 
-  let override_re = regex::Regex::new("^([^=]+)=(.*)$").unwrap();
+  let override_re = Regex::new("^([^=]+)=(.*)$").unwrap();
 
   let raw_arguments = matches.values_of("ARGUMENTS").map(|values| values.collect::<Vec<_>>())
     .unwrap_or_default();

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,66 @@
+use ::prelude::*;
+
+pub struct Platform;
+
+pub trait PlatformInterface {
+  /// Construct a command equivelant to running the script at `path` with the
+  /// shebang line `shebang`
+  fn make_shebang_command(path: &Path, command: &str, argument: Option<&str>) -> process::Command;
+
+  /// Set the execute permission on the file pointed to by `path`
+  fn set_execute_permission(path: &Path) -> Result<(), io::Error>;
+
+  /// Extract the signal from a process exit status, if it was terminated by a signal
+  fn signal_from_exit_status(exit_status: process::ExitStatus) -> Option<i32>;
+}
+
+#[cfg(unix)]
+impl PlatformInterface for Platform {
+  fn make_shebang_command(path: &Path, _command: &str, _argument: Option<&str>) -> process::Command {
+    // shebang scripts can be executed directly on unix
+    process::Command::new(path)
+  }
+
+  fn set_execute_permission(path: &Path) -> Result<(), io::Error> {
+    use std::os::unix::fs::PermissionsExt;
+
+    // get current permissions
+    let mut permissions = fs::metadata(&path)?.permissions();
+
+    // set the execute bit
+    let current_mode = permissions.mode();
+    permissions.set_mode(current_mode | 0o100);
+
+    // set the new permissions
+    fs::set_permissions(&path, permissions)
+  }
+
+  fn signal_from_exit_status(exit_status: process::ExitStatus) -> Option<i32> {
+    use std::os::unix::process::ExitStatusExt;
+    exit_status.signal()
+  }
+}
+
+#[cfg(windows)]
+impl PlatformInterface for Platform {
+  fn make_shebang_command(path: &Path, command: &str, argument: Option<&str>) -> process::Command {
+    let mut cmd = process::Command::new(command);
+    if let Some(argument) = argument {
+      cmd.arg(argument);
+    }
+    cmd.arg(path);
+    cmd
+  }
+
+  fn set_execute_permission(_path: &Path) -> Result<(), io::Error> {
+    // it is not necessary to set an execute permission on a script on windows,
+    // so this is a nop
+    Ok(())
+  }
+
+  fn signal_from_exit_status(_exit_status: process::ExitStatus) -> Option<i32> {
+    // The rust standard library does not expose a way to extract a signal
+    // from a process exit status, so just return None
+    None
+  }
+}

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1111,3 +1111,23 @@ fn readme_test() {
     parse_success(&justfile);
   }
 }
+
+#[test]
+fn split_shebang() {
+  use ::split_shebang;
+
+  fn check(shebang: &str, expected_split: Option<(&str, Option<&str>)>) {
+    assert_eq!(split_shebang(shebang), expected_split);
+  }
+
+  check("#!    ",                       Some(("",             None              )));
+  check("#!",                           Some(("",             None              )));
+  check("#!/bin/bash",                  Some(("/bin/bash",    None              )));
+  check("#!/bin/bash    ",              Some(("/bin/bash",    None              )));
+  check("#!/usr/bin/env python",        Some(("/usr/bin/env", Some("python"     ))));
+  check("#!/usr/bin/env python   ",     Some(("/usr/bin/env", Some("python"     ))));
+  check("#!/usr/bin/env python -x",     Some(("/usr/bin/env", Some("python -x"  ))));
+  check("#!/usr/bin/env python   -x",   Some(("/usr/bin/env", Some("python   -x"))));
+  check("#!/usr/bin/env python \t-x\t", Some(("/usr/bin/env", Some("python \t-x"))));
+  check("#/usr/bin/env python \t-x\t",  None                                       );
+}


### PR DESCRIPTION
Moves platform specific functionality into its own module.

Thanks to @Meralis40 for starting this!

This also gets just building on windows \\^_^/

Although a lot of tests still fail (✖╭╮✖)

The `PlatformInterface` trait abstracts over platform specific
functionality, with implementations fordifferent platforms
behind #[cfg(*)] attributes.

- `make_shebang_command()` constructs a command which will execute
  the given script as if by a shebang. On linux this executes the
  file, on windows it runs the interpreter directly.

- `set_execute_permission()` sets the execute permission on a
  file. This is a nop on windows, since all files are executable.

- `signal_from_exit_status()` extracts the signal a process was
  halted by from its exit status, if it was halted by a signal.