### PR TITLE
Capture SIGINT/SIGTERM and wait for the child process to terminate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dotenv"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +177,7 @@ dependencies = [
  "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "brev 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "edit-distance 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "executable-path 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -196,6 +206,18 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -401,6 +423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
+"checksum ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "630391922b1b893692c6334369ff528dcc3a9d8061ccf4c803aa8f83cb13db5e"
 "checksum dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d0a1279c96732bc6800ce6337b6a614697b0e74ae058dc03c62ebeb78b4d86"
 "checksum edit-distance 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3bd26878c3d921f89797a4e1a1711919f999a9f6946bb6f5a4ffda126d297b7e"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
@@ -414,6 +437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ regex          = "1.0.0"
 target         = "1.0.0"
 tempdir        = "0.3.5"
 unicode-width  = "0.1.3"
+ctrlc          = { version = "3.1", features = ['termination'] }
 
 [dev-dependencies]
 executable-path = "1.0.0"

--- a/src/assignment_evaluator.rs
+++ b/src/assignment_evaluator.rs
@@ -174,7 +174,7 @@ mod test {
   #[test]
   fn backtick_code() {
     match parse_success("a:\n echo {{`f() { return 100; }; f`}}")
-          .run(no_cwd_err(), &["a"], &Default::default(), &Default::default()).unwrap_err() {
+          .run(no_cwd_err(), &["a"], &Default::default()).unwrap_err() {
       RuntimeError::Backtick{token, output_error: OutputError::Code(code)} => {
         assert_eq!(code, 100);
         assert_eq!(token.lexeme, "`f() { return 100; }; f`");
@@ -197,7 +197,7 @@ recipe:
       ..Default::default()
     };
 
-    match parse_success(text).run(no_cwd_err(), &["recipe"], &configuration, &Default::default()).unwrap_err() {
+    match parse_success(text).run(no_cwd_err(), &["recipe"], &configuration).unwrap_err() {
       RuntimeError::Backtick{token, output_error: OutputError::Code(_)} => {
         assert_eq!(token.lexeme, "`echo $exported_variable`");
       },

--- a/src/assignment_evaluator.rs
+++ b/src/assignment_evaluator.rs
@@ -174,7 +174,7 @@ mod test {
   #[test]
   fn backtick_code() {
     match parse_success("a:\n echo {{`f() { return 100; }; f`}}")
-          .run(no_cwd_err(), &["a"], &Default::default()).unwrap_err() {
+          .run(no_cwd_err(), &["a"], &Default::default(), &Default::default()).unwrap_err() {
       RuntimeError::Backtick{token, output_error: OutputError::Code(code)} => {
         assert_eq!(code, 100);
         assert_eq!(token.lexeme, "`f() { return 100; }; f`");
@@ -197,7 +197,7 @@ recipe:
       ..Default::default()
     };
 
-    match parse_success(text).run(no_cwd_err(), &["recipe"], &configuration).unwrap_err() {
+    match parse_success(text).run(no_cwd_err(), &["recipe"], &configuration, &Default::default()).unwrap_err() {
       RuntimeError::Backtick{token, output_error: OutputError::Code(_)} => {
         assert_eq!(token.lexeme, "`echo $exported_variable`");
       },

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ extern crate regex;
 extern crate target;
 extern crate tempdir;
 extern crate unicode_width;
+extern crate ctrlc;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,13 +1,13 @@
 use common::*;
 
 use std::{convert, ffi, cmp};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use clap::{App, Arg, ArgGroup, AppSettings};
 use configuration::DEFAULT_SHELL;
 use misc::maybe_s;
 use unicode_width::UnicodeWidthStr;
 use ctrlc;
+use recipe::INTERRUPTED;
 
 #[cfg(windows)]
 use ansi_term::enable_ansi_support;
@@ -360,17 +360,14 @@ pub fn run() {
     overrides,
   };
 
-  let interrupted = Arc::new(AtomicBool::new(false));
-  let interrupted_clone = interrupted.clone();
   ctrlc::set_handler(move || {
-    interrupted_clone.store(true, Ordering::SeqCst);
+    INTERRUPTED.store(true, Ordering::SeqCst);
   }).expect("Error setting Ctrl-C handler");
 
   if let Err(run_error) = justfile.run(
     invocation_directory,
     &arguments,
-    &configuration,
-    &interrupted)
+    &configuration)
   {
     if !configuration.quiet {
       if color.stderr().active() {


### PR DESCRIPTION
I'm not entirely sure this is the right approach to threading the `interrupted` flag through to the other code, but it seems to work.