### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,22 +6,21 @@ dependencies = [
  "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "brev 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "edit-distance 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "edit-distance 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -35,7 +34,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -89,7 +88,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "edit-distance"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -104,7 +103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itertools"
-version = "0.5.10"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -126,7 +125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -148,10 +147,10 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "0.1.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -159,25 +158,25 @@ name = "rand"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.80"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.3.9"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -199,7 +198,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -213,20 +212,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "thread_local"
-version = "0.2.7"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -240,13 +231,26 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "utf8-ranges"
-version = "0.1.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vec_map"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -260,7 +264,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
@@ -269,28 +273,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2267a8fdd4dce6956ba6649e130f62fb279026e5e84b92aa939ac8f85ce3f9f0"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
-"checksum edit-distance 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd50a61206c09132fdf9cbaccc64a82cfccb6be528453903e03d4eb4ec80a61d"
+"checksum edit-distance 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6a34f5204fbc13582de418611cf3a7dcdd07c6d312a5b631597ba72c06b9d9c9"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
+"checksum itertools 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22c285d60139cf413244894189ca52debcfd70b57966feed060da76802e415a0"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "8a014d9226c2cc402676fbe9ea2e15dd5222cd1dd57f576b5b283178c944a264"
+"checksum libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "2370ca07ec338939e356443dac2296f581453c35fe1e3a3ed06023c49435f915"
 "checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
 "checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
-"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
-"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
-"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
+"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
+"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum textwrap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f728584ea33b0ad19318e20557cb0a39097751dbb07171419673502f848c7af6"
-"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
+"checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
-"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,18 +6,15 @@ authors     = ["Casey Rodarmor <casey@rodarmor.com>"]
 license     = "WTFPL OR MIT OR Apache-2.0"
 homepage    = "https://github.com/casey/just"
 
-[dev-dependencies]
-glob = "^0.2.11"
-
 [dependencies]
 ansi_term     = "^0.9.0"
 atty          = "^0.2.1"
 brev          = "^0.1.6"
 clap          = "^2.0.0"
-edit-distance = "^1.0.0"
-itertools     = "^0.5.5"
+edit-distance = "^2.0.0"
+itertools     = "^0.6.2"
 lazy_static   = "^0.2.1"
 libc          = "^0.2.21"
-regex         = "^0.1.77"
+regex         = "^0.2.2"
 tempdir       = "^0.3.5"
 unicode-width = "^0.1.3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -134,7 +134,7 @@ pub fn app() {
 
   for argument in raw_arguments.iter().take_while(|arg| override_re.is_match(arg)) {
     let captures = override_re.captures(argument).unwrap();
-    overrides.insert(captures.at(1).unwrap(), captures.at(2).unwrap());
+    overrides.insert(captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str());
   }
 
   let rest = raw_arguments.iter().skip_while(|arg| override_re.is_match(arg))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,9 @@ fn split_shebang(shebang: &str) -> Option<(&str, Option<&str>)> {
   if EMPTY.is_match(shebang) {
     Some(("", None))
   } else if let Some(captures) = SIMPLE.captures(shebang) {
-    Some((captures.at(1).unwrap(), None))
+    Some((captures.get(1).unwrap().as_str(), None))
   } else if let Some(captures) = ARGUMENT.captures(shebang) {
-    Some((captures.at(1).unwrap(), Some(captures.at(2).unwrap())))
+    Some((captures.get(1).unwrap().as_str(), Some(captures.get(2).unwrap().as_str())))
   } else {
     None
   }
@@ -1554,7 +1554,7 @@ fn tokenize(text: &str) -> Result<Vec<Token>, CompileError> {
   }
 
   fn indentation(text: &str) -> Option<&str> {
-    INDENT.captures(text).map(|captures| captures.at(1).unwrap())
+    INDENT.captures(text).map(|captures| captures.get(1).unwrap().as_str())
   }
 
   let mut tokens = vec![];
@@ -1645,64 +1645,64 @@ fn tokenize(text: &str) -> Result<Vec<Token>, CompileError> {
     let (prefix, lexeme, kind) =
     if let (0, &State::Indent(indent), Some(captures)) =
       (column, state.last().unwrap(), LINE.captures(rest)) {
-      let line = captures.at(0).unwrap();
+      let line = captures.get(0).unwrap().as_str();
       if !line.starts_with(indent) {
         return error!(ErrorKind::InternalError{message: "unexpected indent".to_string()});
       }
       state.push(State::Text);
       (&line[0..indent.len()], "", Line)
     } else if let Some(captures) = EOF.captures(rest) {
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), Eof)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Eof)
     } else if let State::Text = *state.last().unwrap() {
       if let Some(captures) = INTERPOLATION_START.captures(rest) {
         state.push(State::Interpolation);
-        ("", captures.at(0).unwrap(), InterpolationStart)
+        ("", captures.get(0).unwrap().as_str(), InterpolationStart)
       } else if let Some(captures) = LEADING_TEXT.captures(rest) {
-        ("", captures.at(1).unwrap(), Text)
+        ("", captures.get(1).unwrap().as_str(), Text)
       } else if let Some(captures) = TEXT.captures(rest) {
-        ("", captures.at(1).unwrap(), Text)
+        ("", captures.get(1).unwrap().as_str(), Text)
       } else if let Some(captures) = EOL.captures(rest) {
         state.pop();
-        (captures.at(1).unwrap(), captures.at(2).unwrap(), Eol)
+        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Eol)
       } else {
         return error!(ErrorKind::InternalError{
           message: format!("Could not match token in text state: \"{}\"", rest)
         });
       }
     } else if let Some(captures) = INTERPOLATION_START_TOKEN.captures(rest) {
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), InterpolationStart)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), InterpolationStart)
     } else if let Some(captures) = INTERPOLATION_END.captures(rest) {
       if state.last().unwrap() == &State::Interpolation {
         state.pop();
       }
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), InterpolationEnd)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), InterpolationEnd)
     } else if let Some(captures) = NAME.captures(rest) {
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), Name)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Name)
     } else if let Some(captures) = EOL.captures(rest) {
       if state.last().unwrap() == &State::Interpolation {
         return error!(ErrorKind::InternalError {
           message: "hit EOL while still in interpolation state".to_string()
         });
       }
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), Eol)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Eol)
     } else if let Some(captures) = BACKTICK.captures(rest) {
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), Backtick)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Backtick)
     } else if let Some(captures) = COLON.captures(rest) {
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), Colon)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Colon)
     } else if let Some(captures) = AT.captures(rest) {
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), At)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), At)
     } else if let Some(captures) = PLUS.captures(rest) {
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), Plus)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Plus)
     } else if let Some(captures) = EQUALS.captures(rest) {
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), Equals)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Equals)
     } else if let Some(captures) = COMMENT.captures(rest) {
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), Comment)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Comment)
     } else if let Some(captures) = RAW_STRING.captures(rest) {
-      (captures.at(1).unwrap(), captures.at(2).unwrap(), RawString)
+      (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), RawString)
     } else if UNTERMINATED_RAW_STRING.is_match(rest) {
       return error!(ErrorKind::UnterminatedString);
     } else if let Some(captures) = STRING.captures(rest) {
-      let prefix = captures.at(1).unwrap();
+      let prefix = captures.get(1).unwrap().as_str();
       let contents = &rest[prefix.len()+1..];
       if contents.is_empty() {
         return error!(ErrorKind::UnterminatedString);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,5 +1,3 @@
-extern crate glob;
-
 use ::prelude::*;
 
 pub fn just_binary_path() -> PathBuf {


### PR DESCRIPTION
Fixes  #224

Also removes the dependency on `glob`, since that wasn't being used. `cargo outdated` ftw.