### PR TITLE
Fix integration tests with dash

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1194,6 +1194,7 @@ foo:
   status:   EXIT_SUCCESS,
 }
 
+#[cfg(not(windows))]
 integration_test! {
   name:     env_var_functions,
   justfile: r#"
@@ -1209,6 +1210,24 @@ foo:
   stderr:   format!("/bin/echo '{}' 'HTAP' 'ABC'\n", env::var("USER").unwrap()).as_str(),
   status:   EXIT_SUCCESS,
 }
+
+#[cfg(windows)]
+integration_test! {
+  name:     env_var_functions,
+  justfile: r#"
+p = env_var('USERNAME')
+b = env_var_or_default('ZADDY', 'HTAP')
+x = env_var_or_default('XYZ', 'ABC')
+
+foo:
+  /bin/echo '{{p}}' '{{b}}' '{{x}}'
+"#,
+  args:     (),
+  stdout:   format!("{} HTAP ABC\n", env::var("USERNAME").unwrap()).as_str(),
+  stderr:   format!("/bin/echo '{}' 'HTAP' 'ABC'\n", env::var("USERNAME").unwrap()).as_str(),
+  status:   EXIT_SUCCESS,
+}
+
 
 integration_test! {
   name:     env_var_failure,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -234,19 +234,19 @@ integration_test! {
 
 integration_test! {
   name:     backtick_success,
-  justfile: "a = `printf Hello,`\nbar:\n printf '{{a + `printf ' world!'`}}'",
+  justfile: "a = `printf Hello,`\nbar:\n printf '{{a + `printf ' world.'`}}'",
   args:     (),
-  stdout:   "Hello, world!",
-  stderr:   "printf 'Hello, world!'\n",
+  stdout:   "Hello, world.",
+  stderr:   "printf 'Hello, world.'\n",
   status:   EXIT_SUCCESS,
 }
 
 integration_test! {
   name:     backtick_trimming,
-  justfile: "a = `echo Hello,`\nbar:\n echo '{{a + `echo ' world!'`}}'",
+  justfile: "a = `echo Hello,`\nbar:\n echo '{{a + `echo ' world.'`}}'",
   args:     (),
-  stdout:   "Hello, world!\n",
-  stderr:   "echo 'Hello, world!'\n",
+  stdout:   "Hello, world.\n",
+  stderr:   "echo 'Hello, world.'\n",
   status:   EXIT_SUCCESS,
 }
 
@@ -974,12 +974,12 @@ integration_test! {
   name:     use_raw_string_default,
   justfile: r#"
 bar:
-hello baz arg='XYZ\t"	':
+hello baz arg='XYZ"	':
   printf '{{baz}}...{{arg}}'
 "#,
   args:     ("hello", "ABC"),
-  stdout:   "ABC...XYZ\t\"\t",
-  stderr:   "printf 'ABC...XYZ\\t\"\t'\n",
+  stdout:   "ABC...XYZ\"\t",
+  stderr:   "printf 'ABC...XYZ\"\t'\n",
   status:   EXIT_SUCCESS,
 }
 
@@ -1197,7 +1197,7 @@ foo:
 integration_test! {
   name:     env_var_functions,
   justfile: r#"
-p = env_var('PATH')
+p = env_var('USER')
 b = env_var_or_default('ZADDY', 'HTAP')
 x = env_var_or_default('XYZ', 'ABC')
 
@@ -1205,8 +1205,8 @@ foo:
   /bin/echo '{{p}}' '{{b}}' '{{x}}'
 "#,
   args:     (),
-  stdout:   format!("{} HTAP ABC\n", env::var("PATH").unwrap()).as_str(),
-  stderr:   format!("/bin/echo '{}' 'HTAP' 'ABC'\n", env::var("PATH").unwrap()).as_str(),
+  stdout:   format!("{} HTAP ABC\n", env::var("USER").unwrap()).as_str(),
+  stderr:   format!("/bin/echo '{}' 'HTAP' 'ABC'\n", env::var("USER").unwrap()).as_str(),
   status:   EXIT_SUCCESS,
 }
 


### PR DESCRIPTION
Integration tests run with bash, dash, and whatever's installed as `sh`, to ensure compatibility with a wide range of systems.

This commit changed the way that dash escapes special characters:

https://git.kernel.org/pub/scm/utils/dash/dash.git/commit/?id=6900ff60ef7347a8c1445853a8f4689808e0976e

And broke our tests. This commit modifies our tests to be compatible with dash before and after the changes, and should fix the Travis build.