### PR TITLE
Print recipe signature if missing arguments

### DIFF
--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -99,6 +99,7 @@ impl<'a> Justfile<'a> where {
           if !argument_range.range_contains(argument_count) {
             return Err(RuntimeError::ArgumentCountMismatch {
               recipe: recipe.name,
+              parameters: recipe.parameters.iter().map(|p| p.name).collect(),
               found: tail.len(),
               min: recipe.min_arguments(),
               max: recipe.max_arguments(),
@@ -307,11 +308,13 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
+        parameters,
         found,
         min,
         max,
       } => {
         assert_eq!(recipe, "a");
+        assert_eq!(parameters, ["b", "c", "d"]);
         assert_eq!(found, 2);
         assert_eq!(min, 3);
         assert_eq!(max, 3);
@@ -328,11 +331,13 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
+        parameters,
         found,
         min,
         max,
       } => {
         assert_eq!(recipe, "a");
+        assert_eq!(parameters, ["b", "c", "d"]);
         assert_eq!(found, 2);
         assert_eq!(min, 3);
         assert_eq!(max, usize::MAX - 1);
@@ -349,11 +354,13 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
+        parameters,
         found,
         min,
         max,
       } => {
         assert_eq!(recipe, "a");
+        assert_eq!(parameters, ["b", "c", "d"]);
         assert_eq!(found, 0);
         assert_eq!(min, 3);
         assert_eq!(max, 3);
@@ -370,11 +377,13 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
+        parameters,
         found,
         min,
         max,
       } => {
         assert_eq!(recipe, "a");
+        assert_eq!(parameters, ["b", "c", "d"]);
         assert_eq!(found, 1);
         assert_eq!(min, 2);
         assert_eq!(max, 3);
@@ -391,11 +400,13 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
+        parameters,
         found,
         min,
         max,
       } => {
         assert_eq!(recipe, "a");
+        assert_eq!(parameters, ["b", "c", "d"]);
         assert_eq!(found, 0);
         assert_eq!(min, 1);
         assert_eq!(max, 3);

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -99,7 +99,7 @@ impl<'a> Justfile<'a> where {
           if !argument_range.range_contains(argument_count) {
             return Err(RuntimeError::ArgumentCountMismatch {
               recipe: recipe.name,
-              parameters: recipe.parameters.iter().map(|p| p.name).collect(),
+              parameters: recipe.parameters.iter().collect::<Vec<_>>(),
               found: tail.len(),
               min: recipe.min_arguments(),
               max: recipe.max_arguments(),
@@ -308,13 +308,12 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
-        parameters,
+        parameters: _,
         found,
         min,
         max,
       } => {
         assert_eq!(recipe, "a");
-        assert_eq!(parameters, ["b", "c", "d"]);
         assert_eq!(found, 2);
         assert_eq!(min, 3);
         assert_eq!(max, 3);
@@ -331,13 +330,12 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
-        parameters,
+        parameters: _,
         found,
         min,
         max,
       } => {
         assert_eq!(recipe, "a");
-        assert_eq!(parameters, ["b", "c", "d"]);
         assert_eq!(found, 2);
         assert_eq!(min, 3);
         assert_eq!(max, usize::MAX - 1);
@@ -354,13 +352,12 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
-        parameters,
+        parameters: _,
         found,
         min,
         max,
       } => {
         assert_eq!(recipe, "a");
-        assert_eq!(parameters, ["b", "c", "d"]);
         assert_eq!(found, 0);
         assert_eq!(min, 3);
         assert_eq!(max, 3);
@@ -377,13 +374,12 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
-        parameters,
+        parameters: _,
         found,
         min,
         max,
       } => {
         assert_eq!(recipe, "a");
-        assert_eq!(parameters, ["b", "c", "d"]);
         assert_eq!(found, 1);
         assert_eq!(min, 2);
         assert_eq!(max, 3);
@@ -400,13 +396,12 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
-        parameters,
+        parameters: _,
         found,
         min,
         max,
       } => {
         assert_eq!(recipe, "a");
-        assert_eq!(parameters, ["b", "c", "d"]);
         assert_eq!(found, 0);
         assert_eq!(min, 1);
         assert_eq!(max, 3);

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -99,7 +99,7 @@ impl<'a> Justfile<'a> where {
           if !argument_range.range_contains(argument_count) {
             return Err(RuntimeError::ArgumentCountMismatch {
               recipe: recipe.name,
-              parameters: recipe.parameters.iter().collect::<Vec<_>>(),
+              parameters: recipe.parameters.iter().collect(),
               found: tail.len(),
               min: recipe.min_arguments(),
               max: recipe.max_arguments(),

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -308,12 +308,17 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
-        parameters: _,
+        parameters,
         found,
         min,
         max,
       } => {
+        let param_names = parameters
+          .iter()
+          .map(|p| p.name)
+          .collect::<Vec<&str>>();
         assert_eq!(recipe, "a");
+        assert_eq!(param_names, ["b", "c", "d"]);
         assert_eq!(found, 2);
         assert_eq!(min, 3);
         assert_eq!(max, 3);
@@ -330,12 +335,17 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
-        parameters: _,
+        parameters,
         found,
         min,
         max,
       } => {
+        let param_names = parameters
+          .iter()
+          .map(|p| p.name)
+          .collect::<Vec<&str>>();
         assert_eq!(recipe, "a");
+        assert_eq!(param_names, ["b", "c", "d"]);
         assert_eq!(found, 2);
         assert_eq!(min, 3);
         assert_eq!(max, usize::MAX - 1);
@@ -352,12 +362,17 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
-        parameters: _,
+        parameters,
         found,
         min,
         max,
       } => {
+        let param_names = parameters
+          .iter()
+          .map(|p| p.name)
+          .collect::<Vec<&str>>();
         assert_eq!(recipe, "a");
+        assert_eq!(param_names, ["b", "c", "d"]);
         assert_eq!(found, 0);
         assert_eq!(min, 3);
         assert_eq!(max, 3);
@@ -374,12 +389,17 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
-        parameters: _,
+        parameters,
         found,
         min,
         max,
       } => {
+        let param_names = parameters
+          .iter()
+          .map(|p| p.name)
+          .collect::<Vec<&str>>();
         assert_eq!(recipe, "a");
+        assert_eq!(param_names, ["b", "c", "d"]);
         assert_eq!(found, 1);
         assert_eq!(min, 2);
         assert_eq!(max, 3);
@@ -396,12 +416,17 @@ a return code:
     {
       ArgumentCountMismatch {
         recipe,
-        parameters: _,
+        parameters,
         found,
         min,
         max,
       } => {
+        let param_names = parameters
+          .iter()
+          .map(|p| p.name)
+          .collect::<Vec<&str>>();
         assert_eq!(recipe, "a");
+        assert_eq!(param_names, ["b", "c", "d"]);
         assert_eq!(found, 0);
         assert_eq!(min, 1);
         assert_eq!(max, 3);

--- a/src/runtime_error.rs
+++ b/src/runtime_error.rs
@@ -23,7 +23,7 @@ fn write_token_error_context(f: &mut fmt::Formatter, token: &Token) -> Result<()
 
 #[derive(Debug)]
 pub enum RuntimeError<'a> {
-  ArgumentCountMismatch{recipe: &'a str, parameters: Vec<&'a str>, found: usize, min: usize, max: usize},
+  ArgumentCountMismatch{recipe: &'a str, parameters: Vec<&'a Parameter<'a>>, found: usize, min: usize, max: usize},
   Backtick{token: Token<'a>, output_error: OutputError},
   Code{recipe: &'a str, line_number: Option<usize>, code: i32},
   Cygpath{recipe: &'a str, output_error: OutputError},
@@ -77,7 +77,10 @@ impl<'a> Display for RuntimeError<'a> {
           write!(f, "Recipe `{}` got {} argument{} but {}takes {}\n",
                     recipe, found, maybe_s(found),
                     if expected < found { "only " } else { "" }, expected)?;
-          write!(f, "Usage:\n just {} {}", recipe, parameters.join(" "));
+          write!(f, "usage:\n    just {}", recipe)?;
+          for param in parameters {
+            write!(f, " {:#}", param)?;
+          }
         } else if found < min {
           write!(f, "Recipe `{}` got {} argument{} but takes at least {}",
                     recipe, found, maybe_s(found), min)?;

--- a/src/runtime_error.rs
+++ b/src/runtime_error.rs
@@ -74,23 +74,23 @@ impl<'a> Display for RuntimeError<'a> {
       ArgumentCountMismatch{recipe, ref parameters, found, min, max} => {
         if min == max {
           let expected = min;
-          write!(f, "Recipe `{}` got {} argument{} but {}takes {}\n",
+          write!(f, "Recipe `{}` got {} argument{} but {}takes {}",
                     recipe, found, maybe_s(found),
                     if expected < found { "only " } else { "" }, expected)?;
-          write!(f, "usage:\n    just {}", recipe)?;
-          for param in parameters {
-            if color.stdout().active() {
-              write!(f, " {:#}", param)?;
-            } else {
-              write!(f, " {}", param)?;
-            }
-          }
         } else if found < min {
           write!(f, "Recipe `{}` got {} argument{} but takes at least {}",
                     recipe, found, maybe_s(found), min)?;
         } else if found > max {
           write!(f, "Recipe `{}` got {} argument{} but takes at most {}",
                     recipe, found, maybe_s(found), max)?;
+        }
+        write!(f, "\nusage:\n    just {}", recipe)?;
+        for param in parameters {
+          if color.stderr().active() {
+            write!(f, " {:#}", param)?;
+          } else {
+            write!(f, " {}", param)?;
+          }
         }
       },
       Code{recipe, line_number, code} => {

--- a/src/runtime_error.rs
+++ b/src/runtime_error.rs
@@ -79,7 +79,11 @@ impl<'a> Display for RuntimeError<'a> {
                     if expected < found { "only " } else { "" }, expected)?;
           write!(f, "usage:\n    just {}", recipe)?;
           for param in parameters {
-            write!(f, " {:#}", param)?;
+            if color.stdout().active() {
+              write!(f, " {:#}", param)?;
+            } else {
+              write!(f, " {}", param)?;
+            }
           }
         } else if found < min {
           write!(f, "Recipe `{}` got {} argument{} but takes at least {}",

--- a/src/runtime_error.rs
+++ b/src/runtime_error.rs
@@ -23,7 +23,7 @@ fn write_token_error_context(f: &mut fmt::Formatter, token: &Token) -> Result<()
 
 #[derive(Debug)]
 pub enum RuntimeError<'a> {
-  ArgumentCountMismatch{recipe: &'a str, found: usize, min: usize, max: usize},
+  ArgumentCountMismatch{recipe: &'a str, parameters: Vec<&'a str>, found: usize, min: usize, max: usize},
   Backtick{token: Token<'a>, output_error: OutputError},
   Code{recipe: &'a str, line_number: Option<usize>, code: i32},
   Cygpath{recipe: &'a str, output_error: OutputError},
@@ -71,12 +71,13 @@ impl<'a> Display for RuntimeError<'a> {
                   maybe_s(overrides.len()),
                   And(&overrides.iter().map(Tick).collect::<Vec<_>>()))?;
       },
-      ArgumentCountMismatch{recipe, found, min, max} => {
+      ArgumentCountMismatch{recipe, ref parameters, found, min, max} => {
         if min == max {
           let expected = min;
-          write!(f, "Recipe `{}` got {} argument{} but {}takes {}",
+          write!(f, "Recipe `{}` got {} argument{} but {}takes {}\n",
                     recipe, found, maybe_s(found),
                     if expected < found { "only " } else { "" }, expected)?;
+          write!(f, "Usage:\n just {} {}", recipe, parameters.join(" "));
         } else if found < min {
           write!(f, "Recipe `{}` got {} argument{} but takes at least {}",
                     recipe, found, maybe_s(found), min)?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -779,7 +779,7 @@ foo A B:
     ",
   args:     ("foo", "ONE"),
   stdout:   "",
-  stderr:   "error: Recipe `foo` got 1 argument but takes 2\nUsage:\n just foo A B\n",
+  stderr:   "error: Recipe `foo` got 1 argument but takes 2\nusage:\n    just foo \u{1b}[36mA\u{1b}[0m \u{1b}[36mB\u{1b}[0m\n",
   status:   EXIT_FAILURE,
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -779,7 +779,7 @@ foo A B:
     ",
   args:     ("foo", "ONE"),
   stdout:   "",
-  stderr:   "error: Recipe `foo` got 1 argument but takes 2\nusage:\n    just foo \u{1b}[36mA\u{1b}[0m \u{1b}[36mB\u{1b}[0m\n",
+  stderr:   "error: Recipe `foo` got 1 argument but takes 2\nusage:\n    just foo A B\n",
   status:   EXIT_FAILURE,
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -779,7 +779,7 @@ foo A B:
     ",
   args:     ("foo", "ONE"),
   stdout:   "",
-  stderr:   "error: Recipe `foo` got 1 argument but takes 2\n",
+  stderr:   "error: Recipe `foo` got 1 argument but takes 2\nUsage:\n just foo A B\n",
   status:   EXIT_FAILURE,
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -803,7 +803,7 @@ foo A B C='C':
     ",
   args:     ("foo", "bar"),
   stdout:   "",
-  stderr:   "error: Recipe `foo` got 1 argument but takes at least 2\n",
+  stderr:   "error: Recipe `foo` got 1 argument but takes at least 2\nusage:\n    just foo A B C='C'\n",
   status:   EXIT_FAILURE,
 }
 
@@ -1670,7 +1670,7 @@ a x y +z:
 ",
   args:     ("a", "0", "1"),
   stdout:   "",
-  stderr:   "error: Recipe `a` got 2 arguments but takes at least 3\n",
+  stderr:   "error: Recipe `a` got 2 arguments but takes at least 3\nusage:\n    just a x y +z\n",
   status:   EXIT_FAILURE,
 }
 


### PR DESCRIPTION
references issue #341 

Wasn't sure what format would be the best, but I took a stab at it and and printed out a simple usage doc on top of the error that was already there. Let me know what more I can do to help/make the code cleaner! I'm still fairly new to rust, so if this seems like a naÏve approach, please forgive me :laughing:   

