### PR TITLE
Only provide MinGW build on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
 
     # MSVC
     #- TARGET: i686-pc-windows-msvc
-    - TARGET: x86_64-pc-windows-msvc
+    #- TARGET: x86_64-pc-windows-msvc
 
     # Testing other channels
     #- TARGET: x86_64-pc-windows-gnu


### PR DESCRIPTION
Apparently the MSVC build depends on a shared library, see #266, so the MinGW build should/might be less problematic.