### PR TITLE
:fire: Stop parsing flags after positional args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "just"
-version = "0.2.33"
+version = "0.3.0"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "just"
-version     = "0.2.33"
+version     = "0.3.0"
 description = "🤖 Just a command runner"
 authors     = ["Casey Rodarmor <casey@rodarmor.com>"]
 license     = "WTFPL OR MIT OR Apache-2.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,6 +44,7 @@ pub fn app() {
     .author(env!("CARGO_PKG_AUTHORS"))
     .about(concat!(env!("CARGO_PKG_DESCRIPTION"), " - ", env!("CARGO_PKG_HOMEPAGE")))
     .setting(AppSettings::ColoredHelp)
+    .setting(AppSettings::TrailingVarArg)
     .arg(Arg::with_name("ARGUMENTS")
          .multiple(true)
          .help("The recipe(s) to run, defaults to the first recipe in the justfile"))

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -52,8 +52,8 @@ fn integration_test(
 
   let output = process::Command::new(&super::test_utils::just_binary_path())
     .current_dir(tmp.path())
-    .args(args)
     .args(&["--shell", shell])
+    .args(args)
     .output()
     .expect("just invocation failed");
 
@@ -409,7 +409,7 @@ integration_test! {
  echo hello
  echo {{`exit 111`}}
 a = `exit 222`",
-  args:     ("--set", "foo", "bar", "a", "b", "--set", "baz", "bob", "--set", "a", "b"),
+  args:     ("--set", "foo", "bar", "--set", "baz", "bob", "--set", "a", "b", "a", "b"),
   stdout:   "",
   stderr:   "error: Variables `baz` and `foo` overridden on the command line but not present \
     in justfile\n",
@@ -551,7 +551,7 @@ export ABC = FOO + "-" + BAR + "-" + baz
 wut:
   echo $FOO $BAR $ABC
 "#,
-  args:     ("FOO=hello", "--set", "BAR", "bye"),
+  args:     ("--set", "BAR", "bye", "FOO=hello"),
   stdout:   "hello bye hello-bye-c\n",
   stderr:   "echo $FOO $BAR $ABC\n",
   status:   EXIT_SUCCESS,
@@ -1582,5 +1582,17 @@ a:
   args:     ("--color", "always", "--highlight", "--verbose"),
   stdout:   "hi\n",
   stderr:   "\u{1b}[1;36m===> Running recipe `a`...\u{1b}[0m\n\u{1b}[1mecho hi\u{1b}[0m\n",
+  status:   EXIT_SUCCESS,
+}
+
+integration_test! {
+  name:     trailing_flags,
+  justfile: "
+echo A B C:
+  echo {{A}} {{B}} {{C}}
+",
+  args:     ("echo", "--some", "--awesome", "--flags"),
+  stdout:   "--some --awesome --flags\n",
+  stderr:   "echo --some --awesome --flags\n",
   status:   EXIT_SUCCESS,
 }


### PR DESCRIPTION
This allows things like the following to work as,
I hope, one would expect:

```
  commit +flags:
    git commit {{flags}}

  $ just commit -a
```

It is however a breaking change, so also bump version number to 0.3.0.

Fixes #216