### PR TITLE
Stop empty comment from swallowing next line

### DIFF
--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1614,3 +1614,17 @@ echo A B C:
   stderr:   "echo --some --awesome --flags\n",
   status:   EXIT_SUCCESS,
 }
+
+integration_test! {
+   name:     comment_before_variable,
+   justfile: "
+#
+A='1'
+echo:
+  echo {{A}}
+ ",
+   args:     ("echo"),
+   stdout:   "1\n",
+   stderr:   "echo 1\n",
+   status:   EXIT_SUCCESS,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1528,7 +1528,7 @@ fn tokenize(text: &str) -> Result<Vec<Token>, CompileError> {
     static ref BACKTICK:                  Regex = token(r"`[^`\n\r]*`"               );
     static ref COLON:                     Regex = token(r":"                         );
     static ref AT:                        Regex = token(r"@"                         );
-    static ref COMMENT:                   Regex = token(r"#([^!].*)?$"               );
+    static ref COMMENT:                   Regex = token(r"#([^!\n\r].*)?$"           );
     static ref EOF:                       Regex = token(r"(?-m)$"                    );
     static ref EOL:                       Regex = token(r"\n|\r\n"                   );
     static ref EQUALS:                    Regex = token(r"="                         );

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -157,6 +157,17 @@ hello:
 }
 
 #[test]
+fn tokenize_comment_before_variable() {
+  let text = "
+#
+A='1'
+echo:
+  echo {{A}}
+  ";
+  tokenize_success(text, "$#$N='$N:$>^_{N}$<.");
+}
+
+#[test]
 fn tokenize_interpolation_backticks() {
   tokenize_success(
     "hello:\n echo {{`echo hello` + `echo goodbye`}}",


### PR DESCRIPTION
Stop empty comments from swallowing the next line.