### PR TITLE
Move output() and OutputError into brev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = "0.2.26"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "brev 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "brev 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "edit-distance 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -45,7 +45,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "brev"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -217,7 +217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
-"checksum brev 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "363b8e31f04a5c26761f0a01da8f46eb172485d029a01042ad07fc01faef62ad"
+"checksum brev 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb37ce3b65873276d1587151ef5b63bcc15c8da8dd5058792f5660cb32206d97"
 "checksum clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f57e9b63057a545ad2ecd773ea61e49422ed1b1d63d74d5da5ecaee55b3396cd"
 "checksum edit-distance 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd50a61206c09132fdf9cbaccc64a82cfccb6be528453903e03d4eb4ec80a61d"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -75,7 +75,7 @@ impl PlatformInterface for Platform {
 
   fn signal_from_exit_status(_exit_status: process::ExitStatus) -> Option<i32> {
     // The rust standard library does not expose a way to extract a signal
-    // from a process exit status, so just return None
+    // from a windows process exit status, so just return None
     None
   }
 }


### PR DESCRIPTION
They're pretty generic and generally useful, so move them into brev on crates.io.