### PR TITLE
Refactor the --shell internals

### DIFF
--- a/src/assignment_evaluator.rs
+++ b/src/assignment_evaluator.rs
@@ -12,7 +12,7 @@ pub struct AssignmentEvaluator<'a: 'b, 'b> {
   pub overrides: &'b Map<&'b str, &'b str>,
   pub quiet: bool,
   pub scope: &'b Map<&'a str, String>,
-  pub shell: &'b str,
+  pub shell: &'b Shell<'b>,
 }
 
 impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
@@ -22,7 +22,7 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
     dotenv: &'b Map<String, String>,
     overrides: &Map<&str, &str>,
     quiet: bool,
-    shell: &'a str,
+    shell: &'b Shell<'a>,
     dry_run: bool,
   ) -> RunResult<'a, Map<&'a str, String>> {
     let mut evaluator = AssignmentEvaluator {
@@ -140,11 +140,11 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
     raw: &str,
     token: &Token<'a>,
   ) -> RunResult<'a, String> {
-    let mut cmd = Command::new(self.shell);
+    let mut cmd = self.shell.command();
 
     cmd.export_environment_variables(self.scope, dotenv, self.exports)?;
 
-    cmd.arg("-cu").arg(raw);
+    cmd.arg(raw);
 
     cmd.stderr(if self.quiet {
       process::Stdio::null()

--- a/src/common.rs
+++ b/src/common.rs
@@ -34,5 +34,6 @@ pub use recipe::{Recipe, RecipeContext};
 pub use recipe_resolver::RecipeResolver;
 pub use runtime_error::{RunResult, RuntimeError};
 pub use shebang::Shebang;
+pub use shell::Shell;
 pub use token::{Token, TokenKind};
 pub use verbosity::Verbosity;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,6 +1,6 @@
 use common::*;
 
-pub const DEFAULT_SHELL: &str = "sh";
+pub const DEFAULT_SHELL: Shell = Shell::ShLike("sh");
 
 pub struct Configuration<'a> {
   pub dry_run: bool,
@@ -8,7 +8,7 @@ pub struct Configuration<'a> {
   pub highlight: bool,
   pub overrides: Map<&'a str, &'a str>,
   pub quiet: bool,
-  pub shell: &'a str,
+  pub shell: Shell<'a>,
   pub color: Color,
   pub verbosity: Verbosity,
 }

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -69,7 +69,7 @@ impl<'a> Justfile<'a> where {
       &dotenv,
       &configuration.overrides,
       configuration.quiet,
-      configuration.shell,
+      &configuration.shell,
       configuration.dry_run,
     )?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ mod recipe_resolver;
 mod run;
 mod runtime_error;
 mod shebang;
+mod shell;
 mod token;
 mod verbosity;
 

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -1,6 +1,6 @@
 use common::*;
 
-use std::process::{Command, ExitStatus, Stdio};
+use std::process::{ExitStatus, Stdio};
 
 use platform::{Platform, PlatformInterface};
 
@@ -94,7 +94,7 @@ impl<'a> Recipe<'a> {
           None => {
             return Err(RuntimeError::Internal {
               message: "missing parameter without default".to_string(),
-            })
+            });
           }
         }
       } else if parameter.variadic {
@@ -117,7 +117,7 @@ impl<'a> Recipe<'a> {
       overrides: &empty(),
       quiet: configuration.quiet,
       scope: &context.scope,
-      shell: configuration.shell,
+      shell: &configuration.shell,
       dotenv,
       exports,
     };
@@ -226,7 +226,7 @@ impl<'a> Recipe<'a> {
             command: interpreter.to_string(),
             argument: argument.map(String::from),
             io_error,
-          })
+          });
         }
       };
     } else {
@@ -276,9 +276,9 @@ impl<'a> Recipe<'a> {
           continue;
         }
 
-        let mut cmd = Command::new(configuration.shell);
+        let mut cmd = configuration.shell.command();
 
-        cmd.arg("-cu").arg(command);
+        cmd.arg(command);
 
         if configuration.quiet {
           cmd.stderr(Stdio::null());
@@ -305,7 +305,7 @@ impl<'a> Recipe<'a> {
             return Err(RuntimeError::IoError {
               recipe: self.name,
               io_error,
-            })
+            });
           }
         };
       }

--- a/src/run.rs
+++ b/src/run.rs
@@ -135,7 +135,7 @@ pub fn run() {
       Arg::with_name("SHELL")
         .long("shell")
         .takes_value(true)
-        .default_value(DEFAULT_SHELL)
+        .default_value(DEFAULT_SHELL.name())
         .help("Invoke <SHELL> to run recipes"),
     )
     .arg(
@@ -423,7 +423,10 @@ pub fn run() {
     evaluate: matches.is_present("EVALUATE"),
     highlight: matches.is_present("HIGHLIGHT"),
     quiet: matches.is_present("QUIET"),
-    shell: matches.value_of("SHELL").unwrap(),
+    shell: matches
+      .value_of("SHELL")
+      .map(|s| Shell::new(s))
+      .unwrap_or(DEFAULT_SHELL),
     verbosity,
     color,
     overrides,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,33 @@
+use std::process::Command;
+
+pub enum Shell<'a> {
+  ShLike(&'a str),
+  Custom(&'a str),
+}
+
+impl<'a> Shell<'a> {
+  pub fn new(cmd: &str) -> Shell {
+    //! Build a Shell variant from a string (shell executable name)
+    match cmd {
+      "sh" | "bash" | "dash" => Shell::ShLike(cmd),
+      cmd => Shell::Custom(cmd),
+    }
+  }
+  pub fn command(&self) -> Command {
+    //! Return a `Command` instance with the right executable and arguments
+    match self {
+      Shell::ShLike(s) => {
+        let mut cmd = Command::new(s);
+        cmd.arg("-cu");
+        cmd
+      }
+      Shell::Custom(s) => Command::new(s),
+    }
+  }
+  pub fn name(&self) -> &str {
+    match self {
+      Shell::ShLike(s) => s,
+      Shell::Custom(cmd) => cmd,
+    }
+  }
+}


### PR DESCRIPTION
This PR contains a little internal rework in the direction of #326:

- add a `Shell` enum around the shell str
- manage `ShLike` shells with the previous `-cu` argument
- allow a generic `Custom` shell without extra argument

The pattern for multi-platform scripts is:

```makefile
build:
    just _build-{{os()}}

_build-linux:
   ...

_build-windows:
   ...
```

And I had to put in place a wrapper around `cmd.exe` to translate `-cu` into `/C`. This PR adds the extra argument only for _sh like_ shells.

An upcoming PR may introduce some new features, like the support for `cmd` with the required options.
A subsequent one may add another option to allow to specify and shell command and some extra arguments, something like:

```
--shell: as it is (with automatic arguments for known shells)
--shell-args: multiple arguments, may override an automatic argument
```

I'm not a Windows user, but I have some CI running on Windows where I can test something.