### PR TITLE
Fix instructions for install command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,11 +52,18 @@ On Windows, `just` works with the `sh` provided by https://git-scm.com[Git for W
 
 Pre-built binaries for Linux, MacOS, and Windows can be found on https://github.com/casey/just/releases[the releases page].
 
-You can use the following command to download the latest binary for your platform, just replace `DESTINATION_DIRECTORY` with the directory where you'd like to put `just`:
+You can use the following command to download the latest binary for MacOS or Windows, just replace `DESTINATION_DIRECTORY` with the directory where you'd like to put `just`:
 
 ```sh
 curl -LSfs https://japaric.github.io/trust/install.sh | \
   sh -s -- --git casey/just --to DESTINATION_DIRECTORY
+```
+
+On Linux, use:
+
+```sh
+curl -LSfs https://japaric.github.io/trust/install.sh | \
+  sh -s -- --git casey/just --target x86_64-unknown-linux-musl --to DESTINATION_DIRECTORY
 ```
 
 === Homebrew


### PR DESCRIPTION
@cledoux pointed out in #329 that one-liner install command is broken on Linux. This diff fixes it by giving it the correct target.