### PR TITLE
Provide prebuilt binary install command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,6 +52,13 @@ On Windows, `just` works with the `sh` provided by https://git-scm.com[Git for W
 
 Pre-built binaries for Linux, MacOS, and Windows can be found on https://github.com/casey/just/releases[the releases page].
 
+You can use the following command to download the latest binary for your platform, just replace `DESTINATION_DIRECTORY` with the directory where you'd like to put `just`:
+
+```sh
+curl -LSfs https://japaric.github.io/trust/install.sh | \
+  sh -s -- --git casey/just --to DESTINATION_DIRECTORY
+```
+
 === Homebrew
 
 On MacOS, `just` is a available through the https://brew.sh[Homebrew] package manager. Install Homebrew using the instructions at https://brew.sh, then run:


### PR DESCRIPTION
@cledoux mentioned wanting an easy shell command to install `just` on a new machine, and I finally got around to seeing how much work it would be. It turns out that since binaries are built with the excellent trust CI templates, it's already done for us.