### PR TITLE
Refactor RunError::Backtick* to use OutputError

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@ use ::prelude::*;
 use std::{convert, ffi};
 use std::collections::BTreeMap;
 use self::clap::{App, Arg, ArgGroup, AppSettings};
-use super::{Slurp, RunError, RunOptions, compile, DEFAULT_SHELL};
+use super::{Slurp, RunOptions, compile, DEFAULT_SHELL};
 
 macro_rules! warn {
   ($($arg:tt)*) => {{
@@ -353,9 +353,7 @@ pub fn app() {
         warn!("{}", run_error);
       }
     }
-    match run_error {
-      RunError::Code{code, .. } | RunError::BacktickCode{code, ..} => process::exit(code),
-      _ => process::exit(libc::EXIT_FAILURE),
-    }
+
+    process::exit(run_error.code().unwrap_or(libc::EXIT_FAILURE));
   }
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -3,8 +3,8 @@ extern crate brev;
 
 use super::{
   And, CompileError, ErrorKind, Justfile, Or,
-  RunError, RunOptions, Token, compile, contains,
-  tokenize
+  OutputError, RunError, RunOptions, Token,
+  compile, contains, tokenize
 };
 
 use super::TokenKind::*;
@@ -1016,7 +1016,7 @@ fn missing_all_defaults() {
 fn backtick_code() {
   match parse_success("a:\n echo {{`f() { return 100; }; f`}}")
         .run(&["a"], &Default::default()).unwrap_err() {
-    RunError::BacktickCode{code, token} => {
+    RunError::Backtick{token, output_error: OutputError::Code(code)} => {
       assert_eq!(code, 100);
       assert_eq!(token.lexeme, "`f() { return 100; }; f`");
     },
@@ -1054,7 +1054,7 @@ recipe:
   };
 
   match parse_success(text).run(&["recipe"], &options).unwrap_err() {
-    RunError::BacktickCode{code: _, token} => {
+    RunError::Backtick{token, output_error: OutputError::Code(_)} => {
       assert_eq!(token.lexeme, "`echo $exported_variable`");
     },
     other => panic!("expected a backtick code errror, but got: {}", other),


### PR DESCRIPTION
Add `output()` to get stdout of a command, return a OutputError if
it failes. Refactor backtick run errors to contain an OutputError.