### PR TITLE
Make shebangs work on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod prelude {
   pub use std::io::prelude::*;
   pub use libc::{EXIT_FAILURE, EXIT_SUCCESS};
   pub use regex::Regex;
-  pub use std::path::Path;
+  pub use std::path::{Path, PathBuf};
   pub use std::{cmp, env, fs, fmt, io, iter, process};
 }
 


### PR DESCRIPTION
We use EXEPATH, which points to the root of the MinGW installation
and can be used as a base for translating the unix path to the
executable in the shebang line.

If we're not on MinGW, well, we just throw up our hands and hope
for the best.