### PR TITLE
Clean up grammar

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -23,17 +23,21 @@ STRING     = "[^"]*" # also processes \n \r \t \" \\ escapes
 TEXT       = recipe text, only matches in a recipe body
 ```
 
+grammar syntax
+--------------
+
+```
+|   alternation
+()  grouping
+[]  option (0 or 1 times)
+{}  repetition (0 to n times)
+X+  repetition (1 to n times)
+```
+
 grammar
 -------
 
 ```
-# key
-# |  alternation
-# () grouping
-# [] option (0 or 1 times)
-# {} repetition (0 to n times)
-# X+ repetition (1 to n times)
-
 justfile      : {item} EOF
 
 item          : recipe

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -29,18 +29,16 @@ grammar syntax
 ```
 |   alternation
 ()  grouping
-[]  option (0 or 1 times)
-{}  repetition (0 or more times)
-X?  option (0 or 1 times)
-X*  repetition (0 or more times)
-X+  repetition (1 or more times)
+_?  option (0 or 1 times)
+_*  repetition (0 or more times)
+_+  repetition (1 or more times)
 ```
 
 grammar
 -------
 
 ```
-justfile      : {item} EOF
+justfile      : item* EOF
 
 item          : recipe
               | assignment
@@ -62,7 +60,7 @@ value         : STRING
               | NAME
               | BACKTICK
 
-recipe        : '@'? NAME parameter* ['+' parameter] ':' dependencies? body?
+recipe        : '@'? NAME parameter* ('+' parameter)? ':' dependencies? body?
 
 parameter     : NAME
               | NAME '=' STRING

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -30,8 +30,10 @@ grammar syntax
 |   alternation
 ()  grouping
 []  option (0 or 1 times)
-{}  repetition (0 to n times)
-X+  repetition (1 to n times)
+{}  repetition (0 or more times)
+X?  option (0 or 1 times)
+X*  repetition (0 or more times)
+X+  repetition (1 or more times)
 ```
 
 grammar
@@ -60,7 +62,7 @@ value         : STRING
               | NAME
               | BACKTICK
 
-recipe        : ['@'] NAME {parameter} ['+' parameter] ':' [dependencies] [body]
+recipe        : '@'? NAME parameter* ['+' parameter] ':' dependencies? body?
 
 parameter     : NAME
               | NAME '=' STRING

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -28,11 +28,11 @@ grammar
 
 ```
 # key
-# |   alternation
-# ()  grouping
-# []  option (0 or 1 times)
-# {}  repetition (0 to n times)
-# {}+ repetition (1 to n times)
+# |  alternation
+# () grouping
+# [] option (0 or 1 times)
+# {} repetition (0 to n times)
+# X+ repetition (1 to n times)
 
 justfile      : {item} EOF
 
@@ -62,11 +62,11 @@ parameter     : NAME
               | NAME '=' STRING
               | NAME '=' RAW_STRING
 
-dependencies  : {NAME}+
+dependencies  : NAME+
 
-body          : INDENT {line}+ DEDENT
+body          : INDENT line+ DEDENT
 
-line          : LINE {TEXT | interpolation}+ NEWLINE
+line          : LINE (TEXT | interpolation)+ NEWLINE
               | NEWLINE
 
 interpolation : '{{' expression '}}'


### PR DESCRIPTION
Use proper-ish EBNF in grammar. Don't list simple terminals in the list of tokens.