### PR TITLE
Update readme with scoop installation instructions.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,12 +59,6 @@ curl -LSfs https://japaric.github.io/trust/install.sh | \
   sh -s -- --git casey/just --to DESTINATION_DIRECTORY
 ```
 
-Alternatively, you can install `just` via the https://scoop.sh[scoop package manager] with the following command:
-
-```powershell
-scoop install just
-```
-
 On Linux, use:
 
 ```sh
@@ -74,19 +68,25 @@ curl -LSfs https://japaric.github.io/trust/install.sh | \
 
 === Homebrew
 
-On MacOS, `just` is a available through the https://brew.sh[Homebrew] package manager. Install Homebrew using the instructions at https://brew.sh, then run:
+On MacOS, `just` can be installed using the https://brew.sh[Homebrew package manager]. Install Homebrew using the instructions https://brew.sh[here], then run:
 
 `brew install just`
 
+=== Scoop
+
+On Windows, `just` can be installed using the https://scoop.sh[Scoop package manager]. Install Scoop using the instractions https://scoop.sh/[here], then run:
+
+```powershell
+scoop install just
+```
+
 === Cargo
 
-`just` can be installed using `cargo`, the https://www.rust-lang.org[rust language package manager]:
+On Windows, Linux, and macOS, `just` can be installed using Cargo, the https://www.rust-lang.org[rust language package manager]. Install Cargo using the instructions https://www.rustup.rs[here], then run:
 
-1. Install rust and cargo by following the instructions https://www.rustup.rs[here]
-2. Run `cargo install just`
-3. Add `~/.cargo/bin` to your shell's $PATH.
+`cargo install just`
 
-`rustup` may have done #3 for you. If this doesn't work, put `export PATH="$HOME/.cargo/bin:$PATH"` in your shell's configuration file
+(You might also need to add `~/.cargo/bin` to your shell's `$PATH`. If you can't run just after installing it, put `export PATH="$HOME/.cargo/bin:$PATH"` in your shell's configuration file.)
 
 
 == Quick Start

--- a/README.adoc
+++ b/README.adoc
@@ -59,6 +59,12 @@ curl -LSfs https://japaric.github.io/trust/install.sh | \
   sh -s -- --git casey/just --to DESTINATION_DIRECTORY
 ```
 
+Alternatively, you can install `just` via the https://scoop.sh[scoop package manager] with the following command:
+
+```powershell
+scoop install just
+```
+
 On Linux, use:
 
 ```sh


### PR DESCRIPTION
I recently added a manifest for installing just with the scoop package manager: https://github.com/lukesampson/scoop/pull/2638.

I updated the installation instructions for just with a link to scoop and a command for installing just on windows.