### PR TITLE
Fix `just` shows escape code instead of colored text on Windows 10 Console

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -125,11 +125,15 @@ impl Color {
   }
 
   pub fn active(&self) -> bool {
-    match self.use_color {
+    let mut activated = match self.use_color {
       UseColor::Always => true,
       UseColor::Never  => false,
       UseColor::Auto   => self.atty,
+    };
+    if cfg!(windows) && activated {
+      activated = ansi_term::enable_ansi_support().is_ok();
     }
+    activated
   }
 
   pub fn paint<'a>(&self, text: &'a str) -> ANSIGenericString<'a, str> {

--- a/src/color.rs
+++ b/src/color.rs
@@ -125,13 +125,14 @@ impl Color {
   }
 
   pub fn active(&self) -> bool {
-    let mut activated = match self.use_color {
+    let activated = match self.use_color {
       UseColor::Always => true,
       UseColor::Never  => false,
       UseColor::Auto   => self.atty,
     };
-    if cfg!(windows) && activated {
-      activated = ansi_term::enable_ansi_support().is_ok();
+    if activated {
+      #[cfg(windows)]
+      ansi_term::enable_ansi_support().is_ok();
     }
     activated
   }

--- a/src/color.rs
+++ b/src/color.rs
@@ -125,16 +125,11 @@ impl Color {
   }
 
   pub fn active(&self) -> bool {
-    let activated = match self.use_color {
+    match self.use_color {
       UseColor::Always => true,
       UseColor::Never  => false,
       UseColor::Auto   => self.atty,
-    };
-    if activated {
-      #[cfg(windows)]
-      ansi_term::enable_ansi_support().is_ok();
     }
-    activated
   }
 
   pub fn paint<'a>(&self, text: &'a str) -> ANSIGenericString<'a, str> {

--- a/src/run.rs
+++ b/src/run.rs
@@ -2,9 +2,12 @@ use common::*;
 
 use std::{convert, ffi, cmp};
 use clap::{App, Arg, ArgGroup, AppSettings};
-use misc::maybe_s;
 use configuration::DEFAULT_SHELL;
+use misc::maybe_s;
 use unicode_width::UnicodeWidthStr;
+
+#[cfg(windows)]
+use ansi_term::enable_ansi_support;
 
 macro_rules! die {
   ($($arg:tt)*) => {{
@@ -134,7 +137,7 @@ pub fn run() {
 
   if color.active() {
     #[cfg(windows)]
-    ansi_term::enable_ansi_support().ok();
+    enable_ansi_support().ok();
   }
 
   let set_count = matches.occurrences_of("SET");

--- a/src/run.rs
+++ b/src/run.rs
@@ -132,6 +132,11 @@ pub fn run() {
     other    => die!("Invalid argument `{}` to --color. This is a bug in just.", other),
   };
 
+  if color.active() {
+    #[cfg(windows)]
+    ansi_term::enable_ansi_support().ok();
+  }
+
   let set_count = matches.occurrences_of("SET");
   let mut overrides = Map::new();
   if set_count > 0 {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/830515/36297215-d0e7f1ec-1334-11e8-8e51-33c959c67306.png)

On Windows 10, `just` shows escape code instead of colored text.

According to [ansi_term crate](https://crates.io/crates/ansi_term)'s README, Application must enable ANSI support for print colored text on Windows 10 Console.

> Note for Windows 10 users: On Windows 10, the application must enable ANSI support first:
> ```rust
> let enabled = ansi_term::enable_ansi_support();
> ```

This commit add `ansi_term::enable_ansi_support()` into `active` function.