### PR TITLE
Explain binary installs first, remove git install

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -37,7 +37,7 @@ toc::[]
 
 `just` should run on any system with a reasonable `sh`, including Linux, MacOS, and the BSDs.
 
-On Windows, `just` works with the `sh` provided by http://www.cygwin.com[Cygwin], https://git-scm.com[git], and https://desktop.github.com[GitHub Desktop].
+On Windows, `just` works with the `sh` provided by https://git-scm.com[Git for Windows], https://desktop.github.com[GitHub Desktop], and http://www.cygwin.com[Cygwin].
 
 === Pre-built Binaries
 

--- a/README.asc
+++ b/README.asc
@@ -35,7 +35,9 @@ toc::[]
 
 == Installation
 
-`just` should run on any system with a reasonable `sh`.
+`just` should run on any system with a reasonable `sh`, including Linux, MacOS, and the BSDs.
+
+On Windows, `just` works with the `sh` provided by http://www.cygwin.com[Cygwin], https://git-scm.com[git], and https://desktop.github.com[GitHub Desktop].
 
 === Pre-built Binaries
 

--- a/README.asc
+++ b/README.asc
@@ -35,9 +35,17 @@ toc::[]
 
 == Installation
 
-`just` should run on any system with a reasonable `sh`. 
+`just` should run on any system with a reasonable `sh`.
 
-On Windows, you'll need to install https://git-scm.com[git] or https://desktop.github.com[GitHub Desktop].
+=== Pre-built Binaries
+
+Pre-built binaries for Linux, macOS, and Windows can be found on https://github.com/casey/just/releases[the releases page].
+
+=== Homebrew
+
+On MacOS, `just` is a available through the https://brew.sh[Homebrew] package manager. Install Homebrew using the instructions at https://brew.sh, then run:
+
+`brew install just`
 
 === Cargo
 
@@ -49,15 +57,6 @@ On Windows, you'll need to install https://git-scm.com[git] or https://desktop.g
 
 `rustup` may have done #3 for you. If this doesn't work, put `export PATH="$HOME/.cargo/bin:$PATH"` in your shell's configuration file
 
-=== Homebrew
-
-On MacOS, `just` is a available through the https://brew.sh[Homebrew] package manager. Install Homebrew using the instructions at https://brew.sh, then run:
-
-`brew install just`
-
-=== Pre-built Binaries
-
-Pre-built binaries for Linux, macOS, and Windows can be found on https://github.com/casey/just/releases[the releases page].
 
 == Quick Start
 

--- a/README.asc
+++ b/README.asc
@@ -41,7 +41,7 @@ On Windows, `just` works with the `sh` provided by https://git-scm.com[Git for W
 
 === Pre-built Binaries
 
-Pre-built binaries for Linux, macOS, and Windows can be found on https://github.com/casey/just/releases[the releases page].
+Pre-built binaries for Linux, MacOS, and Windows can be found on https://github.com/casey/just/releases[the releases page].
 
 === Homebrew
 


### PR DESCRIPTION
I saw someone get confused and think they need to install via cargo.

Not sure what installing git has to do with this project?