### PR TITLE
Format source code with rustfmt

### DIFF
--- a/src/assignment_evaluator.rs
+++ b/src/assignment_evaluator.rs
@@ -5,30 +5,30 @@ use brev;
 pub struct AssignmentEvaluator<'a: 'b, 'b> {
   pub assignments: &'b Map<&'a str, Expression<'a>>,
   pub invocation_directory: &'b Result<PathBuf, String>,
-  pub dotenv:      &'b Map<String, String>,
-  pub dry_run:     bool,
-  pub evaluated:   Map<&'a str, String>,
-  pub exports:     &'b Set<&'a str>,
-  pub overrides:   &'b Map<&'b str, &'b str>,
-  pub quiet:       bool,
-  pub scope:       &'b Map<&'a str, String>,
-  pub shell:       &'b str,
+  pub dotenv: &'b Map<String, String>,
+  pub dry_run: bool,
+  pub evaluated: Map<&'a str, String>,
+  pub exports: &'b Set<&'a str>,
+  pub overrides: &'b Map<&'b str, &'b str>,
+  pub quiet: bool,
+  pub scope: &'b Map<&'a str, String>,
+  pub shell: &'b str,
 }
 
 impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
   pub fn evaluate_assignments(
     assignments: &Map<&'a str, Expression<'a>>,
     invocation_directory: &Result<PathBuf, String>,
-    dotenv:      &'b Map<String, String>,
-    overrides:   &Map<&str, &str>,
-    quiet:       bool,
-    shell:       &'a str,
-    dry_run:     bool,
+    dotenv: &'b Map<String, String>,
+    overrides: &Map<&str, &str>,
+    quiet: bool,
+    shell: &'a str,
+    dry_run: bool,
   ) -> RunResult<'a, Map<&'a str, String>> {
     let mut evaluator = AssignmentEvaluator {
       evaluated: empty(),
-      exports:   &empty(),
-      scope:     &empty(),
+      exports: &empty(),
+      scope: &empty(),
       assignments,
       invocation_directory,
       dotenv,
@@ -47,14 +47,14 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
 
   pub fn evaluate_line(
     &mut self,
-    line:      &[Fragment<'a>],
-    arguments: &Map<&str, Cow<str>>
+    line: &[Fragment<'a>],
+    arguments: &Map<&str, Cow<str>>,
   ) -> RunResult<'a, String> {
     let mut evaluated = String::new();
     for fragment in line {
       match *fragment {
-        Fragment::Text{ref text} => evaluated += text.lexeme,
-        Fragment::Expression{ref expression} => {
+        Fragment::Text { ref text } => evaluated += text.lexeme,
+        Fragment::Expression { ref expression } => {
           evaluated += &self.evaluate_expression(expression, arguments)?;
         }
       }
@@ -76,7 +76,7 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
       }
     } else {
       return Err(RuntimeError::Internal {
-        message: format!("attempted to evaluated unknown assignment {}", name)
+        message: format!("attempted to evaluated unknown assignment {}", name),
       });
     }
 
@@ -86,10 +86,10 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
   fn evaluate_expression(
     &mut self,
     expression: &Expression<'a>,
-    arguments:  &Map<&str, Cow<str>>
+    arguments: &Map<&str, Cow<str>>,
   ) -> RunResult<'a, String> {
     match *expression {
-      Expression::Variable{name, ..} => {
+      Expression::Variable { name, .. } => {
         if self.evaluated.contains_key(name) {
           Ok(self.evaluated[name].clone())
         } else if self.scope.contains_key(name) {
@@ -101,50 +101,50 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
           Ok(arguments[name].to_string())
         } else {
           Err(RuntimeError::Internal {
-            message: format!("attempted to evaluate undefined variable `{}`", name)
+            message: format!("attempted to evaluate undefined variable `{}`", name),
           })
         }
       }
-      Expression::Call{name, arguments: ref call_arguments, ref token} => {
-        let call_arguments = call_arguments.iter().map(|argument| {
-          self.evaluate_expression(argument, arguments)
-        }).collect::<Result<Vec<String>, RuntimeError>>()?;
+      Expression::Call {
+        name,
+        arguments: ref call_arguments,
+        ref token,
+      } => {
+        let call_arguments = call_arguments
+          .iter()
+          .map(|argument| self.evaluate_expression(argument, arguments))
+          .collect::<Result<Vec<String>, RuntimeError>>()?;
         let context = FunctionContext {
           invocation_directory: &self.invocation_directory,
           dotenv: self.dotenv,
         };
         evaluate_function(token, name, &context, &call_arguments)
       }
-      Expression::String{ref cooked_string} => Ok(cooked_string.cooked.clone()),
-      Expression::Backtick{raw, ref token} => {
+      Expression::String { ref cooked_string } => Ok(cooked_string.cooked.clone()),
+      Expression::Backtick { raw, ref token } => {
         if self.dry_run {
           Ok(format!("`{}`", raw))
         } else {
           Ok(self.run_backtick(self.dotenv, raw, token)?)
         }
       }
-      Expression::Concatination{ref lhs, ref rhs} => {
-        Ok(
-          self.evaluate_expression(lhs, arguments)?
-            +
-          &self.evaluate_expression(rhs, arguments)?
-        )
+      Expression::Concatination { ref lhs, ref rhs } => {
+        Ok(self.evaluate_expression(lhs, arguments)? + &self.evaluate_expression(rhs, arguments)?)
       }
     }
   }
 
   fn run_backtick(
     &self,
-    dotenv:  &Map<String, String>,
-    raw:     &str,
-    token:   &Token<'a>,
+    dotenv: &Map<String, String>,
+    raw: &str,
+    token: &Token<'a>,
   ) -> RunResult<'a, String> {
     let mut cmd = Command::new(self.shell);
 
     cmd.export_environment_variables(self.scope, dotenv, self.exports)?;
 
-    cmd.arg("-cu")
-       .arg(raw);
+    cmd.arg("-cu").arg(raw);
 
     cmd.stderr(if self.quiet {
       process::Stdio::null()
@@ -152,12 +152,14 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
       process::Stdio::inherit()
     });
 
-    InterruptHandler::guard(|| brev::output(cmd)
-      .map_err(|output_error| RuntimeError::Backtick{token: token.clone(), output_error})
-    )
+    InterruptHandler::guard(|| {
+      brev::output(cmd).map_err(|output_error| RuntimeError::Backtick {
+        token: token.clone(),
+        output_error,
+      })
+    })
   }
 }
-
 
 #[cfg(test)]
 mod test {
@@ -173,11 +175,16 @@ mod test {
   #[test]
   fn backtick_code() {
     match parse_success("a:\n echo {{`f() { return 100; }; f`}}")
-          .run(&no_cwd_err(), &["a"], &Default::default()).unwrap_err() {
-      RuntimeError::Backtick{token, output_error: OutputError::Code(code)} => {
+      .run(&no_cwd_err(), &["a"], &Default::default())
+      .unwrap_err()
+    {
+      RuntimeError::Backtick {
+        token,
+        output_error: OutputError::Code(code),
+      } => {
         assert_eq!(code, 100);
         assert_eq!(token.lexeme, "`f() { return 100; }; f`");
-      },
+      }
       other => panic!("expected a code run error, but got: {}", other),
     }
   }
@@ -196,10 +203,16 @@ recipe:
       ..Default::default()
     };
 
-    match parse_success(text).run(&no_cwd_err(), &["recipe"], &configuration).unwrap_err() {
-      RuntimeError::Backtick{token, output_error: OutputError::Code(_)} => {
+    match parse_success(text)
+      .run(&no_cwd_err(), &["recipe"], &configuration)
+      .unwrap_err()
+    {
+      RuntimeError::Backtick {
+        token,
+        output_error: OutputError::Code(_),
+      } => {
         assert_eq!(token.lexeme, "`echo $exported_variable`");
-      },
+      }
       other => panic!("expected a backtick code errror, but got: {}", other),
     }
   }

--- a/src/color.rs
+++ b/src/color.rs
@@ -3,8 +3,8 @@ extern crate atty;
 
 use common::*;
 
-use self::ansi_term::{Style, Prefix, Suffix, ANSIGenericString};
 use self::ansi_term::Color::*;
+use self::ansi_term::{ANSIGenericString, Prefix, Style, Suffix};
 use self::atty::is as is_atty;
 use self::atty::Stream;
 
@@ -18,26 +18,23 @@ pub enum UseColor {
 #[derive(Copy, Clone)]
 pub struct Color {
   use_color: UseColor,
-  atty:      bool,
-  style:     Style,
+  atty: bool,
+  style: Style,
 }
 
 impl Default for Color {
   fn default() -> Color {
     Color {
       use_color: UseColor::Never,
-      atty:      false,
-      style:     Style::new(),
+      atty: false,
+      style: Style::new(),
     }
   }
 }
 
 impl Color {
   fn restyle(self, style: Style) -> Color {
-    Color {
-      style,
-      ..self
-    }
+    Color { style, ..self }
   }
 
   fn redirect(self, stream: Stream) -> Color {
@@ -127,8 +124,8 @@ impl Color {
   pub fn active(&self) -> bool {
     match self.use_color {
       UseColor::Always => true,
-      UseColor::Never  => false,
-      UseColor::Auto   => self.atty,
+      UseColor::Never => false,
+      UseColor::Auto => self.atty,
     }
   }
 

--- a/src/command_ext.rs
+++ b/src/command_ext.rs
@@ -3,18 +3,18 @@ use common::*;
 pub trait CommandExt {
   fn export_environment_variables<'a>(
     &mut self,
-    scope:   &Map<&'a str, String>,
-    dotenv:  &Map<String, String>,
-    exports: &Set<&'a str>
+    scope: &Map<&'a str, String>,
+    dotenv: &Map<String, String>,
+    exports: &Set<&'a str>,
   ) -> RunResult<'a, ()>;
 }
 
 impl CommandExt for Command {
   fn export_environment_variables<'a>(
     &mut self,
-    scope:   &Map<&'a str, String>,
-    dotenv:  &Map<String, String>,
-    exports: &Set<&'a str>
+    scope: &Map<&'a str, String>,
+    dotenv: &Map<String, String>,
+    exports: &Set<&'a str>,
   ) -> RunResult<'a, ()> {
     for (name, value) in dotenv {
       self.env(name, value);
@@ -24,7 +24,7 @@ impl CommandExt for Command {
         self.env(name, value);
       } else {
         return Err(RuntimeError::Internal {
-          message: format!("scope does not contain exported variable `{}`",  name),
+          message: format!("scope does not contain exported variable `{}`", name),
         });
       }
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,7 +6,7 @@ pub use std::ops::Range;
 pub use std::path::{Path, PathBuf};
 pub use std::process::Command;
 pub use std::sync::{Mutex, MutexGuard};
-pub use std::{cmp, env, fs, fmt, io, iter, process, vec, usize};
+pub use std::{cmp, env, fmt, fs, io, iter, process, usize, vec};
 
 pub use color::Color;
 pub use libc::{EXIT_FAILURE, EXIT_SUCCESS};
@@ -32,7 +32,7 @@ pub use parser::Parser;
 pub use range_ext::RangeExt;
 pub use recipe::{Recipe, RecipeContext};
 pub use recipe_resolver::RecipeResolver;
-pub use runtime_error::{RuntimeError, RunResult};
+pub use runtime_error::{RunResult, RuntimeError};
 pub use shebang::Shebang;
 pub use token::{Token, TokenKind};
 pub use verbosity::Verbosity;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,26 +3,26 @@ use common::*;
 pub const DEFAULT_SHELL: &str = "sh";
 
 pub struct Configuration<'a> {
-  pub dry_run:   bool,
-  pub evaluate:  bool,
+  pub dry_run: bool,
+  pub evaluate: bool,
   pub highlight: bool,
   pub overrides: Map<&'a str, &'a str>,
-  pub quiet:     bool,
-  pub shell:     &'a str,
-  pub color:     Color,
+  pub quiet: bool,
+  pub shell: &'a str,
+  pub color: Color,
   pub verbosity: Verbosity,
 }
 
 impl<'a> Default for Configuration<'a> {
   fn default() -> Configuration<'static> {
     Configuration {
-      dry_run:   false,
-      evaluate:  false,
+      dry_run: false,
+      evaluate: false,
       highlight: false,
       overrides: empty(),
-      quiet:     false,
-      shell:     DEFAULT_SHELL,
-      color:     default(),
+      quiet: false,
+      shell: DEFAULT_SHELL,
+      color: default(),
       verbosity: Verbosity::from_flag_occurrences(0),
     }
   }

--- a/src/cooked_string.rs
+++ b/src/cooked_string.rs
@@ -2,30 +2,35 @@ use common::*;
 
 #[derive(PartialEq, Debug)]
 pub struct CookedString<'a> {
-  pub raw:    &'a str,
+  pub raw: &'a str,
   pub cooked: String,
 }
 
 impl<'a> CookedString<'a> {
   pub fn new(token: &Token<'a>) -> CompilationResult<'a, CookedString<'a>> {
-    let raw = &token.lexeme[1..token.lexeme.len()-1];
+    let raw = &token.lexeme[1..token.lexeme.len() - 1];
 
     if let TokenKind::RawString = token.kind {
-      Ok(CookedString{cooked: raw.to_string(), raw})
+      Ok(CookedString {
+        cooked: raw.to_string(),
+        raw,
+      })
     } else if let TokenKind::StringToken = token.kind {
       let mut cooked = String::new();
       let mut escape = false;
       for c in raw.chars() {
         if escape {
           match c {
-            'n'   => cooked.push('\n'),
-            'r'   => cooked.push('\r'),
-            't'   => cooked.push('\t'),
-            '\\'  => cooked.push('\\'),
-            '"'   => cooked.push('"'),
-            other => return Err(token.error(CompilationErrorKind::InvalidEscapeSequence {
-              character: other,
-            })),
+            'n' => cooked.push('\n'),
+            'r' => cooked.push('\r'),
+            't' => cooked.push('\t'),
+            '\\' => cooked.push('\\'),
+            '"' => cooked.push('"'),
+            other => {
+              return Err(
+                token.error(CompilationErrorKind::InvalidEscapeSequence { character: other }),
+              )
+            }
           }
           escape = false;
           continue;
@@ -36,10 +41,10 @@ impl<'a> CookedString<'a> {
         }
         cooked.push(c);
       }
-      Ok(CookedString{raw, cooked})
+      Ok(CookedString { raw, cooked })
     } else {
       Err(token.error(CompilationErrorKind::Internal {
-        message: "cook_string() called on non-string token".to_string()
+        message: "cook_string() called on non-string token".to_string(),
       }))
     }
   }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -2,35 +2,50 @@ use common::*;
 
 #[derive(PartialEq, Debug)]
 pub enum Expression<'a> {
-  Backtick{raw: &'a str, token: Token<'a>},
-  Call{name: &'a str, token: Token<'a>, arguments: Vec<Expression<'a>>},
-  Concatination{lhs: Box<Expression<'a>>, rhs: Box<Expression<'a>>},
-  String{cooked_string: CookedString<'a>},
-  Variable{name: &'a str, token: Token<'a>},
+  Backtick {
+    raw: &'a str,
+    token: Token<'a>,
+  },
+  Call {
+    name: &'a str,
+    token: Token<'a>,
+    arguments: Vec<Expression<'a>>,
+  },
+  Concatination {
+    lhs: Box<Expression<'a>>,
+    rhs: Box<Expression<'a>>,
+  },
+  String {
+    cooked_string: CookedString<'a>,
+  },
+  Variable {
+    name: &'a str,
+    token: Token<'a>,
+  },
 }
 
 impl<'a> Expression<'a> {
   pub fn variables(&'a self) -> Variables<'a> {
-    Variables {
-      stack: vec![self],
-    }
+    Variables { stack: vec![self] }
   }
 
   pub fn functions(&'a self) -> Functions<'a> {
-    Functions {
-      stack: vec![self],
-    }
+    Functions { stack: vec![self] }
   }
 }
 
 impl<'a> Display for Expression<'a> {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     match *self {
-      Expression::Backtick     {raw, ..            } => write!(f, "`{}`", raw)?,
-      Expression::Concatination{ref lhs, ref rhs   } => write!(f, "{} + {}", lhs, rhs)?,
-      Expression::String       {ref cooked_string  } => write!(f, "\"{}\"", cooked_string.raw)?,
-      Expression::Variable     {name, ..           } => write!(f, "{}", name)?,
-      Expression::Call         {name, ref arguments, ..} => {
+      Expression::Backtick { raw, .. } => write!(f, "`{}`", raw)?,
+      Expression::Concatination { ref lhs, ref rhs } => write!(f, "{} + {}", lhs, rhs)?,
+      Expression::String { ref cooked_string } => write!(f, "\"{}\"", cooked_string.raw)?,
+      Expression::Variable { name, .. } => write!(f, "{}", name)?,
+      Expression::Call {
+        name,
+        ref arguments,
+        ..
+      } => {
         write!(f, "{}(", name)?;
         for (i, argument) in arguments.iter().enumerate() {
           if i > 0 {
@@ -56,11 +71,11 @@ impl<'a> Iterator for Variables<'a> {
   fn next(&mut self) -> Option<&'a Token<'a>> {
     match self.stack.pop() {
       None
-      | Some(&Expression::String{..})
-      | Some(&Expression::Backtick{..})
-      | Some(&Expression::Call{..}) => None,
-      Some(&Expression::Variable{ref token,..}) => Some(token),
-      Some(&Expression::Concatination{ref lhs, ref rhs}) => {
+      | Some(&Expression::String { .. })
+      | Some(&Expression::Backtick { .. })
+      | Some(&Expression::Call { .. }) => None,
+      Some(&Expression::Variable { ref token, .. }) => Some(token),
+      Some(&Expression::Concatination { ref lhs, ref rhs }) => {
         self.stack.push(lhs);
         self.stack.push(rhs);
         self.next()
@@ -79,11 +94,15 @@ impl<'a> Iterator for Functions<'a> {
   fn next(&mut self) -> Option<Self::Item> {
     match self.stack.pop() {
       None
-      | Some(&Expression::String{..})
-      | Some(&Expression::Backtick{..})
-      | Some(&Expression::Variable{..}) => None,
-      Some(&Expression::Call{ref token, ref arguments, ..}) => Some((token, arguments.len())),
-      Some(&Expression::Concatination{ref lhs, ref rhs}) => {
+      | Some(&Expression::String { .. })
+      | Some(&Expression::Backtick { .. })
+      | Some(&Expression::Variable { .. }) => None,
+      Some(&Expression::Call {
+        ref token,
+        ref arguments,
+        ..
+      }) => Some((token, arguments.len())),
+      Some(&Expression::Concatination { ref lhs, ref rhs }) => {
         self.stack.push(lhs);
         self.stack.push(rhs);
         self.next()

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -2,14 +2,14 @@ use common::*;
 
 #[derive(PartialEq, Debug)]
 pub enum Fragment<'a> {
-  Text{text: Token<'a>},
-  Expression{expression: Expression<'a>},
+  Text { text: Token<'a> },
+  Expression { expression: Expression<'a> },
 }
 
 impl<'a> Fragment<'a> {
   pub fn continuation(&self) -> bool {
     match *self {
-      Fragment::Text{ref text} => text.lexeme.ends_with('\\'),
+      Fragment::Text { ref text } => text.lexeme.ends_with('\\'),
       _ => false,
     }
   }

--- a/src/function.rs
+++ b/src/function.rs
@@ -6,19 +6,24 @@ use platform::{Platform, PlatformInterface};
 
 lazy_static! {
   static ref FUNCTIONS: Map<&'static str, Function> = vec![
-    ("arch",               Function::Nullary(arch              )),
-    ("os",                 Function::Nullary(os                )),
-    ("os_family",          Function::Nullary(os_family         )),
-    ("env_var",            Function::Unary  (env_var           )),
-    ("env_var_or_default", Function::Binary (env_var_or_default)),
-    ("invocation_directory", Function::Nullary(invocation_directory)),
-  ].into_iter().collect();
+    ("arch", Function::Nullary(arch)),
+    ("os", Function::Nullary(os)),
+    ("os_family", Function::Nullary(os_family)),
+    ("env_var", Function::Unary(env_var)),
+    ("env_var_or_default", Function::Binary(env_var_or_default)),
+    (
+      "invocation_directory",
+      Function::Nullary(invocation_directory)
+    ),
+  ]
+  .into_iter()
+  .collect();
 }
 
 enum Function {
-  Nullary(fn(&FunctionContext,           ) -> Result<String, String>),
-  Unary  (fn(&FunctionContext, &str      ) -> Result<String, String>),
-  Binary (fn(&FunctionContext, &str, &str) -> Result<String, String>),
+  Nullary(fn(&FunctionContext) -> Result<String, String>),
+  Unary(fn(&FunctionContext, &str) -> Result<String, String>),
+  Binary(fn(&FunctionContext, &str, &str) -> Result<String, String>),
 }
 
 impl Function {
@@ -26,8 +31,8 @@ impl Function {
     use self::Function::*;
     match *self {
       Nullary(_) => 0,
-      Unary(_)   => 1,
-      Binary(_)  => 2,
+      Unary(_) => 1,
+      Binary(_) => 2,
     }
   }
 }
@@ -42,45 +47,56 @@ pub fn resolve_function<'a>(token: &Token<'a>, argc: usize) -> CompilationResult
   if let Some(function) = FUNCTIONS.get(&name) {
     use self::Function::*;
     match (function, argc) {
-      (&Nullary(_), 0) |
-      (&Unary(_),   1) |
-      (&Binary(_),  2) => Ok(()),
-      _               => {
-        Err(token.error(CompilationErrorKind::FunctionArgumentCountMismatch{
-          function: name, found: argc, expected: function.argc(),
-        }))
-      }
+      (&Nullary(_), 0) | (&Unary(_), 1) | (&Binary(_), 2) => Ok(()),
+      _ => Err(
+        token.error(CompilationErrorKind::FunctionArgumentCountMismatch {
+          function: name,
+          found: argc,
+          expected: function.argc(),
+        }),
+      ),
     }
   } else {
-    Err(token.error(CompilationErrorKind::UnknownFunction{function: token.lexeme}))
+    Err(token.error(CompilationErrorKind::UnknownFunction {
+      function: token.lexeme,
+    }))
   }
 }
 
 pub fn evaluate_function<'a>(
-  token:     &Token<'a>,
-  name:      &'a str,
-  context:   &FunctionContext,
-  arguments: &[String]
+  token: &Token<'a>,
+  name: &'a str,
+  context: &FunctionContext,
+  arguments: &[String],
 ) -> RunResult<'a, String> {
   if let Some(function) = FUNCTIONS.get(name) {
     use self::Function::*;
     let argc = arguments.len();
     match (function, argc) {
-      (&Nullary(f), 0) => f(context)
-        .map_err(|message| RuntimeError::FunctionCall{token: token.clone(), message}),
-      (&Unary(f), 1) => f(context, &arguments[0])
-        .map_err(|message| RuntimeError::FunctionCall{token: token.clone(), message}),
-      (&Binary(f), 2) => f(context, &arguments[0], &arguments[1])
-        .map_err(|message| RuntimeError::FunctionCall{token: token.clone(), message}),
-      _                => {
-        Err(RuntimeError::Internal {
-          message: format!("attempted to evaluate function `{}` with {} arguments", name, argc)
+      (&Nullary(f), 0) => f(context).map_err(|message| RuntimeError::FunctionCall {
+        token: token.clone(),
+        message,
+      }),
+      (&Unary(f), 1) => f(context, &arguments[0]).map_err(|message| RuntimeError::FunctionCall {
+        token: token.clone(),
+        message,
+      }),
+      (&Binary(f), 2) => {
+        f(context, &arguments[0], &arguments[1]).map_err(|message| RuntimeError::FunctionCall {
+          token: token.clone(),
+          message,
         })
       }
+      _ => Err(RuntimeError::Internal {
+        message: format!(
+          "attempted to evaluate function `{}` with {} arguments",
+          name, argc
+        ),
+      }),
     }
   } else {
     Err(RuntimeError::Internal {
-      message: format!("attempted to evaluate unknown function: `{}`", name)
+      message: format!("attempted to evaluate unknown function: `{}`", name),
     })
   }
 }
@@ -98,9 +114,9 @@ pub fn os_family(_context: &FunctionContext) -> Result<String, String> {
 }
 
 pub fn invocation_directory(context: &FunctionContext) -> Result<String, String> {
-  context.invocation_directory.clone()
-    .and_then(|s| Platform::to_shell_path(&s)
-      .map_err(|e| format!("Error getting shell path: {}", e)))
+  context.invocation_directory.clone().and_then(|s| {
+    Platform::to_shell_path(&s).map_err(|e| format!("Error getting shell path: {}", e))
+  })
 }
 
 pub fn env_var(context: &FunctionContext, key: &str) -> Result<String, String> {
@@ -112,16 +128,18 @@ pub fn env_var(context: &FunctionContext, key: &str) -> Result<String, String> {
 
   match env::var(key) {
     Err(NotPresent) => Err(format!("environment variable `{}` not present", key)),
-    Err(NotUnicode(os_string)) =>
-      Err(format!("environment variable `{}` not unicode: {:?}", key, os_string)),
+    Err(NotUnicode(os_string)) => Err(format!(
+      "environment variable `{}` not unicode: {:?}",
+      key, os_string
+    )),
     Ok(value) => Ok(value),
   }
 }
 
 pub fn env_var_or_default(
   context: &FunctionContext,
-  key:      &str,
-  default:  &str,
+  key: &str,
+  default: &str,
 ) -> Result<String, String> {
   if let Some(value) = context.dotenv.get(key) {
     return Ok(value.clone());
@@ -130,8 +148,10 @@ pub fn env_var_or_default(
   use std::env::VarError::*;
   match env::var(key) {
     Err(NotPresent) => Ok(default.to_string()),
-    Err(NotUnicode(os_string)) =>
-      Err(format!("environment variable `{}` not unicode: {:?}", key, os_string)),
+    Err(NotUnicode(os_string)) => Err(format!(
+      "environment variable `{}` not unicode: {:?}",
+      key, os_string
+    )),
     Ok(value) => Ok(value),
   }
 }

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -2,7 +2,7 @@ use common::*;
 
 pub fn compile(text: &str) {
   if let Err(error) = Parser::parse(text) {
-    if let CompilationErrorKind::Internal{..} = error.kind {
+    if let CompilationErrorKind::Internal { .. } = error.kind {
       panic!("{}", error)
     }
   }

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -126,17 +126,15 @@ impl<'a> Justfile<'a> where {
       });
     }
 
-    let context = RecipeContext{invocation_directory, configuration, scope};
+    let context = RecipeContext {
+      invocation_directory,
+      configuration,
+      scope,
+    };
 
     let mut ran = empty();
     for (recipe, arguments) in grouped {
-      self.run_recipe(
-        &context,
-        recipe,
-        arguments,
-        &dotenv,
-        &mut ran,
-      )?
+      self.run_recipe(&context, recipe, arguments, &dotenv, &mut ran)?
     }
 
     Ok(())
@@ -152,21 +150,10 @@ impl<'a> Justfile<'a> where {
   ) -> RunResult<()> {
     for dependency_name in &recipe.dependencies {
       if !ran.contains(dependency_name) {
-        self.run_recipe(
-          context,
-          &self.recipes[dependency_name],
-          &[],
-          dotenv,
-          ran,
-        )?;
+        self.run_recipe(context, &self.recipes[dependency_name], &[], dotenv, ran)?;
       }
     }
-    recipe.run(
-      context,
-      arguments,
-      dotenv,
-      &self.exports,
-    )?;
+    recipe.run(context, arguments, dotenv, &self.exports)?;
     ran.insert(recipe.name);
     Ok(())
   }
@@ -313,10 +300,7 @@ a return code:
         min,
         max,
       } => {
-        let param_names = parameters
-          .iter()
-          .map(|p| p.name)
-          .collect::<Vec<&str>>();
+        let param_names = parameters.iter().map(|p| p.name).collect::<Vec<&str>>();
         assert_eq!(recipe, "a");
         assert_eq!(param_names, ["b", "c", "d"]);
         assert_eq!(found, 2);
@@ -340,10 +324,7 @@ a return code:
         min,
         max,
       } => {
-        let param_names = parameters
-          .iter()
-          .map(|p| p.name)
-          .collect::<Vec<&str>>();
+        let param_names = parameters.iter().map(|p| p.name).collect::<Vec<&str>>();
         assert_eq!(recipe, "a");
         assert_eq!(param_names, ["b", "c", "d"]);
         assert_eq!(found, 2);
@@ -367,10 +348,7 @@ a return code:
         min,
         max,
       } => {
-        let param_names = parameters
-          .iter()
-          .map(|p| p.name)
-          .collect::<Vec<&str>>();
+        let param_names = parameters.iter().map(|p| p.name).collect::<Vec<&str>>();
         assert_eq!(recipe, "a");
         assert_eq!(param_names, ["b", "c", "d"]);
         assert_eq!(found, 0);
@@ -394,10 +372,7 @@ a return code:
         min,
         max,
       } => {
-        let param_names = parameters
-          .iter()
-          .map(|p| p.name)
-          .collect::<Vec<&str>>();
+        let param_names = parameters.iter().map(|p| p.name).collect::<Vec<&str>>();
         assert_eq!(recipe, "a");
         assert_eq!(param_names, ["b", "c", "d"]);
         assert_eq!(found, 1);
@@ -421,10 +396,7 @@ a return code:
         min,
         max,
       } => {
-        let param_names = parameters
-          .iter()
-          .map(|p| p.name)
-          .collect::<Vec<&str>>();
+        let param_names = parameters.iter().map(|p| p.name).collect::<Vec<&str>>();
         assert_eq!(recipe, "a");
         assert_eq!(param_names, ["b", "c", "d"]);
         assert_eq!(found, 0);

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,7 +1,7 @@
 use common::*;
 
-use TokenKind::*;
 use CompilationErrorKind::*;
+use TokenKind::*;
 
 fn re(pattern: &str) -> Regex {
   Regex::new(pattern).unwrap()
@@ -21,12 +21,12 @@ fn mixed_whitespace(text: &str) -> bool {
 
 pub struct Lexer<'a> {
   tokens: Vec<Token<'a>>,
-  text:   &'a str,
-  rest:   &'a str,
-  index:  usize,
+  text: &'a str,
+  rest: &'a str,
+  index: usize,
   column: usize,
-  line:   usize,
-  state:  Vec<State<'a>>,
+  line: usize,
+  state: Vec<State<'a>>,
 }
 
 #[derive(PartialEq)]
@@ -39,13 +39,13 @@ enum State<'a> {
 
 impl<'a> Lexer<'a> {
   pub fn lex(text: &'a str) -> CompilationResult<Vec<Token<'a>>> {
-    let lexer = Lexer{
+    let lexer = Lexer {
       tokens: vec![],
-      rest:   text,
-      index:  0,
-      line:   0,
+      rest: text,
+      index: 0,
+      line: 0,
       column: 0,
-      state:  vec![State::Start],
+      state: vec![State::Start],
       text,
     };
 
@@ -54,21 +54,21 @@ impl<'a> Lexer<'a> {
 
   fn error(&self, kind: CompilationErrorKind<'a>) -> CompilationError<'a> {
     CompilationError {
-      text:   self.text,
-      index:  self.index,
-      line:   self.line,
+      text: self.text,
+      index: self.index,
+      line: self.line,
       column: self.column,
-      width:  None,
+      width: None,
       kind,
     }
   }
 
   fn token(&self, prefix: &'a str, lexeme: &'a str, kind: TokenKind) -> Token<'a> {
     Token {
-      index:  self.index,
-      line:   self.line,
+      index: self.index,
+      line: self.line,
       column: self.column,
-      text:   self.text,
+      text: self.text,
       prefix,
       lexeme,
       kind,
@@ -80,19 +80,21 @@ impl<'a> Lexer<'a> {
       static ref INDENT: Regex = re(r"^([ \t]*)[^ \t\n\r]");
     }
 
-    let indentation = INDENT.captures(self.rest).map(|captures| captures.get(1).unwrap().as_str());
+    let indentation = INDENT
+      .captures(self.rest)
+      .map(|captures| captures.get(1).unwrap().as_str());
 
     if self.column == 0 {
       if let Some(kind) = match (self.state.last().unwrap(), indentation) {
         // ignore: was no indentation and there still isn't
         //         or current line is blank
-        (&State::Start, Some("")) | (_, None) => {
-          None
-        }
+        (&State::Start, Some("")) | (_, None) => None,
         // indent: was no indentation, now there is
         (&State::Start, Some(current)) => {
           if mixed_whitespace(current) {
-            return Err(self.error(MixedLeadingWhitespace{whitespace: current}));
+            return Err(self.error(MixedLeadingWhitespace {
+              whitespace: current,
+            }));
           }
           //indent = Some(current);
           self.state.push(State::Indent(current));
@@ -107,9 +109,9 @@ impl<'a> Lexer<'a> {
         // was indentation and still is, check if the new indentation matches
         (&State::Indent(previous), Some(current)) => {
           if !current.starts_with(previous) {
-            return Err(self.error(InconsistentLeadingWhitespace{
+            return Err(self.error(InconsistentLeadingWhitespace {
               expected: previous,
-              found: current
+              found: current,
             }));
           }
           None
@@ -117,7 +119,7 @@ impl<'a> Lexer<'a> {
         // at column 0 in some other state: this should never happen
         (&State::Text, _) | (&State::Interpolation, _) => {
           return Err(self.error(Internal {
-            message: "unexpected state at column 0".to_string()
+            message: "unexpected state at column 0".to_string(),
           }));
         }
       } {
@@ -129,27 +131,27 @@ impl<'a> Lexer<'a> {
 
   pub fn inner(mut self) -> CompilationResult<'a, Vec<Token<'a>>> {
     lazy_static! {
-      static ref AT:                        Regex = token(r"@"                         );
-      static ref BACKTICK:                  Regex = token(r"`[^`\n\r]*`"               );
-      static ref COLON:                     Regex = token(r":"                         );
-      static ref COMMA:                     Regex = token(r","                         );
-      static ref COMMENT:                   Regex = token(r"#([^!\n\r][^\n\r]*)?\r?$"  );
-      static ref EOF:                       Regex = token(r"\z"                        );
-      static ref EOL:                       Regex = token(r"\n|\r\n"                   );
-      static ref EQUALS:                    Regex = token(r"="                         );
-      static ref INTERPOLATION_END:         Regex = token(r"[}][}]"                    );
-      static ref INTERPOLATION_START_TOKEN: Regex = token(r"[{][{]"                    );
-      static ref NAME:                      Regex = token(r"([a-zA-Z_][a-zA-Z0-9_-]*)" );
-      static ref PAREN_L:                   Regex = token(r"[(]"                       );
-      static ref PAREN_R:                   Regex = token(r"[)]"                       );
-      static ref PLUS:                      Regex = token(r"[+]"                       );
-      static ref RAW_STRING:                Regex = token(r#"'[^']*'"#                 );
-      static ref STRING:                    Regex = token(r#"["]"#                     );
-      static ref UNTERMINATED_RAW_STRING:   Regex = token(r#"'[^']*"#                  );
-      static ref INTERPOLATION_START:       Regex = re(r"^[{][{]"                 );
-      static ref LEADING_TEXT:              Regex = re(r"^(?m)(.+?)[{][{]"        );
-      static ref LINE:                      Regex = re(r"^(?m)[ \t]+[^ \t\n\r].*$");
-      static ref TEXT:                      Regex = re(r"^(?m)(.+)"               );
+      static ref AT: Regex = token(r"@");
+      static ref BACKTICK: Regex = token(r"`[^`\n\r]*`");
+      static ref COLON: Regex = token(r":");
+      static ref COMMA: Regex = token(r",");
+      static ref COMMENT: Regex = token(r"#([^!\n\r][^\n\r]*)?\r?$");
+      static ref EOF: Regex = token(r"\z");
+      static ref EOL: Regex = token(r"\n|\r\n");
+      static ref EQUALS: Regex = token(r"=");
+      static ref INTERPOLATION_END: Regex = token(r"[}][}]");
+      static ref INTERPOLATION_START_TOKEN: Regex = token(r"[{][{]");
+      static ref NAME: Regex = token(r"([a-zA-Z_][a-zA-Z0-9_-]*)");
+      static ref PAREN_L: Regex = token(r"[(]");
+      static ref PAREN_R: Regex = token(r"[)]");
+      static ref PLUS: Regex = token(r"[+]");
+      static ref RAW_STRING: Regex = token(r#"'[^']*'"#);
+      static ref STRING: Regex = token(r#"["]"#);
+      static ref UNTERMINATED_RAW_STRING: Regex = token(r#"'[^']*"#);
+      static ref INTERPOLATION_START: Regex = re(r"^[{][{]");
+      static ref LEADING_TEXT: Regex = re(r"^(?m)(.+?)[{][{]");
+      static ref LINE: Regex = re(r"^(?m)[ \t]+[^ \t\n\r].*$");
+      static ref TEXT: Regex = re(r"^(?m)(.+)");
     }
 
     loop {
@@ -163,17 +165,25 @@ impl<'a> Lexer<'a> {
         self.tokens.push(token);
       }
 
-      let (prefix, lexeme, kind) =
-      if let (0, &State::Indent(indent), Some(captures)) =
-        (self.column, self.state.last().unwrap(), LINE.captures(self.rest)) {
+      let (prefix, lexeme, kind) = if let (0, &State::Indent(indent), Some(captures)) = (
+        self.column,
+        self.state.last().unwrap(),
+        LINE.captures(self.rest),
+      ) {
         let line = captures.get(0).unwrap().as_str();
         if !line.starts_with(indent) {
-          return Err(self.error(Internal{message: "unexpected indent".to_string()}));
+          return Err(self.error(Internal {
+            message: "unexpected indent".to_string(),
+          }));
         }
         self.state.push(State::Text);
         (&line[0..indent.len()], "", Line)
       } else if let Some(captures) = EOF.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Eof)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          Eof,
+        )
       } else if let State::Text = *self.state.last().unwrap() {
         if let Some(captures) = INTERPOLATION_START.captures(self.rest) {
           self.state.push(State::Interpolation);
@@ -184,51 +194,111 @@ impl<'a> Lexer<'a> {
           ("", captures.get(1).unwrap().as_str(), Text)
         } else if let Some(captures) = EOL.captures(self.rest) {
           self.state.pop();
-          (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Eol)
+          (
+            captures.get(1).unwrap().as_str(),
+            captures.get(2).unwrap().as_str(),
+            Eol,
+          )
         } else {
           return Err(self.error(Internal {
-            message: format!("Could not match token in text state: \"{}\"", self.rest)
+            message: format!("Could not match token in text state: \"{}\"", self.rest),
           }));
         }
       } else if let Some(captures) = INTERPOLATION_START_TOKEN.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), InterpolationStart)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          InterpolationStart,
+        )
       } else if let Some(captures) = INTERPOLATION_END.captures(self.rest) {
         if self.state.last().unwrap() == &State::Interpolation {
           self.state.pop();
         }
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), InterpolationEnd)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          InterpolationEnd,
+        )
       } else if let Some(captures) = NAME.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Name)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          Name,
+        )
       } else if let Some(captures) = EOL.captures(self.rest) {
         if self.state.last().unwrap() == &State::Interpolation {
           return Err(self.error(UnterminatedInterpolation));
         }
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Eol)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          Eol,
+        )
       } else if let Some(captures) = BACKTICK.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Backtick)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          Backtick,
+        )
       } else if let Some(captures) = COLON.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Colon)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          Colon,
+        )
       } else if let Some(captures) = AT.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), At)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          At,
+        )
       } else if let Some(captures) = COMMA.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Comma)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          Comma,
+        )
       } else if let Some(captures) = PAREN_L.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), ParenL)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          ParenL,
+        )
       } else if let Some(captures) = PAREN_R.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), ParenR)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          ParenR,
+        )
       } else if let Some(captures) = PLUS.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Plus)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          Plus,
+        )
       } else if let Some(captures) = EQUALS.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Equals)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          Equals,
+        )
       } else if let Some(captures) = COMMENT.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), Comment)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          Comment,
+        )
       } else if let Some(captures) = RAW_STRING.captures(self.rest) {
-        (captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str(), RawString)
+        (
+          captures.get(1).unwrap().as_str(),
+          captures.get(2).unwrap().as_str(),
+          RawString,
+        )
       } else if UNTERMINATED_RAW_STRING.is_match(self.rest) {
         return Err(self.error(UnterminatedString));
       } else if let Some(captures) = STRING.captures(self.rest) {
         let prefix = captures.get(1).unwrap().as_str();
-        let contents = &self.rest[prefix.len()+1..];
+        let contents = &self.rest[prefix.len() + 1..];
         if contents.is_empty() {
           return Err(self.error(UnterminatedString));
         }
@@ -266,10 +336,12 @@ impl<'a> Lexer<'a> {
       if len == 0 {
         let last = self.tokens.last().unwrap();
         match last.kind {
-          Eof => {},
-          _ => return Err(last.error(Internal {
-            message: format!("zero length token: {:?}", last)
-          })),
+          Eof => {}
+          _ => {
+            return Err(last.error(Internal {
+              message: format!("zero length token: {:?}", last),
+            }))
+          }
         }
       }
 
@@ -314,46 +386,55 @@ mod test {
         let input = $input;
         let expected = $expected;
         let tokens = ::Lexer::lex(input).unwrap();
-        let roundtrip = tokens.iter().map(|t| {
-          let mut s = String::new();
-          s += t.prefix;
-          s += t.lexeme;
-          s
-        }).collect::<Vec<_>>().join("");
+        let roundtrip = tokens
+          .iter()
+          .map(|t| {
+            let mut s = String::new();
+            s += t.prefix;
+            s += t.lexeme;
+            s
+          })
+          .collect::<Vec<_>>()
+          .join("");
         let actual = token_summary(&tokens);
         if actual != expected {
-          panic!("token summary mismatch:\nexpected: {}\ngot:      {}\n", expected, actual);
+          panic!(
+            "token summary mismatch:\nexpected: {}\ngot:      {}\n",
+            expected, actual
+          );
         }
         assert_eq!(input, roundtrip);
       }
-    }
+    };
   }
 
   fn token_summary(tokens: &[Token]) -> String {
-    tokens.iter().map(|t| {
-      match t.kind {
-        At                 => "@",
-        Backtick           => "`",
-        Colon              => ":",
-        Comma              => ",",
-        Comment{..}        => "#",
-        Dedent             => "<",
-        Eof                => ".",
-        Eol                => "$",
-        Equals             => "=",
-        Indent{..}         => ">",
-        InterpolationEnd   => "}",
+    tokens
+      .iter()
+      .map(|t| match t.kind {
+        At => "@",
+        Backtick => "`",
+        Colon => ":",
+        Comma => ",",
+        Comment { .. } => "#",
+        Dedent => "<",
+        Eof => ".",
+        Eol => "$",
+        Equals => "=",
+        Indent { .. } => ">",
+        InterpolationEnd => "}",
         InterpolationStart => "{",
-        Line{..}           => "^",
-        Name               => "N",
-        ParenL             => "(",
-        ParenR             => ")",
-        Plus               => "+",
-        RawString          => "'",
-        StringToken        => "\"",
-        Text               => "_",
-      }
-    }).collect::<Vec<_>>().join("")
+        Line { .. } => "^",
+        Name => "N",
+        ParenL => "(",
+        ParenR => ")",
+        Plus => "+",
+        RawString => "'",
+        StringToken => "\"",
+        Text => "_",
+      })
+      .collect::<Vec<_>>()
+      .join("")
   }
 
   macro_rules! error_test {
@@ -371,26 +452,26 @@ mod test {
         let input = $input;
 
         let expected = CompilationError {
-          text:   input,
-          index:  $index,
-          line:   $line,
+          text: input,
+          index: $index,
+          line: $line,
           column: $column,
-          width:  $width,
-          kind:   $kind,
+          width: $width,
+          kind: $kind,
         };
 
         if let Err(error) = Lexer::lex(input) {
-          assert_eq!(error.text,   expected.text);
-          assert_eq!(error.index,  expected.index);
-          assert_eq!(error.line,   expected.line);
+          assert_eq!(error.text, expected.text);
+          assert_eq!(error.index, expected.index);
+          assert_eq!(error.line, expected.line);
           assert_eq!(error.column, expected.column);
-          assert_eq!(error.kind,   expected.kind);
-          assert_eq!(error,        expected);
+          assert_eq!(error.kind, expected.kind);
+          assert_eq!(error, expected);
         } else {
           panic!("tokenize succeeded but expected: {}\n{}", expected, input);
         }
       }
-    }
+    };
   }
 
   summary_test! {

--- a/src/load_dotenv.rs
+++ b/src/load_dotenv.rs
@@ -6,12 +6,14 @@ pub fn load_dotenv() -> RunResult<'static, Map<String, String>> {
   match dotenv::dotenv_iter() {
     Ok(iter) => {
       let result: dotenv::Result<Map<String, String>> = iter.collect();
-      result.map_err(|dotenv_error| RuntimeError::Dotenv{dotenv_error})
+      result.map_err(|dotenv_error| RuntimeError::Dotenv { dotenv_error })
     }
-    Err(dotenv_error) => if dotenv_error.not_found() {
-      Ok(Map::new())
-    } else {
-      Err(RuntimeError::Dotenv{dotenv_error})
+    Err(dotenv_error) => {
+      if dotenv_error.not_found() {
+        Ok(Map::new())
+      } else {
+        Err(RuntimeError::Dotenv { dotenv_error })
+      }
     }
   }
 }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -3,7 +3,14 @@ use common::*;
 use unicode_width::UnicodeWidthChar;
 
 pub fn show_whitespace(text: &str) -> String {
-  text.chars().map(|c| match c { '\t' => '␉', ' ' => '␠', _ => c }).collect()
+  text
+    .chars()
+    .map(|c| match c {
+      '\t' => '␉',
+      ' ' => '␠',
+      _ => c,
+    })
+    .collect()
 }
 
 pub fn default<T: Default>() -> T {
@@ -27,15 +34,16 @@ pub fn maybe_s(n: usize) -> &'static str {
 }
 
 pub fn conjoin<T: Display>(
-  f:           &mut fmt::Formatter,
-  values:      &[T],
+  f: &mut fmt::Formatter,
+  values: &[T],
   conjunction: &str,
 ) -> Result<(), fmt::Error> {
-    match values.len() {
-      0 => {},
-      1 => write!(f, "{}", values[0])?,
-      2 => write!(f, "{} {} {}", values[0], conjunction, values[1])?,
-      _ => for (i, item) in values.iter().enumerate() {
+  match values.len() {
+    0 => {}
+    1 => write!(f, "{}", values[0])?,
+    2 => write!(f, "{} {} {}", values[0], conjunction, values[1])?,
+    _ => {
+      for (i, item) in values.iter().enumerate() {
         write!(f, "{}", item)?;
         if i == values.len() - 1 {
         } else if i == values.len() - 2 {
@@ -43,18 +51,19 @@ pub fn conjoin<T: Display>(
         } else {
           write!(f, ", ")?
         }
-      },
+      }
     }
-    Ok(())
+  }
+  Ok(())
 }
 
 pub fn write_error_context(
-  f:      &mut fmt::Formatter,
-  text:   &str,
-  index:  usize,
-  line:   usize,
+  f: &mut fmt::Formatter,
+  text: &str,
+  index: usize,
+  line: usize,
   column: usize,
-  width:  Option<usize>,
+  width: Option<usize>,
 ) -> Result<(), fmt::Error> {
   let line_number = line + 1;
   let red = Color::fmt(f).error();
@@ -62,8 +71,8 @@ pub fn write_error_context(
     Some(line) => {
       let mut i = 0;
       let mut space_column = 0;
-      let mut space_line   = String::new();
-      let mut space_width  = 0;
+      let mut space_line = String::new();
+      let mut space_width = 0;
       for c in line.chars() {
         if c == '\t' {
           space_line.push_str("    ");
@@ -76,7 +85,6 @@ pub fn write_error_context(
         } else {
           if i < column {
             space_column += UnicodeWidthChar::width(c).unwrap_or(0);
-
           }
           if i >= column && i < column + width.unwrap_or(1) {
             space_width += UnicodeWidthChar::width(c).unwrap_or(0);
@@ -90,15 +98,36 @@ pub fn write_error_context(
       writeln!(f, "{} | {}", line_number, space_line)?;
       write!(f, "{0:1$} |", "", line_number_width)?;
       if width == None {
-        write!(f, " {0:1$}{2}^{3}", "", space_column, red.prefix(), red.suffix())?;
+        write!(
+          f,
+          " {0:1$}{2}^{3}",
+          "",
+          space_column,
+          red.prefix(),
+          red.suffix()
+        )?;
       } else {
-        write!(f, " {0:1$}{2}{3:^<4$}{5}", "", space_column,
-                  red.prefix(), "", space_width, red.suffix())?;
+        write!(
+          f,
+          " {0:1$}{2}{3:^<4$}{5}",
+          "",
+          space_column,
+          red.prefix(),
+          "",
+          space_width,
+          red.suffix()
+        )?;
       }
-    },
-    None => if index != text.len() {
-      write!(f, "internal error: Error has invalid line number: {}", line_number)?
-    },
+    }
+    None => {
+      if index != text.len() {
+        write!(
+          f,
+          "internal error: Error has invalid line number: {}",
+          line_number
+        )?
+      }
+    }
   }
   Ok(())
 }
@@ -111,7 +140,7 @@ impl<'a, T: Display> Display for And<'a, T> {
   }
 }
 
-pub struct Or <'a, T: 'a + Display>(pub &'a [T]);
+pub struct Or<'a, T: 'a + Display>(pub &'a [T]);
 
 impl<'a, T: Display> Display for Or<'a, T> {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -133,17 +162,17 @@ mod test {
 
   #[test]
   fn conjoin_or() {
-    assert_eq!("1",             Or(&[1      ]).to_string());
-    assert_eq!("1 or 2",        Or(&[1,2    ]).to_string());
-    assert_eq!("1, 2, or 3",    Or(&[1,2,3  ]).to_string());
-    assert_eq!("1, 2, 3, or 4", Or(&[1,2,3,4]).to_string());
+    assert_eq!("1", Or(&[1]).to_string());
+    assert_eq!("1 or 2", Or(&[1, 2]).to_string());
+    assert_eq!("1, 2, or 3", Or(&[1, 2, 3]).to_string());
+    assert_eq!("1, 2, 3, or 4", Or(&[1, 2, 3, 4]).to_string());
   }
 
   #[test]
   fn conjoin_and() {
-    assert_eq!("1",              And(&[1      ]).to_string());
-    assert_eq!("1 and 2",        And(&[1,2    ]).to_string());
-    assert_eq!("1, 2, and 3",    And(&[1,2,3  ]).to_string());
-    assert_eq!("1, 2, 3, and 4", And(&[1,2,3,4]).to_string());
+    assert_eq!("1", And(&[1]).to_string());
+    assert_eq!("1 and 2", And(&[1, 2]).to_string());
+    assert_eq!("1, 2, and 3", And(&[1, 2, 3]).to_string());
+    assert_eq!("1, 2, 3, and 4", And(&[1, 2, 3, 4]).to_string());
   }
 }

--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -2,9 +2,9 @@ use common::*;
 
 #[derive(PartialEq, Debug)]
 pub struct Parameter<'a> {
-  pub default:  Option<String>,
-  pub name:     &'a str,
-  pub token:    Token<'a>,
+  pub default: Option<String>,
+  pub name: &'a str,
+  pub token: Token<'a>,
   pub variadic: bool,
 }
 
@@ -16,7 +16,10 @@ impl<'a> Display for Parameter<'a> {
     }
     write!(f, "{}", color.parameter().paint(self.name))?;
     if let Some(ref default) = self.default {
-      let escaped = default.chars().flat_map(char::escape_default).collect::<String>();;
+      let escaped = default
+        .chars()
+        .flat_map(char::escape_default)
+        .collect::<String>();;
       write!(f, r#"='{}'"#, color.string().paint(&escaped))?;
     }
     Ok(())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,16 +1,16 @@
 use common::*;
 
 use itertools;
-use TokenKind::*;
 use CompilationErrorKind::*;
+use TokenKind::*;
 
 pub struct Parser<'a> {
-  text:              &'a str,
-  tokens:            itertools::PutBackN<vec::IntoIter<Token<'a>>>,
-  recipes:           Map<&'a str, Recipe<'a>>,
-  assignments:       Map<&'a str, Expression<'a>>,
+  text: &'a str,
+  tokens: itertools::PutBackN<vec::IntoIter<Token<'a>>>,
+  recipes: Map<&'a str, Recipe<'a>>,
+  assignments: Map<&'a str, Expression<'a>>,
   assignment_tokens: Map<&'a str, Token<'a>>,
-  exports:           Set<&'a str>,
+  exports: Set<&'a str>,
 }
 
 impl<'a> Parser<'a> {
@@ -22,11 +22,11 @@ impl<'a> Parser<'a> {
 
   pub fn new(text: &'a str, tokens: Vec<Token<'a>>) -> Parser<'a> {
     Parser {
-      tokens:            itertools::put_back_n(tokens),
-      recipes:           empty(),
-      assignments:       empty(),
+      tokens: itertools::put_back_n(tokens),
+      recipes: empty(),
+      assignments: empty(),
       assignment_tokens: empty(),
-      exports:           empty(),
+      exports: empty(),
       text,
     }
   }
@@ -83,20 +83,20 @@ impl<'a> Parser<'a> {
   fn unexpected_token(&self, found: &Token<'a>, expected: &[TokenKind]) -> CompilationError<'a> {
     found.error(UnexpectedToken {
       expected: expected.to_vec(),
-      found:    found.kind,
+      found: found.kind,
     })
   }
 
   fn recipe(
     &mut self,
-    name:  &Token<'a>,
-    doc:   Option<Token<'a>>,
+    name: &Token<'a>,
+    doc: Option<Token<'a>>,
     quiet: bool,
   ) -> CompilationResult<'a, ()> {
     if let Some(recipe) = self.recipes.get(name.lexeme) {
       return Err(name.error(DuplicateRecipe {
         recipe: recipe.name,
-        first:  recipe.line_number
+        first: recipe.line_number,
       }));
     }
 
@@ -108,11 +108,13 @@ impl<'a> Parser<'a> {
 
       let parameter = match self.accept(Name) {
         Some(parameter) => parameter,
-        None            => if let Some(plus) = plus {
-          return Err(self.unexpected_token(&plus, &[Name]));
-        } else {
-          break
-        },
+        None => {
+          if let Some(plus) = plus {
+            return Err(self.unexpected_token(&plus, &[Name]));
+          } else {
+            break;
+          }
+        }
       };
 
       let variadic = plus.is_some();
@@ -125,7 +127,8 @@ impl<'a> Parser<'a> {
 
       if parameters.iter().any(|p| p.name == parameter.lexeme) {
         return Err(parameter.error(DuplicateParameter {
-          recipe: name.lexeme, parameter: parameter.lexeme
+          recipe: name.lexeme,
+          parameter: parameter.lexeme,
         }));
       }
 
@@ -142,7 +145,7 @@ impl<'a> Parser<'a> {
       }
 
       if parsed_parameter_with_default && default.is_none() {
-        return Err(parameter.error(RequiredParameterFollowsDefaultParameter{
+        return Err(parameter.error(RequiredParameterFollowsDefaultParameter {
           parameter: parameter.lexeme,
         }));
       }
@@ -151,8 +154,8 @@ impl<'a> Parser<'a> {
       parsed_variadic_parameter = variadic;
 
       parameters.push(Parameter {
-        name:     parameter.lexeme,
-        token:    parameter,
+        name: parameter.lexeme,
+        token: parameter,
         default,
         variadic,
       });
@@ -173,8 +176,8 @@ impl<'a> Parser<'a> {
     while let Some(dependency) = self.accept(Name) {
       if dependencies.contains(&dependency.lexeme) {
         return Err(dependency.error(DuplicateDependency {
-          recipe:     name.lexeme,
-          dependency: dependency.lexeme
+          recipe: name.lexeme,
+          dependency: dependency.lexeme,
         }));
       }
       dependencies.push(dependency.lexeme);
@@ -195,9 +198,9 @@ impl<'a> Parser<'a> {
           continue;
         }
         if let Some(token) = self.expect(Line) {
-          return Err(token.error(Internal{
-            message: format!("Expected a line but got {}", token.kind)
-          }))
+          return Err(token.error(Internal {
+            message: format!("Expected a line but got {}", token.kind),
+          }));
         }
         let mut fragments = vec![];
 
@@ -209,18 +212,22 @@ impl<'a> Parser<'a> {
                   shebang = true;
                 }
               } else if !shebang
-                && !lines.last().and_then(|line| line.last())
-                  .map(Fragment::continuation).unwrap_or(false)
-                && (token.lexeme.starts_with(' ') || token.lexeme.starts_with('\t')) {
+                && !lines
+                  .last()
+                  .and_then(|line| line.last())
+                  .map(Fragment::continuation)
+                  .unwrap_or(false)
+                && (token.lexeme.starts_with(' ') || token.lexeme.starts_with('\t'))
+              {
                 return Err(token.error(ExtraLeadingWhitespace));
               }
             }
-            fragments.push(Fragment::Text{text: token});
+            fragments.push(Fragment::Text { text: token });
           } else if let Some(token) = self.expect(InterpolationStart) {
             return Err(self.unexpected_token(&token, &[Text, InterpolationStart, Eol]));
           } else {
-            fragments.push(Fragment::Expression{
-              expression: self.expression()?
+            fragments.push(Fragment::Expression {
+              expression: self.expression()?,
             });
 
             if let Some(token) = self.expect(InterpolationEnd) {
@@ -233,18 +240,21 @@ impl<'a> Parser<'a> {
       }
     }
 
-    self.recipes.insert(name.lexeme, Recipe {
-      line_number:       name.line,
-      name:              name.lexeme,
-      doc:               doc.map(|t| t.lexeme[1..].trim()),
-      private:           &name.lexeme[0..1] == "_",
-      dependencies,
-      dependency_tokens,
-      lines,
-      parameters,
-      quiet,
-      shebang,
-    });
+    self.recipes.insert(
+      name.lexeme,
+      Recipe {
+        line_number: name.line,
+        name: name.lexeme,
+        doc: doc.map(|t| t.lexeme[1..].trim()),
+        private: &name.lexeme[0..1] == "_",
+        dependencies,
+        dependency_tokens,
+        lines,
+        parameters,
+        quiet,
+        shebang,
+      },
+    );
 
     Ok(())
   }
@@ -261,24 +271,34 @@ impl<'a> Parser<'a> {
           if let Some(token) = self.expect(ParenR) {
             return Err(self.unexpected_token(&token, &[Name, StringToken, ParenR]));
           }
-          Expression::Call {name: first.lexeme, token: first, arguments}
+          Expression::Call {
+            name: first.lexeme,
+            token: first,
+            arguments,
+          }
         } else {
-          Expression::Variable {name: first.lexeme, token: first}
+          Expression::Variable {
+            name: first.lexeme,
+            token: first,
+          }
         }
       }
       Backtick => Expression::Backtick {
-        raw:   &first.lexeme[1..first.lexeme.len()-1],
-        token: first
+        raw: &first.lexeme[1..first.lexeme.len() - 1],
+        token: first,
       },
-      RawString | StringToken => {
-        Expression::String{cooked_string: CookedString::new(&first)?}
-      }
+      RawString | StringToken => Expression::String {
+        cooked_string: CookedString::new(&first)?,
+      },
       _ => return Err(self.unexpected_token(&first, &[Name, StringToken])),
     };
 
     if self.accepted(Plus) {
       let rhs = self.expression()?;
-      Ok(Expression::Concatination{lhs: Box::new(lhs), rhs: Box::new(rhs)})
+      Ok(Expression::Concatination {
+        lhs: Box::new(lhs),
+        rhs: Box::new(rhs),
+      })
     } else {
       Ok(lhs)
     }
@@ -304,7 +324,9 @@ impl<'a> Parser<'a> {
 
   fn assignment(&mut self, name: Token<'a>, export: bool) -> CompilationResult<'a, ()> {
     if self.assignments.contains_key(name.lexeme) {
-      return Err(name.error(DuplicateVariable {variable: name.lexeme}));
+      return Err(name.error(DuplicateVariable {
+        variable: name.lexeme,
+      }));
     }
     if export {
       self.exports.insert(name.lexeme);
@@ -338,49 +360,58 @@ impl<'a> Parser<'a> {
             }
             doc = Some(token);
           }
-          At => if let Some(name) = self.accept(Name) {
-            self.recipe(&name, doc, true)?;
-            doc = None;
-          } else {
-            let unexpected = &self.tokens.next().unwrap();
-            return Err(self.unexpected_token(unexpected, &[Name]));
-          },
-          Name => if token.lexeme == "export" {
-            let next = self.tokens.next().unwrap();
-            if next.kind == Name && self.accepted(Equals) {
-              self.assignment(next, true)?;
+          At => {
+            if let Some(name) = self.accept(Name) {
+              self.recipe(&name, doc, true)?;
               doc = None;
             } else {
-              self.tokens.put_back(next);
+              let unexpected = &self.tokens.next().unwrap();
+              return Err(self.unexpected_token(unexpected, &[Name]));
+            }
+          }
+          Name => {
+            if token.lexeme == "export" {
+              let next = self.tokens.next().unwrap();
+              if next.kind == Name && self.accepted(Equals) {
+                self.assignment(next, true)?;
+                doc = None;
+              } else {
+                self.tokens.put_back(next);
+                self.recipe(&token, doc, false)?;
+                doc = None;
+              }
+            } else if self.accepted(Equals) {
+              self.assignment(token, false)?;
+              doc = None;
+            } else {
               self.recipe(&token, doc, false)?;
               doc = None;
             }
-          } else if self.accepted(Equals) {
-            self.assignment(token, false)?;
-            doc = None;
-          } else {
-            self.recipe(&token, doc, false)?;
-            doc = None;
-          },
+          }
           _ => return Err(self.unexpected_token(&token, &[Name, At])),
         },
-        None => return Err(CompilationError {
-          text:   self.text,
-          index:  0,
-          line:   0,
-          column: 0,
-          width:  None,
-          kind:   Internal {
-            message: "unexpected end of token stream".to_string()
-          }
-        }),
+        None => {
+          return Err(CompilationError {
+            text: self.text,
+            index: 0,
+            line: 0,
+            column: 0,
+            width: None,
+            kind: Internal {
+              message: "unexpected end of token stream".to_string(),
+            },
+          })
+        }
       }
     }
 
     if let Some(token) = self.tokens.next() {
       return Err(token.error(Internal {
-        message: format!("unexpected token remaining after parsing completed: {:?}", token.kind)
-      }))
+        message: format!(
+          "unexpected token remaining after parsing completed: {:?}",
+          token.kind
+        ),
+      }));
     }
 
     RecipeResolver::resolve_recipes(&self.recipes, &self.assignments, self.text)?;
@@ -389,7 +420,7 @@ impl<'a> Parser<'a> {
       for parameter in &recipe.parameters {
         if self.assignments.contains_key(parameter.token.lexeme) {
           return Err(parameter.token.error(ParameterShadowsVariable {
-            parameter: parameter.token.lexeme
+            parameter: parameter.token.lexeme,
           }));
         }
       }
@@ -407,9 +438,9 @@ impl<'a> Parser<'a> {
     AssignmentResolver::resolve_assignments(&self.assignments, &self.assignment_tokens)?;
 
     Ok(Justfile {
-      recipes:     self.recipes,
+      recipes: self.recipes,
       assignments: self.assignments,
-      exports:     self.exports,
+      exports: self.exports,
     })
   }
 }
@@ -434,7 +465,7 @@ mod test {
           assert_eq!(actual, expected);
         }
       }
-    }
+    };
   }
 
   summary_test! {
@@ -502,7 +533,7 @@ export a = "hello"
   }
 
   summary_test! {
-    parse_complex,
+  parse_complex,
     "
 x:
 y:
@@ -540,7 +571,7 @@ z:"
   }
 
   summary_test! {
-    parse_shebang,
+  parse_shebang,
     "
 practicum = 'hello'
 install:
@@ -565,7 +596,7 @@ install:
   }
 
   summary_test! {
-    parse_assignments,
+  parse_assignments,
     r#"a = "0"
 c = a + b + a + b
 b = "1"
@@ -578,7 +609,7 @@ c = a + b + a + b"#,
   }
 
   summary_test! {
-    parse_assignment_backticks,
+  parse_assignment_backticks,
     "a = `echo hello`
 c = a + b + a + b
 b = `echo goodbye`",
@@ -590,7 +621,7 @@ c = a + b + a + b",
   }
 
   summary_test! {
-    parse_interpolation_backticks,
+  parse_interpolation_backticks,
     r#"a:
  echo {{  `echo hello` + "blarg"   }} {{   `echo bob`   }}"#,
     r#"a:
@@ -616,7 +647,7 @@ c = a + b + a + b",
   }
 
   summary_test! {
-    parameters,
+  parameters,
     "a b c:
   {{b}} {{c}}",
     "a b c:
@@ -624,7 +655,7 @@ c = a + b + a + b",
   }
 
   summary_test! {
-    unary_functions,
+  unary_functions,
     "
 x = arch()
 
@@ -637,7 +668,7 @@ a:
   }
 
   summary_test! {
-    env_functions,
+  env_functions,
     r#"
 x = env_var('foo',)
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -7,8 +7,11 @@ pub struct Platform;
 pub trait PlatformInterface {
   /// Construct a command equivelant to running the script at `path` with the
   /// shebang line `shebang`
-  fn make_shebang_command(path: &Path, command: &str, argument: Option<&str>)
-    -> Result<Command, brev::OutputError>;
+  fn make_shebang_command(
+    path: &Path,
+    command: &str,
+    argument: Option<&str>,
+  ) -> Result<Command, brev::OutputError>;
 
   /// Set the execute permission on the file pointed to by `path`
   fn set_execute_permission(path: &Path) -> Result<(), io::Error>;
@@ -20,12 +23,13 @@ pub trait PlatformInterface {
   fn to_shell_path(path: &Path) -> Result<String, String>;
 }
 
-
 #[cfg(unix)]
 impl PlatformInterface for Platform {
-  fn make_shebang_command(path: &Path, _command: &str, _argument: Option<&str>)
-    -> Result<Command, brev::OutputError>
-  {
+  fn make_shebang_command(
+    path: &Path,
+    _command: &str,
+    _argument: Option<&str>,
+  ) -> Result<Command, brev::OutputError> {
     // shebang scripts can be executed directly on unix
     Ok(Command::new(path))
   }
@@ -50,17 +54,20 @@ impl PlatformInterface for Platform {
   }
 
   fn to_shell_path(path: &Path) -> Result<String, String> {
-    path.to_str().map(str::to_string)
-      .ok_or_else(|| String::from(
-        "Error getting current directory: unicode decode error"))
+    path
+      .to_str()
+      .map(str::to_string)
+      .ok_or_else(|| String::from("Error getting current directory: unicode decode error"))
   }
 }
 
 #[cfg(windows)]
 impl PlatformInterface for Platform {
-  fn make_shebang_command(path: &Path, command: &str, argument: Option<&str>)
-    -> Result<Command, brev::OutputError>
-  {
+  fn make_shebang_command(
+    path: &Path,
+    command: &str,
+    argument: Option<&str>,
+  ) -> Result<Command, brev::OutputError> {
     // Translate path to the interpreter from unix style to windows style
     let mut cygpath = Command::new("cygpath");
     cygpath.arg("--windows");

--- a/src/range_ext.rs
+++ b/src/range_ext.rs
@@ -4,8 +4,11 @@ pub trait RangeExt<T> {
   fn range_contains(&self, i: T) -> bool;
 }
 
-impl<T> RangeExt<T> for Range<T> where T: PartialOrd + Copy {
-  fn range_contains(&self,  i: T) -> bool {
+impl<T> RangeExt<T> for Range<T>
+where
+  T: PartialOrd + Copy,
+{
+  fn range_contains(&self, i: T) -> bool {
     i >= self.start && i < self.end
   }
 }
@@ -16,10 +19,10 @@ mod test {
 
   #[test]
   fn range() {
-    assert!( ( 0.. 1).range_contains( 0));
-    assert!( (10..20).range_contains(15));
-    assert!(!( 0.. 0).range_contains( 0));
-    assert!(!( 1..10).range_contains( 0));
-    assert!(!( 1..10).range_contains(10));
+    assert!((0..1).range_contains(0));
+    assert!((10..20).range_contains(15));
+    assert!(!(0..0).range_contains(0));
+    assert!(!(1..10).range_contains(0));
+    assert!(!(1..10).range_contains(10));
   }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,23 +1,21 @@
 use common::*;
 
-use std::{convert, ffi};
-use clap::{App, Arg, ArgGroup, AppSettings};
+use clap::{App, AppSettings, Arg, ArgGroup};
 use configuration::DEFAULT_SHELL;
-use misc::maybe_s;
-use unicode_width::UnicodeWidthStr;
 use env_logger;
 use interrupt_handler::InterruptHandler;
+use misc::maybe_s;
+use std::{convert, ffi};
+use unicode_width::UnicodeWidthStr;
 
 #[cfg(windows)]
 use ansi_term::enable_ansi_support;
 
 fn edit<P: convert::AsRef<ffi::OsStr>>(path: P) -> ! {
-  let editor = env::var_os("EDITOR")
-    .unwrap_or_else(|| die!("Error getting EDITOR environment variable"));
+  let editor =
+    env::var_os("EDITOR").unwrap_or_else(|| die!("Error getting EDITOR environment variable"));
 
-  let error = Command::new(editor)
-    .arg(path)
-    .status();
+  let error = Command::new(editor).arg(path).status();
 
   match error {
     Ok(status) => process::exit(status.code().unwrap_or(EXIT_FAILURE)),
@@ -42,102 +40,151 @@ pub fn run() {
   enable_ansi_support().ok();
 
   env_logger::Builder::from_env(
-    env_logger::Env::new().filter("JUST_LOG").write_style("JUST_LOG_STYLE")
-  ).init();
+    env_logger::Env::new()
+      .filter("JUST_LOG")
+      .write_style("JUST_LOG_STYLE"),
+  )
+  .init();
 
-  let invocation_directory = env::current_dir()
-    .map_err(|e| format!("Error getting current directory: {}", e));
+  let invocation_directory =
+    env::current_dir().map_err(|e| format!("Error getting current directory: {}", e));
 
   let matches = App::new(env!("CARGO_PKG_NAME"))
     .version(concat!("v", env!("CARGO_PKG_VERSION")))
     .author(env!("CARGO_PKG_AUTHORS"))
-    .about(concat!(env!("CARGO_PKG_DESCRIPTION"), " - ", env!("CARGO_PKG_HOMEPAGE")))
+    .about(concat!(
+      env!("CARGO_PKG_DESCRIPTION"),
+      " - ",
+      env!("CARGO_PKG_HOMEPAGE")
+    ))
     .help_message("Print help information")
     .version_message("Print version information")
     .setting(AppSettings::ColoredHelp)
     .setting(AppSettings::TrailingVarArg)
-    .arg(Arg::with_name("ARGUMENTS")
-         .multiple(true)
-         .help("The recipe(s) to run, defaults to the first recipe in the justfile"))
-    .arg(Arg::with_name("COLOR")
-         .long("color")
-         .takes_value(true)
-         .possible_values(&["auto", "always", "never"])
-         .default_value("auto")
-         .help("Print colorful output"))
-    .arg(Arg::with_name("DRY-RUN")
-         .long("dry-run")
-         .help("Print what just would do without doing it")
-         .conflicts_with("QUIET"))
-    .arg(Arg::with_name("DUMP")
-         .long("dump")
-         .help("Print entire justfile"))
-    .arg(Arg::with_name("EDIT")
-         .short("e")
-         .long("edit")
-         .help("Open justfile with $EDITOR"))
-    .arg(Arg::with_name("EVALUATE")
-         .long("evaluate")
-         .help("Print evaluated variables"))
-    .arg(Arg::with_name("HIGHLIGHT")
-         .long("highlight")
-         .help("Highlight echoed recipe lines in bold"))
-    .arg(Arg::with_name("JUSTFILE")
-         .short("f")
-         .long("justfile")
-         .takes_value(true)
-         .help("Use <JUSTFILE> as justfile. --working-directory must also be set")
-         .requires("WORKING-DIRECTORY"))
-    .arg(Arg::with_name("LIST")
-         .short("l")
-         .long("list")
-         .help("List available recipes and their arguments"))
-    .arg(Arg::with_name("QUIET")
-         .short("q")
-         .long("quiet")
-         .help("Suppress all output")
-         .conflicts_with("DRY-RUN"))
-    .arg(Arg::with_name("SET")
-         .long("set")
-         .takes_value(true)
-         .number_of_values(2)
-         .value_names(&["VARIABLE", "VALUE"])
-         .multiple(true)
-         .help("Set <VARIABLE> to <VALUE>"))
-    .arg(Arg::with_name("SHELL")
-         .long("shell")
-         .takes_value(true)
-         .default_value(DEFAULT_SHELL)
-         .help("Invoke <SHELL> to run recipes"))
-    .arg(Arg::with_name("SHOW")
-         .short("s")
-         .long("show")
-         .takes_value(true)
-         .value_name("RECIPE")
-         .help("Show information about <RECIPE>"))
-    .arg(Arg::with_name("SUMMARY")
-         .long("summary")
-         .help("List names of available recipes"))
-    .arg(Arg::with_name("VERBOSE")
-         .short("v")
-         .long("verbose")
-         .multiple(true)
-         .help("Use verbose output"))
-    .arg(Arg::with_name("WORKING-DIRECTORY")
+    .arg(
+      Arg::with_name("ARGUMENTS")
+        .multiple(true)
+        .help("The recipe(s) to run, defaults to the first recipe in the justfile"),
+    )
+    .arg(
+      Arg::with_name("COLOR")
+        .long("color")
+        .takes_value(true)
+        .possible_values(&["auto", "always", "never"])
+        .default_value("auto")
+        .help("Print colorful output"),
+    )
+    .arg(
+      Arg::with_name("DRY-RUN")
+        .long("dry-run")
+        .help("Print what just would do without doing it")
+        .conflicts_with("QUIET"),
+    )
+    .arg(
+      Arg::with_name("DUMP")
+        .long("dump")
+        .help("Print entire justfile"),
+    )
+    .arg(
+      Arg::with_name("EDIT")
+        .short("e")
+        .long("edit")
+        .help("Open justfile with $EDITOR"),
+    )
+    .arg(
+      Arg::with_name("EVALUATE")
+        .long("evaluate")
+        .help("Print evaluated variables"),
+    )
+    .arg(
+      Arg::with_name("HIGHLIGHT")
+        .long("highlight")
+        .help("Highlight echoed recipe lines in bold"),
+    )
+    .arg(
+      Arg::with_name("JUSTFILE")
+        .short("f")
+        .long("justfile")
+        .takes_value(true)
+        .help("Use <JUSTFILE> as justfile. --working-directory must also be set")
+        .requires("WORKING-DIRECTORY"),
+    )
+    .arg(
+      Arg::with_name("LIST")
+        .short("l")
+        .long("list")
+        .help("List available recipes and their arguments"),
+    )
+    .arg(
+      Arg::with_name("QUIET")
+        .short("q")
+        .long("quiet")
+        .help("Suppress all output")
+        .conflicts_with("DRY-RUN"),
+    )
+    .arg(
+      Arg::with_name("SET")
+        .long("set")
+        .takes_value(true)
+        .number_of_values(2)
+        .value_names(&["VARIABLE", "VALUE"])
+        .multiple(true)
+        .help("Set <VARIABLE> to <VALUE>"),
+    )
+    .arg(
+      Arg::with_name("SHELL")
+        .long("shell")
+        .takes_value(true)
+        .default_value(DEFAULT_SHELL)
+        .help("Invoke <SHELL> to run recipes"),
+    )
+    .arg(
+      Arg::with_name("SHOW")
+        .short("s")
+        .long("show")
+        .takes_value(true)
+        .value_name("RECIPE")
+        .help("Show information about <RECIPE>"),
+    )
+    .arg(
+      Arg::with_name("SUMMARY")
+        .long("summary")
+        .help("List names of available recipes"),
+    )
+    .arg(
+      Arg::with_name("VERBOSE")
+        .short("v")
+        .long("verbose")
+        .multiple(true)
+        .help("Use verbose output"),
+    )
+    .arg(
+      Arg::with_name("WORKING-DIRECTORY")
         .short("d")
         .long("working-directory")
         .takes_value(true)
         .help("Use <WORKING-DIRECTORY> as working directory. --justfile must also be set")
-        .requires("JUSTFILE"))
-    .group(ArgGroup::with_name("EARLY-EXIT")
-         .args(&["DUMP", "EDIT", "LIST", "SHOW", "SUMMARY", "ARGUMENTS", "EVALUATE"]))
+        .requires("JUSTFILE"),
+    )
+    .group(ArgGroup::with_name("EARLY-EXIT").args(&[
+      "DUMP",
+      "EDIT",
+      "LIST",
+      "SHOW",
+      "SUMMARY",
+      "ARGUMENTS",
+      "EVALUATE",
+    ]))
     .get_matches();
 
   let color = match matches.value_of("COLOR").expect("`--color` had no value") {
-    "auto"   => Color::auto(),
+    "auto" => Color::auto(),
     "always" => Color::always(),
-    "never"  => Color::never(),
-    other    => die!("Invalid argument `{}` to --color. This is a bug in just.", other),
+    "never" => Color::never(),
+    other => die!(
+      "Invalid argument `{}` to --color. This is a bug in just.",
+      other
+    ),
   };
 
   let set_count = matches.occurrences_of("SET");
@@ -151,15 +198,25 @@ pub fn run() {
 
   let override_re = Regex::new("^([^=]+)=(.*)$").unwrap();
 
-  let raw_arguments = matches.values_of("ARGUMENTS").map(|values| values.collect::<Vec<_>>())
+  let raw_arguments = matches
+    .values_of("ARGUMENTS")
+    .map(|values| values.collect::<Vec<_>>())
     .unwrap_or_default();
 
-  for argument in raw_arguments.iter().take_while(|arg| override_re.is_match(arg)) {
+  for argument in raw_arguments
+    .iter()
+    .take_while(|arg| override_re.is_match(arg))
+  {
     let captures = override_re.captures(argument).unwrap();
-    overrides.insert(captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str());
+    overrides.insert(
+      captures.get(1).unwrap().as_str(),
+      captures.get(2).unwrap().as_str(),
+    );
   }
 
-  let rest = raw_arguments.iter().skip_while(|arg| override_re.is_match(arg))
+  let rest = raw_arguments
+    .iter()
+    .skip_while(|arg| override_re.is_match(arg))
     .enumerate()
     .flat_map(|(i, argument)| {
       if i == 0 {
@@ -208,10 +265,12 @@ pub fn run() {
     'outer: loop {
       for candidate in &["justfile", "Justfile"] {
         match fs::metadata(candidate) {
-          Ok(metadata) => if metadata.is_file() {
-            name = *candidate;
-            break 'outer;
-          },
+          Ok(metadata) => {
+            if metadata.is_file() {
+              name = *candidate;
+              break 'outer;
+            }
+          }
           Err(error) => {
             if error.kind() != io::ErrorKind::NotFound {
               die!("Error fetching justfile metadata: {}", error)
@@ -221,7 +280,11 @@ pub fn run() {
       }
 
       match env::current_dir() {
-        Ok(pathbuf) => if pathbuf.as_os_str() == "/" { die!("No justfile found."); },
+        Ok(pathbuf) => {
+          if pathbuf.as_os_str() == "/" {
+            die!("No justfile found.");
+          }
+        }
         Err(error) => die!("Error getting current dir: {}", error),
       }
 
@@ -240,19 +303,21 @@ pub fn run() {
       .unwrap_or_else(|error| die!("Error reading justfile: {}", error));
   }
 
-  let justfile = Parser::parse(&text).unwrap_or_else(|error|
+  let justfile = Parser::parse(&text).unwrap_or_else(|error| {
     if color.stderr().active() {
       die!("{:#}", error);
     } else {
       die!("{}", error);
     }
-  );
+  });
 
   if matches.is_present("SUMMARY") {
     if justfile.count() == 0 {
       eprintln!("Justfile contains no recipes.");
     } else {
-      let summary = justfile.recipes.iter()
+      let summary = justfile
+        .recipes
+        .iter()
         .filter(|&(_, recipe)| !recipe.private)
         .map(|(name, _)| name)
         .cloned()
@@ -305,10 +370,12 @@ pub fn run() {
       }
       if let Some(doc) = recipe.doc {
         print!(
-          " {:padding$}{} {}", "", doc_color.paint("#"), doc_color.paint(doc),
-          padding = max_line_width.saturating_sub(
-            line_widths.get(name).cloned().unwrap_or(max_line_width)
-          )
+          " {:padding$}{} {}",
+          "",
+          doc_color.paint("#"),
+          doc_color.paint(doc),
+          padding =
+            max_line_width.saturating_sub(line_widths.get(name).cloned().unwrap_or(max_line_width))
         );
       }
       println!();
@@ -337,8 +404,12 @@ pub fn run() {
   } else if let Some(recipe) = justfile.first() {
     let min_arguments = recipe.min_arguments();
     if min_arguments > 0 {
-      die!("Recipe `{}` cannot be used as default recipe since it requires at least {} argument{}.",
-           recipe.name, min_arguments, maybe_s(min_arguments));
+      die!(
+        "Recipe `{}` cannot be used as default recipe since it requires at least {} argument{}.",
+        recipe.name,
+        min_arguments,
+        maybe_s(min_arguments)
+      );
     }
     vec![recipe.name]
   } else {
@@ -348,11 +419,11 @@ pub fn run() {
   let verbosity = Verbosity::from_flag_occurrences(matches.occurrences_of("VERBOSE"));
 
   let configuration = Configuration {
-    dry_run:   matches.is_present("DRY-RUN"),
-    evaluate:  matches.is_present("EVALUATE"),
+    dry_run: matches.is_present("DRY-RUN"),
+    evaluate: matches.is_present("EVALUATE"),
     highlight: matches.is_present("HIGHLIGHT"),
-    quiet:     matches.is_present("QUIET"),
-    shell:     matches.value_of("SHELL").unwrap(),
+    quiet: matches.is_present("QUIET"),
+    shell: matches.value_of("SHELL").unwrap(),
     verbosity,
     color,
     overrides,
@@ -362,11 +433,7 @@ pub fn run() {
     warn!("Failed to set CTRL-C handler: {}", error)
   }
 
-  if let Err(run_error) = justfile.run(
-    &invocation_directory,
-    &arguments,
-    &configuration)
-  {
+  if let Err(run_error) = justfile.run(&invocation_directory, &arguments, &configuration) {
     if !configuration.quiet {
       if color.stderr().active() {
         eprintln!("{:#}", run_error);

--- a/src/runtime_error.rs
+++ b/src/runtime_error.rs
@@ -4,7 +4,7 @@ use dotenv;
 
 use brev::OutputError;
 
-use misc::{And, Or, maybe_s, Tick, ticks, write_error_context};
+use misc::{maybe_s, ticks, write_error_context, And, Or, Tick};
 
 use self::RuntimeError::*;
 
@@ -17,38 +17,82 @@ fn write_token_error_context(f: &mut fmt::Formatter, token: &Token) -> Result<()
     token.index,
     token.line,
     token.column + token.prefix.len(),
-    Some(token.lexeme.len())
+    Some(token.lexeme.len()),
   )
 }
 
 #[derive(Debug)]
 pub enum RuntimeError<'a> {
-  ArgumentCountMismatch{
+  ArgumentCountMismatch {
     recipe: &'a str,
     parameters: Vec<&'a Parameter<'a>>,
     found: usize,
     min: usize,
     max: usize,
   },
-  Backtick{token: Token<'a>, output_error: OutputError},
-  Code{recipe: &'a str, line_number: Option<usize>, code: i32},
-  Cygpath{recipe: &'a str, output_error: OutputError},
-  Dotenv{dotenv_error: dotenv::Error},
-  FunctionCall{token: Token<'a>, message: String},
-  Internal{message: String},
-  IoError{recipe: &'a str, io_error: io::Error},
-  Shebang{recipe: &'a str, command: String, argument: Option<String>, io_error: io::Error},
-  Signal{recipe: &'a str, line_number: Option<usize>, signal: i32},
-  TmpdirIoError{recipe: &'a str, io_error: io::Error},
-  UnknownOverrides{overrides: Vec<&'a str>},
-  UnknownRecipes{recipes: Vec<&'a str>, suggestion: Option<&'a str>},
-  Unknown{recipe: &'a str, line_number: Option<usize>},
+  Backtick {
+    token: Token<'a>,
+    output_error: OutputError,
+  },
+  Code {
+    recipe: &'a str,
+    line_number: Option<usize>,
+    code: i32,
+  },
+  Cygpath {
+    recipe: &'a str,
+    output_error: OutputError,
+  },
+  Dotenv {
+    dotenv_error: dotenv::Error,
+  },
+  FunctionCall {
+    token: Token<'a>,
+    message: String,
+  },
+  Internal {
+    message: String,
+  },
+  IoError {
+    recipe: &'a str,
+    io_error: io::Error,
+  },
+  Shebang {
+    recipe: &'a str,
+    command: String,
+    argument: Option<String>,
+    io_error: io::Error,
+  },
+  Signal {
+    recipe: &'a str,
+    line_number: Option<usize>,
+    signal: i32,
+  },
+  TmpdirIoError {
+    recipe: &'a str,
+    io_error: io::Error,
+  },
+  UnknownOverrides {
+    overrides: Vec<&'a str>,
+  },
+  UnknownRecipes {
+    recipes: Vec<&'a str>,
+    suggestion: Option<&'a str>,
+  },
+  Unknown {
+    recipe: &'a str,
+    line_number: Option<usize>,
+  },
 }
 
 impl<'a> RuntimeError<'a> {
   pub fn code(&self) -> Option<i32> {
     match *self {
-      Code{code, ..} | Backtick{output_error: OutputError::Code(code), ..} => Some(code),
+      Code { code, .. }
+      | Backtick {
+        output_error: OutputError::Code(code),
+        ..
+      } => Some(code),
       _ => None,
     }
   }
@@ -57,7 +101,11 @@ impl<'a> RuntimeError<'a> {
 impl<'a> Display for RuntimeError<'a> {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     use RuntimeError::*;
-    let color = if f.alternate() { Color::always() } else { Color::never() };
+    let color = if f.alternate() {
+      Color::always()
+    } else {
+      Color::never()
+    };
     let error = color.error();
     let message = color.message();
     write!(f, "{} {}", error.paint("error:"), message.prefix())?;
@@ -65,30 +113,64 @@ impl<'a> Display for RuntimeError<'a> {
     let mut error_token = None;
 
     match *self {
-      UnknownRecipes{ref recipes, ref suggestion} => {
-        write!(f, "Justfile does not contain recipe{} {}.",
-                  maybe_s(recipes.len()), Or(&ticks(recipes)))?;
+      UnknownRecipes {
+        ref recipes,
+        ref suggestion,
+      } => {
+        write!(
+          f,
+          "Justfile does not contain recipe{} {}.",
+          maybe_s(recipes.len()),
+          Or(&ticks(recipes))
+        )?;
         if let Some(suggestion) = *suggestion {
           write!(f, "\nDid you mean `{}`?", suggestion)?;
         }
-      },
-      UnknownOverrides{ref overrides} => {
-        write!(f, "Variable{} {} overridden on the command line but not present in justfile",
-                  maybe_s(overrides.len()),
-                  And(&overrides.iter().map(Tick).collect::<Vec<_>>()))?;
-      },
-      ArgumentCountMismatch{recipe, ref parameters, found, min, max} => {
+      }
+      UnknownOverrides { ref overrides } => {
+        write!(
+          f,
+          "Variable{} {} overridden on the command line but not present in justfile",
+          maybe_s(overrides.len()),
+          And(&overrides.iter().map(Tick).collect::<Vec<_>>())
+        )?;
+      }
+      ArgumentCountMismatch {
+        recipe,
+        ref parameters,
+        found,
+        min,
+        max,
+      } => {
         if min == max {
           let expected = min;
-          write!(f, "Recipe `{}` got {} argument{} but {}takes {}",
-                    recipe, found, maybe_s(found),
-                    if expected < found { "only " } else { "" }, expected)?;
+          write!(
+            f,
+            "Recipe `{}` got {} argument{} but {}takes {}",
+            recipe,
+            found,
+            maybe_s(found),
+            if expected < found { "only " } else { "" },
+            expected
+          )?;
         } else if found < min {
-          write!(f, "Recipe `{}` got {} argument{} but takes at least {}",
-                    recipe, found, maybe_s(found), min)?;
+          write!(
+            f,
+            "Recipe `{}` got {} argument{} but takes at least {}",
+            recipe,
+            found,
+            maybe_s(found),
+            min
+          )?;
         } else if found > max {
-          write!(f, "Recipe `{}` got {} argument{} but takes at most {}",
-                    recipe, found, maybe_s(found), max)?;
+          write!(
+            f,
+            "Recipe `{}` got {} argument{} but takes at most {}",
+            recipe,
+            found,
+            maybe_s(found),
+            max
+          )?;
         }
         write!(f, "\nusage:\n    just {}", recipe)?;
         for param in parameters {
@@ -98,89 +180,170 @@ impl<'a> Display for RuntimeError<'a> {
             write!(f, " {}", param)?;
           }
         }
-      },
-      Code{recipe, line_number, code} => {
+      }
+      Code {
+        recipe,
+        line_number,
+        code,
+      } => {
         if let Some(n) = line_number {
-          write!(f, "Recipe `{}` failed on line {} with exit code {}", recipe, n, code)?;
+          write!(
+            f,
+            "Recipe `{}` failed on line {} with exit code {}",
+            recipe, n, code
+          )?;
         } else {
           write!(f, "Recipe `{}` failed with exit code {}", recipe, code)?;
         }
-      },
-      Cygpath{recipe, ref output_error} => match *output_error {
+      }
+      Cygpath {
+        recipe,
+        ref output_error,
+      } => match *output_error {
         OutputError::Code(code) => {
-          write!(f, "Cygpath failed with exit code {} while translating recipe `{}` \
-                     shebang interpreter path", code, recipe)?;
+          write!(
+            f,
+            "Cygpath failed with exit code {} while translating recipe `{}` \
+             shebang interpreter path",
+            code, recipe
+          )?;
         }
         OutputError::Signal(signal) => {
-          write!(f, "Cygpath terminated by signal {} while translating recipe `{}` \
-                     shebang interpreter path", signal, recipe)?;
+          write!(
+            f,
+            "Cygpath terminated by signal {} while translating recipe `{}` \
+             shebang interpreter path",
+            signal, recipe
+          )?;
         }
         OutputError::Unknown => {
-          write!(f, "Cygpath experienced an unknown failure while translating recipe `{}` \
-                     shebang interpreter path", recipe)?;
+          write!(
+            f,
+            "Cygpath experienced an unknown failure while translating recipe `{}` \
+             shebang interpreter path",
+            recipe
+          )?;
         }
         OutputError::Io(ref io_error) => {
           match io_error.kind() {
             io::ErrorKind::NotFound => write!(
-              f, "Could not find `cygpath` executable to translate recipe `{}` \
-                  shebang interpreter path:\n{}", recipe, io_error),
+              f,
+              "Could not find `cygpath` executable to translate recipe `{}` \
+               shebang interpreter path:\n{}",
+              recipe, io_error
+            ),
             io::ErrorKind::PermissionDenied => write!(
-              f, "Could not run `cygpath` executable to translate recipe `{}` \
-                  shebang interpreter path:\n{}", recipe, io_error),
+              f,
+              "Could not run `cygpath` executable to translate recipe `{}` \
+               shebang interpreter path:\n{}",
+              recipe, io_error
+            ),
             _ => write!(f, "Could not run `cygpath` executable:\n{}", io_error),
           }?;
         }
         OutputError::Utf8(ref utf8_error) => {
-          write!(f, "Cygpath successfully translated recipe `{}` shebang interpreter path, \
-                     but output was not utf8: {}", recipe, utf8_error)?;
+          write!(
+            f,
+            "Cygpath successfully translated recipe `{}` shebang interpreter path, \
+             but output was not utf8: {}",
+            recipe, utf8_error
+          )?;
         }
       },
-      Dotenv{ref dotenv_error} => {
+      Dotenv { ref dotenv_error } => {
         writeln!(f, "Failed to load .env: {}", dotenv_error)?;
       }
-      FunctionCall{ref token, ref message} => {
+      FunctionCall {
+        ref token,
+        ref message,
+      } => {
         writeln!(f, "Call to function `{}` failed: {}", token.lexeme, message)?;
         error_token = Some(token);
       }
-      Shebang{recipe, ref command, ref argument, ref io_error} => {
+      Shebang {
+        recipe,
+        ref command,
+        ref argument,
+        ref io_error,
+      } => {
         if let Some(ref argument) = *argument {
-          write!(f, "Recipe `{}` with shebang `#!{} {}` execution error: {}",
-                    recipe, command, argument, io_error)?;
+          write!(
+            f,
+            "Recipe `{}` with shebang `#!{} {}` execution error: {}",
+            recipe, command, argument, io_error
+          )?;
         } else {
-          write!(f, "Recipe `{}` with shebang `#!{}` execution error: {}",
-                    recipe, command, io_error)?;
+          write!(
+            f,
+            "Recipe `{}` with shebang `#!{}` execution error: {}",
+            recipe, command, io_error
+          )?;
         }
       }
-      Signal{recipe, line_number, signal} => {
+      Signal {
+        recipe,
+        line_number,
+        signal,
+      } => {
         if let Some(n) = line_number {
-          write!(f, "Recipe `{}` was terminated on line {} by signal {}", recipe, n, signal)?;
+          write!(
+            f,
+            "Recipe `{}` was terminated on line {} by signal {}",
+            recipe, n, signal
+          )?;
         } else {
           write!(f, "Recipe `{}` was terminated by signal {}", recipe, signal)?;
         }
       }
-      Unknown{recipe, line_number} => {
+      Unknown {
+        recipe,
+        line_number,
+      } => {
         if let Some(n) = line_number {
-          write!(f, "Recipe `{}` failed on line {} for an unknown reason", recipe, n)?;
+          write!(
+            f,
+            "Recipe `{}` failed on line {} for an unknown reason",
+            recipe, n
+          )?;
         } else {
         }
-      },
-      IoError{recipe, ref io_error} => {
+      }
+      IoError {
+        recipe,
+        ref io_error,
+      } => {
         match io_error.kind() {
-          io::ErrorKind::NotFound => writeln!(f,
+          io::ErrorKind::NotFound => writeln!(
+            f,
             "Recipe `{}` could not be run because just could not find `sh`:{}",
-            recipe, io_error),
+            recipe, io_error
+          ),
           io::ErrorKind::PermissionDenied => writeln!(
-            f, "Recipe `{}` could not be run because just could not run `sh`:{}",
-            recipe, io_error),
-          _ => writeln!(f, "Recipe `{}` could not be run because of an IO error while \
-                      launching `sh`:{}", recipe, io_error),
+            f,
+            "Recipe `{}` could not be run because just could not run `sh`:{}",
+            recipe, io_error
+          ),
+          _ => writeln!(
+            f,
+            "Recipe `{}` could not be run because of an IO error while \
+             launching `sh`:{}",
+            recipe, io_error
+          ),
         }?;
-      },
-      TmpdirIoError{recipe, ref io_error} =>
-        writeln!(f, "Recipe `{}` could not be run because of an IO error while trying \
-                  to create a temporary directory or write a file to that directory`:{}",
-                  recipe, io_error)?,
-      Backtick{ref token, ref output_error} => match *output_error {
+      }
+      TmpdirIoError {
+        recipe,
+        ref io_error,
+      } => writeln!(
+        f,
+        "Recipe `{}` could not be run because of an IO error while trying \
+         to create a temporary directory or write a file to that directory`:{}",
+        recipe, io_error
+      )?,
+      Backtick {
+        ref token,
+        ref output_error,
+      } => match *output_error {
         OutputError::Code(code) => {
           writeln!(f, "Backtick failed with exit code {}", code)?;
           error_token = Some(token);
@@ -196,24 +359,40 @@ impl<'a> Display for RuntimeError<'a> {
         OutputError::Io(ref io_error) => {
           match io_error.kind() {
             io::ErrorKind::NotFound => write!(
-              f, "Backtick could not be run because just could not find `sh`:\n{}",
-              io_error),
+              f,
+              "Backtick could not be run because just could not find `sh`:\n{}",
+              io_error
+            ),
             io::ErrorKind::PermissionDenied => write!(
-              f, "Backtick could not be run because just could not run `sh`:\n{}", io_error),
-            _ => write!(f, "Backtick could not be run because of an IO \
-                            error while launching `sh`:\n{}", io_error),
+              f,
+              "Backtick could not be run because just could not run `sh`:\n{}",
+              io_error
+            ),
+            _ => write!(
+              f,
+              "Backtick could not be run because of an IO \
+               error while launching `sh`:\n{}",
+              io_error
+            ),
           }?;
           error_token = Some(token);
         }
         OutputError::Utf8(ref utf8_error) => {
-          writeln!(f, "Backtick succeeded but stdout was not utf8: {}", utf8_error)?;
+          writeln!(
+            f,
+            "Backtick succeeded but stdout was not utf8: {}",
+            utf8_error
+          )?;
           error_token = Some(token);
         }
       },
-      Internal{ref message} => {
-        write!(f, "Internal error, this may indicate a bug in just: {} \
-                   consider filing an issue: https://github.com/casey/just/issues/new",
-                   message)?;
+      Internal { ref message } => {
+        write!(
+          f,
+          "Internal error, this may indicate a bug in just: {} \
+           consider filing an issue: https://github.com/casey/just/issues/new",
+          message
+        )?;
       }
     }
 

--- a/src/shebang.rs
+++ b/src/shebang.rs
@@ -1,6 +1,6 @@
 pub struct Shebang<'a> {
   pub interpreter: &'a str,
-  pub argument:    Option<&'a str>,
+  pub argument: Option<&'a str>,
 }
 
 impl<'a> Shebang<'a> {
@@ -17,13 +17,16 @@ impl<'a> Shebang<'a> {
       .splitn(2, |c| c == ' ' || c == '\t');
 
     let interpreter = pieces.next().unwrap_or("");
-    let argument    = pieces.next();
+    let argument = pieces.next();
 
     if interpreter == "" {
       return None;
     }
 
-    Some(Shebang{interpreter, argument})
+    Some(Shebang {
+      interpreter,
+      argument,
+    })
   }
 }
 
@@ -35,26 +38,59 @@ mod test {
   fn split_shebang() {
     fn check(text: &str, expected_split: Option<(&str, Option<&str>)>) {
       let shebang = Shebang::new(text);
-      assert_eq!(shebang.map(|shebang| (shebang.interpreter, shebang.argument)), expected_split);
+      assert_eq!(
+        shebang.map(|shebang| (shebang.interpreter, shebang.argument)),
+        expected_split
+      );
     }
 
-    check("#!    ",                         None                                       );
-    check("#!",                             None                                       );
-    check("#!/bin/bash",                    Some(("/bin/bash",    None               )));
-    check("#!/bin/bash    ",                Some(("/bin/bash",    None               )));
-    check("#!/usr/bin/env python",          Some(("/usr/bin/env", Some("python"     ))));
-    check("#!/usr/bin/env python   ",       Some(("/usr/bin/env", Some("python"     ))));
-    check("#!/usr/bin/env python -x",       Some(("/usr/bin/env", Some("python -x"  ))));
-    check("#!/usr/bin/env python   -x",     Some(("/usr/bin/env", Some("python   -x"))));
-    check("#!/usr/bin/env python \t-x\t",   Some(("/usr/bin/env", Some("python \t-x"))));
-    check("#/usr/bin/env python \t-x\t",    None                                       );
-    check("#!  /bin/bash",                  Some(("/bin/bash",    None               )));
-    check("#!\t\t/bin/bash    ",            Some(("/bin/bash",    None               )));
-    check("#!  \t\t/usr/bin/env python",    Some(("/usr/bin/env", Some("python"     ))));
-    check("#!  /usr/bin/env python   ",     Some(("/usr/bin/env", Some("python"     ))));
-    check("#!  /usr/bin/env python -x",     Some(("/usr/bin/env", Some("python -x"  ))));
-    check("#!  /usr/bin/env python   -x",   Some(("/usr/bin/env", Some("python   -x"))));
-    check("#!  /usr/bin/env python \t-x\t", Some(("/usr/bin/env", Some("python \t-x"))));
-    check("#  /usr/bin/env python \t-x\t",  None                                       );
+    check("#!    ", None);
+    check("#!", None);
+    check("#!/bin/bash", Some(("/bin/bash", None)));
+    check("#!/bin/bash    ", Some(("/bin/bash", None)));
+    check(
+      "#!/usr/bin/env python",
+      Some(("/usr/bin/env", Some("python"))),
+    );
+    check(
+      "#!/usr/bin/env python   ",
+      Some(("/usr/bin/env", Some("python"))),
+    );
+    check(
+      "#!/usr/bin/env python -x",
+      Some(("/usr/bin/env", Some("python -x"))),
+    );
+    check(
+      "#!/usr/bin/env python   -x",
+      Some(("/usr/bin/env", Some("python   -x"))),
+    );
+    check(
+      "#!/usr/bin/env python \t-x\t",
+      Some(("/usr/bin/env", Some("python \t-x"))),
+    );
+    check("#/usr/bin/env python \t-x\t", None);
+    check("#!  /bin/bash", Some(("/bin/bash", None)));
+    check("#!\t\t/bin/bash    ", Some(("/bin/bash", None)));
+    check(
+      "#!  \t\t/usr/bin/env python",
+      Some(("/usr/bin/env", Some("python"))),
+    );
+    check(
+      "#!  /usr/bin/env python   ",
+      Some(("/usr/bin/env", Some("python"))),
+    );
+    check(
+      "#!  /usr/bin/env python -x",
+      Some(("/usr/bin/env", Some("python -x"))),
+    );
+    check(
+      "#!  /usr/bin/env python   -x",
+      Some(("/usr/bin/env", Some("python   -x"))),
+    );
+    check(
+      "#!  /usr/bin/env python \t-x\t",
+      Some(("/usr/bin/env", Some("python \t-x"))),
+    );
+    check("#  /usr/bin/env python \t-x\t", None);
   }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -22,28 +22,28 @@ macro_rules! compilation_error_test {
       let input = $input;
 
       let expected = ::CompilationError {
-        text:   input,
-        index:  $index,
-        line:   $line,
+        text: input,
+        index: $index,
+        line: $line,
         column: $column,
-        width:  $width,
-        kind:   $kind,
+        width: $width,
+        kind: $kind,
       };
 
       let tokens = ::Lexer::lex(input).unwrap();
       let parser = ::Parser::new(input, tokens);
 
       if let Err(error) = parser.justfile() {
-        assert_eq!(error.text,   expected.text);
-        assert_eq!(error.index,  expected.index);
-        assert_eq!(error.line,   expected.line);
+        assert_eq!(error.text, expected.text);
+        assert_eq!(error.index, expected.index);
+        assert_eq!(error.line, expected.line);
         assert_eq!(error.column, expected.column);
-        assert_eq!(error.width,  expected.width);
-        assert_eq!(error.kind,   expected.kind);
-        assert_eq!(error,        expected);
+        assert_eq!(error.width, expected.width);
+        assert_eq!(error.kind, expected.kind);
+        assert_eq!(error, expected);
       } else {
         panic!("parse succeeded but expected: {}\n{}", expected, input);
       }
     }
-  }
+  };
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -2,23 +2,23 @@ use common::*;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Token<'a> {
-  pub index:  usize,
-  pub line:   usize,
+  pub index: usize,
+  pub line: usize,
   pub column: usize,
-  pub text:   &'a str,
+  pub text: &'a str,
   pub prefix: &'a str,
   pub lexeme: &'a str,
-  pub kind:   TokenKind,
+  pub kind: TokenKind,
 }
 
 impl<'a> Token<'a> {
   pub fn error(&self, kind: CompilationErrorKind<'a>) -> CompilationError<'a> {
     CompilationError {
       column: self.column + self.prefix.len(),
-      index:  self.index + self.prefix.len(),
-      line:   self.line,
-      text:   self.text,
-      width:  Some(self.lexeme.len()),
+      index: self.index + self.prefix.len(),
+      line: self.line,
+      text: self.text,
+      width: Some(self.lexeme.len()),
       kind,
     }
   }
@@ -51,27 +51,31 @@ pub enum TokenKind {
 impl Display for TokenKind {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     use TokenKind::*;
-    write!(f, "{}", match *self {
-      Backtick           => "backtick",
-      Colon              => "':'",
-      Comma              => "','",
-      Comment            => "comment",
-      Dedent             => "dedent",
-      Eof                => "end of file",
-      Eol                => "end of line",
-      Equals             => "'='",
-      Indent             => "indent",
-      InterpolationEnd   => "'}}'",
-      InterpolationStart => "'{{'",
-      Line               => "command",
-      Name               => "name",
-      Plus               => "'+'",
-      At                 => "'@'",
-      ParenL             => "'('",
-      ParenR             => "')'",
-      StringToken        => "string",
-      RawString          => "raw string",
-      Text               => "command text",
-    })
+    write!(
+      f,
+      "{}",
+      match *self {
+        Backtick => "backtick",
+        Colon => "':'",
+        Comma => "','",
+        Comment => "comment",
+        Dedent => "dedent",
+        Eof => "end of file",
+        Eol => "end of line",
+        Equals => "'='",
+        Indent => "indent",
+        InterpolationEnd => "'}}'",
+        InterpolationStart => "'{{'",
+        Line => "command",
+        Name => "name",
+        Plus => "'+'",
+        At => "'@'",
+        ParenL => "'('",
+        ParenR => "')'",
+        StringToken => "string",
+        RawString => "raw string",
+        Text => "command text",
+      }
+    )
   }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -41,16 +41,19 @@ macro_rules! integration_test {
 }
 
 fn integration_test(
-  shell:           &str,
-  justfile:        &str,
-  args:            &[&str],
+  shell: &str,
+  justfile: &str,
+  args: &[&str],
   expected_stdout: &str,
   expected_stderr: &str,
   expected_status: i32,
 ) {
-  let tmp = TempDir::new("just-integration")
-    .unwrap_or_else(
-      |err| panic!("integration test: failed to create temporary directory: {}", err));
+  let tmp = TempDir::new("just-integration").unwrap_or_else(|err| {
+    panic!(
+      "integration test: failed to create temporary directory: {}",
+      err
+    )
+  });
 
   let mut justfile_path = tmp.path().to_path_buf();
   justfile_path.push("justfile");
@@ -77,13 +80,19 @@ fn integration_test(
 
   let stdout = str::from_utf8(&output.stdout).unwrap();
   if stdout != expected_stdout {
-    println!("bad stdout:\ngot:\n{}\n\nexpected:\n{}", stdout, expected_stdout);
+    println!(
+      "bad stdout:\ngot:\n{}\n\nexpected:\n{}",
+      stdout, expected_stdout
+    );
     failure = true;
   }
 
   let stderr = str::from_utf8(&output.stderr).unwrap();
   if stderr != expected_stderr {
-    println!("bad stderr:\ngot:\n{}\n\nexpected:\n{}", stderr, expected_stderr);
+    println!(
+      "bad stderr:\ngot:\n{}\n\nexpected:\n{}",
+      stderr, expected_stderr
+    );
     failure = true;
   }
 
@@ -591,7 +600,6 @@ wut:
   status:   EXIT_FAILURE,
 }
 
-
 integration_test! {
   name:     export_shebang,
   justfile: r#"
@@ -929,7 +937,6 @@ integration_test! {
   status:   EXIT_FAILURE,
 }
 
-
 integration_test! {
   name:     required_after_default,
   justfile: "bar:\nhello baz arg='foo' bar:",
@@ -968,7 +975,6 @@ hello baz arg="XYZ\t\"	":
   stderr:   "echo 'ABC...XYZ\t\"\t'\n",
   status:   EXIT_SUCCESS,
 }
-
 
 integration_test! {
   name:     use_raw_string_default,
@@ -1227,7 +1233,6 @@ foo:
   stderr:   format!("/bin/echo '{}' 'HTAP' 'ABC'\n", env::var("USERNAME").unwrap()).as_str(),
   status:   EXIT_SUCCESS,
 }
-
 
 integration_test! {
   name:     env_var_failure,
@@ -1499,7 +1504,6 @@ a:"#,
 ",
   status:   EXIT_FAILURE,
 }
-
 
 integration_test! {
   name:     multiline_raw_string,

--- a/tests/interrupts.rs
+++ b/tests/interrupts.rs
@@ -4,8 +4,12 @@ extern crate libc;
 extern crate tempdir;
 
 use executable_path::executable_path;
+use std::{
+  process::Command,
+  thread,
+  time::{Duration, Instant},
+};
 use tempdir::TempDir;
-use std::{process::Command, time::{Duration, Instant}, thread};
 
 #[cfg(unix)]
 fn kill(process_id: u32) {
@@ -16,9 +20,12 @@ fn kill(process_id: u32) {
 
 #[cfg(unix)]
 fn interrupt_test(justfile: &str) {
-  let tmp = TempDir::new("just-interrupts")
-    .unwrap_or_else(
-    |err| panic!("integration test: failed to create temporary directory: {}", err));
+  let tmp = TempDir::new("just-interrupts").unwrap_or_else(|err| {
+    panic!(
+      "integration test: failed to create temporary directory: {}",
+      err
+    )
+  });
 
   let mut justfile_path = tmp.path().to_path_buf();
   justfile_path.push("justfile");
@@ -53,29 +60,35 @@ fn interrupt_test(justfile: &str) {
 #[cfg(unix)]
 #[test]
 fn interrupt_shebang() {
-  interrupt_test("
+  interrupt_test(
+    "
 default:
   #!/usr/bin/env sh
   sleep 2
-");
+",
+  );
 }
 
 #[cfg(unix)]
 #[test]
 fn interrupt_line() {
-  interrupt_test("
+  interrupt_test(
+    "
 default:
   @sleep 2
-");
+",
+  );
 }
 
 #[cfg(unix)]
 #[test]
 fn interrupt_backtick() {
-  interrupt_test("
+  interrupt_test(
+    "
 foo = `sleep 2`
 
 default:
   @echo hello
-");
+",
+  );
 }

--- a/tests/invocation_directory.rs
+++ b/tests/invocation_directory.rs
@@ -4,16 +4,19 @@ extern crate target;
 extern crate tempdir;
 
 use executable_path::executable_path;
+use std::path::Path;
 use std::process;
 use std::str;
-use std::path::Path;
 use tempdir::TempDir;
 
 #[cfg(unix)]
 fn to_shell_path(path: &Path) -> String {
   use std::fs;
-  fs::canonicalize(path).expect("canonicalize failed")
-    .to_str().map(str::to_string).expect("unicode decode failed")
+  fs::canonicalize(path)
+    .expect("canonicalize failed")
+    .to_str()
+    .map(str::to_string)
+    .expect("unicode decode failed")
 }
 
 #[cfg(windows)]
@@ -27,13 +30,19 @@ fn to_shell_path(path: &Path) -> String {
 
 #[test]
 fn test_invocation_directory() {
-  let tmp = TempDir::new("just-integration")
-    .unwrap_or_else(
-      |err| panic!("integration test: failed to create temporary directory: {}", err));
+  let tmp = TempDir::new("just-integration").unwrap_or_else(|err| {
+    panic!(
+      "integration test: failed to create temporary directory: {}",
+      err
+    )
+  });
 
   let mut justfile_path = tmp.path().to_path_buf();
   justfile_path.push("justfile");
-  brev::dump(justfile_path, "default:\n @cd {{invocation_directory()}}\n @echo {{invocation_directory()}}");
+  brev::dump(
+    justfile_path,
+    "default:\n @cd {{invocation_directory()}}\n @echo {{invocation_directory()}}",
+  );
 
   let mut subdir = tmp.path().to_path_buf();
   subdir.push("subdir");
@@ -48,8 +57,7 @@ fn test_invocation_directory() {
   let mut failure = false;
 
   let expected_status = 0;
-  let expected_stdout =
-    to_shell_path(&subdir) + "\n";
+  let expected_stdout = to_shell_path(&subdir) + "\n";
   let expected_stderr = "";
 
   let status = output.status.code().unwrap();
@@ -60,13 +68,19 @@ fn test_invocation_directory() {
 
   let stdout = str::from_utf8(&output.stdout).unwrap();
   if stdout != expected_stdout {
-    println!("bad stdout:\ngot:\n{:?}\n\nexpected:\n{:?}", stdout, expected_stdout);
+    println!(
+      "bad stdout:\ngot:\n{:?}\n\nexpected:\n{:?}",
+      stdout, expected_stdout
+    );
     failure = true;
   }
 
   let stderr = str::from_utf8(&output.stderr).unwrap();
   if stderr != expected_stderr {
-    println!("bad stderr:\ngot:\n{:?}\n\nexpected:\n{:?}", stderr, expected_stderr);
+    println!(
+      "bad stderr:\ngot:\n{:?}\n\nexpected:\n{:?}",
+      stderr, expected_stderr
+    );
     failure = true;
   }
 

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -2,9 +2,9 @@ extern crate brev;
 extern crate executable_path;
 extern crate tempdir;
 
-use tempdir::TempDir;
-use std::{path, str, fs, process};
 use executable_path::executable_path;
+use std::{fs, path, process, str};
+use tempdir::TempDir;
 
 fn search_test<P: AsRef<path::Path>>(path: P, args: &[&str]) {
   let binary = executable_path("just");


### PR DESCRIPTION
I'm attempting to format the codebase with rustfmt, but it appears that the formatting isn't stable, and each additional call to rustfmt produces new diffs.

Reported in rust-lang-nursery/rustfmt/issues/2973