### PR TITLE
Add changelog for v0.3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,44 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.3.12] - 2018-06-19
+## [v0.3.13] - 2018-11-06
+### Added
+- Print recipe signature if missing arguments (#369)
+- Add grandiloquent verbosity level that echos shebang recipes (#348)
+- Wait for child processes to finish (#345)
+- Improve invalid escape sequence error messages (#328)
+
+### Fixed
+- Use PutBackN instead of PutBack in parser (#364)
+
+## [v0.3.12] - 2018-06-19
 ### Added
 - Implemented invocation_directory function
 
-## [0.3.11] - 2018-05-6
+## [v0.3.11] - 2018-05-6
 ### Fixed
 - Fixed colors on windows (#317)
 
-## [0.3.10] - 2018-3-19
+## [v0.3.10] - 2018-3-19
 ## Added
 - Make .env vars available in env_var functions (#310)
 
-## [0.3.8] - 2018-3-5
+## [v0.3.8] - 2018-3-5
 ## Added
 - Add dotenv integration (#306)
 
-## [0.3.7] - 2017-12-11
+## [v0.3.7] - 2017-12-11
 ### Fixed
 - Fix error if ! appears in comment (#296)
 
-## [0.3.6] - 2017-12-11
+## [v0.3.6] - 2017-12-11
 ### Fixed
 - Lex CRLF line endings properly (#292)
 
-## [0.3.5] - 2017-12-11
+## [v0.3.5] - 2017-12-11
 ### Added
 - Align doc-comments in `--list` output (#273)
 - Add `arch()`, `os()`, and `os_family()` functions (#277)
 - Add `env_var(key)` and `env_var_or_default(key, default)` functions (#280)
 
-## [0.3.4] - 2017-10-06
+## [v0.3.4] - 2017-10-06
 ### Added
 - Do not evaluate backticks in assignments during dry runs (#253)
 
 ### Changed
 - Change license to CC0 going forward (#270)
 
-## [0.3.1] - 2017-10-06
+## [v0.3.1] - 2017-10-06
 ### Added
 - Started keeping a changelog in CHANGELOG.md (#220)
 - Recipes whose names begin with an underscore will not appear in `--list` or `--summary` (#229)

--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ version = `sed -En 's/version[[:space:]]*=[[:space:]]*"([^"]+)"/v\1/p' Cargo.tom
 publish: lint clippy test
 	git branch | grep '* master'
 	git diff --no-ext-diff --quiet --exit-code
+	grep {{version}} CHANGELOG.md
 	cargo publish
 	git tag -a {{version}} -m 'Release {{version}}'
 	git push github {{version}}


### PR DESCRIPTION
Also add check that current version appears in CHANGELOG in `publish` recipe, so hopefully I remember to update the CHANGELOG for the current release when bumping versions, not afterward :P