### PR TITLE
Improve invalid escape sequence error messages

### DIFF
--- a/src/compilation_error.rs
+++ b/src/compilation_error.rs
@@ -67,9 +67,16 @@ impl<'a> Display for CompilationError<'a> {
                       variable, circle.join(" -> "))?;
         }
       }
+
       InvalidEscapeSequence{character} => {
-        writeln!(f, "`\\{}` is not a valid escape sequence",
-                    character.escape_default().collect::<String>())?;
+        let representation = match character {
+          '`'  => r"\`".to_string(),
+          '\\' => r"\".to_string(),
+          '\'' => r"'".to_string(),
+          '"' => r#"""#.to_string(),
+          _ => character.escape_default().collect(),
+        };
+        writeln!(f, "`\\{}` is not a valid escape sequence", representation)?;
       }
       DuplicateParameter{recipe, parameter} => {
         writeln!(f, "Recipe `{}` has duplicate parameter `{}`", recipe, parameter)?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1800,3 +1800,18 @@ echo:
    stderr:   "echo dotenv-value\necho dotenv-value\n",
    status:   EXIT_SUCCESS,
 }
+
+integration_test! {
+   name:     invalid_escape_sequence_message,
+   justfile: r#"
+X = "\'"
+"#,
+   args:     (),
+   stdout:   "",
+   stderr:   r#"error: `\'` is not a valid escape sequence
+  |
+2 | X = "\'"
+  |     ^^^^
+"#,
+   status:   EXIT_FAILURE,
+}


### PR DESCRIPTION
The invalid escape sequence error message is delimited with backticks and isn't used as input to other programs, so tweak the escaping rules slightly when printing invalid escape sequences. In particular, `, \, ', and " should not be escaped.

Improves one of the messages that @runimp saw in #327