### PR TITLE
Fail fuzzing on internal errors

### DIFF
--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -1,5 +1,9 @@
 use common::*;
 
 pub fn compile(text: &str) {
-  Parser::parse(text).ok();
+  if let Err(error) = Parser::parse(text) {
+    if let CompilationErrorKind::Internal{..} = error.kind {
+      panic!("{}", error)
+    }
+  }
 }


### PR DESCRIPTION
Internal errors indicate compiler bugs, so we should fail fuzzing if we encounter any.

I changed `just::fuzzing::compile` to return an error iff it encounters an internal error. It stringifies the err value in order to avoid exposing any private types.