### PR TITLE
Attempt to fix homebrew issue on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
       os: osx
       before_install:
         - set -e
+        - brew update
         - brew install dash
 
     # *BSD


### PR DESCRIPTION
Travis builds are failing with:

```
/usr/local/Homebrew/Library/Homebrew/brew.rb:12:in `<main>': Homebrew must be run under Ruby 2.3! (RuntimeError)
/Users/travis/.travis/job_stages: line 57: shell_session_update: command not found
```

According to my extensive research on the internet, aka googling the error message, running `brew update` will fix it.