### PR TITLE
Allow `--justfile` without `--working-directory`

### DIFF
--- a/tests/working_directory.rs
+++ b/tests/working_directory.rs
@@ -1,0 +1,35 @@
+extern crate executable_path;
+extern crate tempdir;
+
+use executable_path::executable_path;
+use std::{error::Error, fs, process::Command};
+use tempdir::TempDir;
+
+/// Test that just runs with the correct working directory when invoked with
+/// `--justfile` but not `--working-directory`
+#[test]
+fn justfile_without_working_directory() -> Result<(), Box<Error>> {
+  let tmp = TempDir::new("just-integration")?;
+  let justfile = tmp.path().join("justfile");
+  let data = tmp.path().join("data");
+  fs::write(
+    &justfile,
+    "foo = `cat data`\ndefault:\n echo {{foo}}\n cat data",
+  )?;
+  fs::write(&data, "found it")?;
+
+  let output = Command::new(executable_path("just"))
+    .arg("--justfile")
+    .arg(&justfile)
+    .output()?;
+
+  if !output.status.success() {
+    panic!()
+  }
+
+  let stdout = String::from_utf8(output.stdout).unwrap();
+
+  assert_eq!(stdout, "found it\nfound it");
+
+  Ok(())
+}


### PR DESCRIPTION
If `--justfile` is passed without `--working-directory`, use the directory the --justfile` is in
as the working directory, as if the justfile were found organically.

@smonami did the work, I just added an integration test.