### PR TITLE
Implement invocation_directory function (fix #312)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -289,6 +289,24 @@ This is an x86_64 machine
 
 - `env_var_or_default(key, default)` – Retrieves the environment variable with name `key`, returning `default` if it is not present.
 
+==== Invocation Directory
+
+- `invocation_directory()` - Retrieves the value of the current working directory, before`just` changed it (chdir'd) prior to executing commands.
+
+For example, to call `rustfmt` on files just under the "current directory" (from the user/invoker's perspective), use the following rule:
+
+```
+rustfmt:
+    find {{invocation_directory()}} -name \*.rs -exec rustfmt {} \;
+```
+
+Alternatively, if your command needs to be run from the current directory, you could use (e.g.):
+
+```
+build:
+    cd {{invocation_directory()}}; ./some_script_that_needs_to_be_run_from_here
+```
+
 ==== Dotenv Integration
 
 `just` will load environment variables from a file named `.env`. This file can be located in the same directory as your justfile or in a parent directory. These variables are environment variables, not `just` variables, and so must be accessed using `$VARIABLE_NAME` in recipes and backticks.

--- a/README.adoc
+++ b/README.adoc
@@ -291,7 +291,7 @@ This is an x86_64 machine
 
 ==== Invocation Directory
 
-- `invocation_directory()` - Retrieves the value of the current working directory, before`just` changed it (chdir'd) prior to executing commands.
+- `invocation_directory()` - Retrieves the path of the current working directory, before `just` changed it (chdir'd) prior to executing commands.
 
 For example, to call `rustfmt` on files just under the "current directory" (from the user/invoker's perspective), use the following rule:
 

--- a/justfile
+++ b/justfile
@@ -141,6 +141,10 @@ ruby:
 	#!/usr/bin/env ruby
 	puts "Hello from ruby!"
 
+# Print working directory, for demonstration purposes!
+pwd:
+	echo {{invocation_directory()}}
+
 # Local Variables:
 # mode: makefile
 # End:

--- a/src/assignment_evaluator.rs
+++ b/src/assignment_evaluator.rs
@@ -4,6 +4,7 @@ use brev;
 
 pub struct AssignmentEvaluator<'a: 'b, 'b> {
   pub assignments: &'b Map<&'a str, Expression<'a>>,
+  pub invocation_directory: Option<&'a str>,
   pub dotenv:      &'b Map<String, String>,
   pub dry_run:     bool,
   pub evaluated:   Map<&'a str, String>,
@@ -17,6 +18,7 @@ pub struct AssignmentEvaluator<'a: 'b, 'b> {
 impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
   pub fn evaluate_assignments(
     assignments: &Map<&'a str, Expression<'a>>,
+    invocation_directory: Option<&'a str>,
     dotenv:      &'b Map<String, String>,
     overrides:   &Map<&str, &str>,
     quiet:       bool,
@@ -28,6 +30,7 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
       exports:   &empty(),
       scope:     &empty(),
       assignments,
+      invocation_directory,
       dotenv,
       dry_run,
       overrides,
@@ -107,6 +110,7 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
           self.evaluate_expression(argument, arguments)
         }).collect::<Result<Vec<String>, RuntimeError>>()?;
         let context = FunctionContext {
+          invocation_directory: self.invocation_directory,
           dotenv: self.dotenv,
         };
         evaluate_function(token, name, &context, &call_arguments)
@@ -164,7 +168,7 @@ mod test {
   #[test]
   fn backtick_code() {
     match parse_success("a:\n echo {{`f() { return 100; }; f`}}")
-          .run(&["a"], &Default::default()).unwrap_err() {
+          .run(None, &["a"], &Default::default()).unwrap_err() {
       RuntimeError::Backtick{token, output_error: OutputError::Code(code)} => {
         assert_eq!(code, 100);
         assert_eq!(token.lexeme, "`f() { return 100; }; f`");
@@ -187,7 +191,7 @@ recipe:
       ..Default::default()
     };
 
-    match parse_success(text).run(&["recipe"], &configuration).unwrap_err() {
+    match parse_success(text).run(None, &["recipe"], &configuration).unwrap_err() {
       RuntimeError::Backtick{token, output_error: OutputError::Code(_)} => {
         assert_eq!(token.lexeme, "`echo $exported_variable`");
       },

--- a/src/assignment_evaluator.rs
+++ b/src/assignment_evaluator.rs
@@ -1,10 +1,12 @@
+use std::path::PathBuf;
+
 use common::*;
 
 use brev;
 
 pub struct AssignmentEvaluator<'a: 'b, 'b> {
   pub assignments: &'b Map<&'a str, Expression<'a>>,
-  pub invocation_directory: &'b Result<String, String>,
+  pub invocation_directory: &'b Result<PathBuf, String>,
   pub dotenv:      &'b Map<String, String>,
   pub dry_run:     bool,
   pub evaluated:   Map<&'a str, String>,
@@ -18,7 +20,7 @@ pub struct AssignmentEvaluator<'a: 'b, 'b> {
 impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
   pub fn evaluate_assignments(
     assignments: &Map<&'a str, Expression<'a>>,
-    invocation_directory: &Result<String, String>,
+    invocation_directory: &Result<PathBuf, String>,
     dotenv:      &'b Map<String, String>,
     overrides:   &Map<&str, &str>,
     quiet:       bool,
@@ -165,7 +167,7 @@ mod test {
   use testing::parse_success;
   use Configuration;
 
-  fn no_cwd_err() -> Result<String, String> {
+  fn no_cwd_err() -> Result<PathBuf, String> {
     Err(String::from("no cwd in tests"))
   }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -8,6 +8,7 @@ lazy_static! {
     ("os_family",          Function::Nullary(os_family         )),
     ("env_var",            Function::Unary  (env_var           )),
     ("env_var_or_default", Function::Binary (env_var_or_default)),
+    ("invocation_directory", Function::Nullary(invocation_directory)),
   ].into_iter().collect();
 }
 
@@ -29,6 +30,7 @@ impl Function {
 }
 
 pub struct FunctionContext<'a> {
+  pub invocation_directory: Option<&'a str>,
   pub dotenv: &'a Map<String, String>,
 }
 
@@ -90,6 +92,14 @@ pub fn os(_context: &FunctionContext) -> Result<String, String> {
 
 pub fn os_family(_context: &FunctionContext) -> Result<String, String> {
   Ok(target::os_family().to_string())
+}
+
+pub fn invocation_directory(context: &FunctionContext) -> Result<String, String> {
+  if let Some(dir) = context.invocation_directory {
+    Ok(dir.to_string())
+  } else {
+    Err(String::from("error getting invocation directory"))
+  }
 }
 
 pub fn env_var(context: &FunctionContext, key: &str) -> Result<String, String> {

--- a/src/function.rs
+++ b/src/function.rs
@@ -30,7 +30,7 @@ impl Function {
 }
 
 pub struct FunctionContext<'a> {
-  pub invocation_directory: Option<&'a str>,
+  pub invocation_directory: &'a Result<String, String>,
   pub dotenv: &'a Map<String, String>,
 }
 
@@ -95,11 +95,7 @@ pub fn os_family(_context: &FunctionContext) -> Result<String, String> {
 }
 
 pub fn invocation_directory(context: &FunctionContext) -> Result<String, String> {
-  if let Some(dir) = context.invocation_directory {
-    Ok(dir.to_string())
-  } else {
-    Err(String::from("error getting invocation directory"))
-  }
+  context.invocation_directory.clone()
 }
 
 pub fn env_var(context: &FunctionContext, key: &str) -> Result<String, String> {

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,5 +1,9 @@
+use std::path::PathBuf;
+
 use common::*;
 use target;
+
+use platform::{Platform, PlatformInterface};
 
 lazy_static! {
   static ref FUNCTIONS: Map<&'static str, Function> = vec![
@@ -30,7 +34,7 @@ impl Function {
 }
 
 pub struct FunctionContext<'a> {
-  pub invocation_directory: &'a Result<String, String>,
+  pub invocation_directory: &'a Result<PathBuf, String>,
   pub dotenv: &'a Map<String, String>,
 }
 
@@ -96,6 +100,8 @@ pub fn os_family(_context: &FunctionContext) -> Result<String, String> {
 
 pub fn invocation_directory(context: &FunctionContext) -> Result<String, String> {
   context.invocation_directory.clone()
+    .and_then(|s| Platform::to_shell_path(&s)
+      .map_err(|e| format!("Error getting shell path: {}", e)))
 }
 
 pub fn env_var(context: &FunctionContext, key: &str) -> Result<String, String> {

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use common::*;
 
 use edit_distance::edit_distance;
@@ -42,7 +44,7 @@ impl<'a, 'b> Justfile<'a> where 'a: 'b {
 
   pub fn run(
     &'a self,
-    invocation_directory: Result<String, String>,
+    invocation_directory: Result<PathBuf, String>,
     arguments:     &[&'a str],
     configuration: &Configuration<'a>,
   ) -> RunResult<'a, ()> {
@@ -125,7 +127,7 @@ impl<'a, 'b> Justfile<'a> where 'a: 'b {
 
   fn run_recipe<'c>(
     &'c self,
-    invocation_directory: &Result<String, String>,
+    invocation_directory: &Result<PathBuf, String>,
     recipe:        &Recipe<'a>,
     arguments:     &[&'a str],
     scope:         &Map<&'c str, String>,
@@ -174,7 +176,7 @@ mod test {
   use testing::parse_success;
   use RuntimeError::*;
 
-  fn no_cwd_err() -> Result<String, String> {
+  fn no_cwd_err() -> Result<PathBuf, String> {
     Err(String::from("no cwd in tests"))
   }
 

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -1,5 +1,6 @@
 use common::*;
 
+use std::path::PathBuf;
 use std::process::{ExitStatus, Command, Stdio};
 
 use platform::{Platform, PlatformInterface};
@@ -50,7 +51,7 @@ impl<'a> Recipe<'a> {
 
   pub fn run(
     &self,
-    invocation_directory: &Result<String, String>,
+    invocation_directory: &Result<PathBuf, String>,
     arguments:     &[&'a str],
     scope:         &Map<&'a str, String>,
     dotenv:        &Map<String, String>,

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -50,6 +50,7 @@ impl<'a> Recipe<'a> {
 
   pub fn run(
     &self,
+    invocation_directory: Option<&'a str>,
     arguments:     &[&'a str],
     scope:         &Map<&'a str, String>,
     dotenv:        &Map<String, String>,
@@ -86,6 +87,7 @@ impl<'a> Recipe<'a> {
 
     let mut evaluator = AssignmentEvaluator {
       assignments: &empty(),
+      invocation_directory,
       dry_run:     configuration.dry_run,
       evaluated:   empty(),
       overrides:   &empty(),

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -50,7 +50,7 @@ impl<'a> Recipe<'a> {
 
   pub fn run(
     &self,
-    invocation_directory: Option<&'a str>,
+    invocation_directory: &Result<String, String>,
     arguments:     &[&'a str],
     scope:         &Map<&'a str, String>,
     dotenv:        &Map<String, String>,

--- a/src/run.rs
+++ b/src/run.rs
@@ -47,6 +47,11 @@ pub fn run() {
   #[cfg(windows)]
   enable_ansi_support().ok();
 
+  let invocation_directory = match env::current_dir() {
+    Ok(pathbuf) => pathbuf,
+    Err(error) => die!("Error getting current dir: {}", error),
+  };
+
   let matches = App::new(env!("CARGO_PKG_NAME"))
     .version(concat!("v", env!("CARGO_PKG_VERSION")))
     .author(env!("CARGO_PKG_AUTHORS"))
@@ -354,7 +359,11 @@ pub fn run() {
     overrides,
   };
 
-  if let Err(run_error) = justfile.run(&arguments, &configuration) {
+  if let Err(run_error) = justfile.run(
+    invocation_directory.to_str(),
+    &arguments,
+    &configuration)
+  {
     if !configuration.quiet {
       if color.stderr().active() {
         eprintln!("{:#}", run_error);

--- a/src/run.rs
+++ b/src/run.rs
@@ -48,11 +48,7 @@ pub fn run() {
   enable_ansi_support().ok();
 
   let invocation_directory = env::current_dir()
-    .map_err(|e| format!("Error getting current directory: {}", e))
-    .and_then(|dir| 
-      dir.to_str()
-        .map(str::to_string)
-        .ok_or_else(|| String::from("Failed to decode utf8")));
+    .map_err(|e| format!("Error getting current directory: {}", e));
 
   let matches = App::new(env!("CARGO_PKG_NAME"))
     .version(concat!("v", env!("CARGO_PKG_VERSION")))

--- a/src/run.rs
+++ b/src/run.rs
@@ -47,10 +47,12 @@ pub fn run() {
   #[cfg(windows)]
   enable_ansi_support().ok();
 
-  let invocation_directory = match env::current_dir() {
-    Ok(pathbuf) => pathbuf,
-    Err(error) => die!("Error getting current dir: {}", error),
-  };
+  let invocation_directory = env::current_dir()
+    .map_err(|e| format!("Error getting current directory: {}", e))
+    .and_then(|dir| 
+      dir.to_str()
+        .map(str::to_string)
+        .ok_or_else(|| String::from("Failed to decode utf8")));
 
   let matches = App::new(env!("CARGO_PKG_NAME"))
     .version(concat!("v", env!("CARGO_PKG_VERSION")))
@@ -360,7 +362,7 @@ pub fn run() {
   };
 
   if let Err(run_error) = justfile.run(
-    invocation_directory.to_str(),
+    invocation_directory,
     &arguments,
     &configuration)
   {

--- a/tests/invocation_directory.rs
+++ b/tests/invocation_directory.rs
@@ -6,12 +6,13 @@ extern crate tempdir;
 
 use executable_path::executable_path;
 use std::process;
-use std::{str, fs};
+use std::str;
 use std::path::Path;
 use tempdir::TempDir;
 
 #[cfg(unix)]
 fn to_shell_path(path: &Path) -> String {
+  use std::fs;
   fs::canonicalize(path).expect("canonicalize failed")
     .to_str().map(str::to_string).expect("unicode decode failed")
 }
@@ -33,7 +34,7 @@ fn test_invocation_directory() {
 
   let mut justfile_path = tmp.path().to_path_buf();
   justfile_path.push("justfile");
-  brev::dump(justfile_path, "default:\n @echo {{invocation_directory()}}");
+  brev::dump(justfile_path, "default:\n @cd {{invocation_directory()}}\n @echo {{invocation_directory()}}");
 
   let mut subdir = tmp.path().to_path_buf();
   subdir.push("subdir");

--- a/tests/invocation_directory.rs
+++ b/tests/invocation_directory.rs
@@ -1,0 +1,65 @@
+extern crate brev;
+extern crate executable_path;
+extern crate libc;
+extern crate target;
+extern crate tempdir;
+
+use executable_path::executable_path;
+use std::process;
+use std::{str, fs};
+use tempdir::TempDir;
+
+#[test]
+fn test_invocation_directory() {
+  let tmp = TempDir::new("just-integration")
+    .unwrap_or_else(
+      |err| panic!("integration test: failed to create temporary directory: {}", err));
+
+  let mut justfile_path = tmp.path().to_path_buf();
+  justfile_path.push("justfile");
+  brev::dump(justfile_path, "default:\n @echo {{invocation_directory()}}");
+
+  let mut dotenv_path = tmp.path().to_path_buf();
+  dotenv_path.push(".env");
+  brev::dump(dotenv_path, "DOTENV_KEY=dotenv-value");
+
+  let mut subdir = tmp.path().to_path_buf();
+  subdir.push("subdir");
+  brev::mkdir(&subdir);
+
+  let output = process::Command::new(&executable_path("just"))
+    .current_dir(&subdir)
+    .args(&["--shell", "sh"])
+    .output()
+    .expect("just invocation failed");
+
+  let mut failure = false;
+
+  let expected_status = 0;
+  let expected_stdout =
+    fs::canonicalize(subdir).expect("canonicalize failed")
+      .to_str().expect("converting path to unicode failed").to_owned() + "\n";
+  let expected_stderr = "";
+
+  let status = output.status.code().unwrap();
+  if status != expected_status {
+    println!("bad status: {} != {}", status, expected_status);
+    failure = true;
+  }
+
+  let stdout = str::from_utf8(&output.stdout).unwrap();
+  if stdout != expected_stdout {
+    println!("bad stdout:\ngot:\n{:?}\n\nexpected:\n{:?}", stdout, expected_stdout);
+    failure = true;
+  }
+
+  let stderr = str::from_utf8(&output.stderr).unwrap();
+  if stderr != expected_stderr {
+    println!("bad stderr:\ngot:\n{:?}\n\nexpected:\n{:?}", stderr, expected_stderr);
+    failure = true;
+  }
+
+  if failure {
+    panic!("test failed");
+  }
+}


### PR DESCRIPTION
`invocation_directory` retrieves the current directory that `just` was invoked from, before the cwd (current working directory) was changed to the location of the justfile.

The name's not perfect, but I'm not one for bikeshedding.