### PR TITLE
Allow outer shebangs so justfiles can be used as scripts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -655,27 +655,28 @@ $ just foo/
 
 === Just scripts
 
-Just can be used as an interpreter for standalone, executable scripts.
+Just can be used as an interpreter for standalone executable scripts.
 
-To do so, add a suitable shebang at the top of a justfile and make it executable:
+To do so, add a suitable shebang to the top of a justfile and make it executable:
 
 ```sh
 $ cat > script <<EOF
 #!/usr/bin/env just --justfile
+
 foo:
   echo foo
 EOF
 $ chmod +x script
-$ ./justfile
+$ ./script foo
 echo foo
 foo
 ```
 
-When a script with a shebang is run, the system supplies the path to the script as an argument to the command in the shebang. So, with a shebang of `#!/usr/bin/env just --justfile`, the command will be `/usr/bin/env just --justfile PATH_TO_SCRIPT`, which allows `just` to location the `justfile`. The shebang line itself starts with a `#`, so will be ignored as a comment.
+When a script with a shebang is run, the system supplies the path to the script as an argument to the command in the shebang. So, with a shebang of `#!/usr/bin/env just --justfile`, the command will be `/usr/bin/env just --justfile PATH_TO_SCRIPT`, which allows `just` to locate correct `justfile`. The shebang line itself starts will be ignored as a comment.
 
 Note that when `just` is invoked with `--justfile` and not `--working-directory`, the working directory will be the directory containing the justfile, not the directory in which the command was invoked.
 
-To use the current working directory as the working directory instead, use `#!/usr/bin/env just --working-directory . --justfile`.
+To use the current working directory instead, use `#!/usr/bin/env just --working-directory . --justfile`.
 
 
 == Frequently Asked Questions

--- a/README.adoc
+++ b/README.adoc
@@ -672,7 +672,7 @@ foo
 
 When a script with a shebang is run, the system supplies the path to the script as an argument to the command in the shebang. So, with a shebang of `#!/usr/bin/env just --justfile`, the command will be `/usr/bin/env just --justfile PATH_TO_SCRIPT`. This allows `just` to locate and execute `justfile`. The shebang line itself will be ignored as a comment during execution.
 
-Without `--working-directory`, `just` will change its working directory to the one containing the argument to `--justfile`. If you'd prefer to leave the working directory unchanged, use `#!/usr/bin/env just --working-directory . --justfile`.
+With the above shebang, `just` will change its working directory to the location of the script. If you'd rather leave the working directory unchanged, use `#!/usr/bin/env just --working-directory . --justfile`.
 
 == Frequently Asked Questions
 

--- a/README.adoc
+++ b/README.adoc
@@ -655,9 +655,7 @@ $ just foo/
 
 === Standalone Scripts
 
-Just can be used as an interpreter for standalone executable scripts.
-
-To do so, add a suitable shebang to the top of a justfile and make it executable:
+By adding a shebang line to the top of a justfile and making it executable, you can use `just` as an interpreter for standalone scripts:
 
 ```sh
 $ cat > script <<EOF
@@ -672,12 +670,9 @@ echo foo
 foo
 ```
 
-When a script with a shebang is run, the system supplies the path to the script as an argument to the command in the shebang. So, with a shebang of `#!/usr/bin/env just --justfile`, the command will be `/usr/bin/env just --justfile PATH_TO_SCRIPT`, which allows `just` to locate correct `justfile`. The shebang line itself starts will be ignored as a comment.
+When a script with a shebang is run, the system supplies the path to the script as an argument to the command in the shebang. So, with a shebang of `#!/usr/bin/env just --justfile`, the command will be `/usr/bin/env just --justfile PATH_TO_SCRIPT`. This allows `just` to locate and execute `justfile`. The shebang line itself will be ignored as a comment during execution.
 
-Note that when `just` is invoked with `--justfile` and not `--working-directory`, the working directory will be the directory containing the justfile, not the directory in which the command was invoked.
-
-To use the current working directory instead, use `#!/usr/bin/env just --working-directory . --justfile`.
-
+Without `--working-directory`, `just` will change its working directory to the one containing the argument to `--justfile`. If you'd prefer to leave the working directory unchanged, use `#!/usr/bin/env just --working-directory . --justfile`.
 
 == Frequently Asked Questions
 

--- a/README.adoc
+++ b/README.adoc
@@ -653,9 +653,9 @@ $ just foo/build
 $ just foo/
 ```
 
-=== Standalone Scripts
+=== Just Scripts
 
-By adding a shebang line to the top of a justfile and making it executable, `just` can be used as an interpreter for standalone scripts:
+By adding a shebang line to the top of a justfile and making it executable, `just` can be used as an interpreter for scripts:
 
 ```sh
 $ cat > script <<EOF

--- a/README.adoc
+++ b/README.adoc
@@ -653,6 +653,31 @@ $ just foo/build
 $ just foo/
 ```
 
+=== Just scripts
+
+Just can be used as an interpreter for standalone, executable scripts.
+
+To do so, add a suitable shebang at the top of a justfile and make it executable:
+
+```sh
+$ cat > script <<EOF
+#!/usr/bin/env just --justfile
+foo:
+  echo foo
+EOF
+$ chmod +x script
+$ ./justfile
+echo foo
+foo
+```
+
+When a script with a shebang is run, the system supplies the path to the script as an argument to the command in the shebang. So, with a shebang of `#!/usr/bin/env just --justfile`, the command will be `/usr/bin/env just --justfile PATH_TO_SCRIPT`, which allows `just` to location the `justfile`. The shebang line itself starts with a `#`, so will be ignored as a comment.
+
+Note that when `just` is invoked with `--justfile` and not `--working-directory`, the working directory will be the directory containing the justfile, not the directory in which the command was invoked.
+
+To use the current working directory as the working directory instead, use `#!/usr/bin/env just --working-directory . --justfile`.
+
+
 == Frequently Asked Questions
 
 === What are the idiosyncrasies of make that just avoids?

--- a/README.adoc
+++ b/README.adoc
@@ -655,7 +655,7 @@ $ just foo/
 
 === Standalone Scripts
 
-By adding a shebang line to the top of a justfile and making it executable, you can use `just` as an interpreter for standalone scripts:
+By adding a shebang line to the top of a justfile and making it executable, `just` can be used as an interpreter for standalone scripts:
 
 ```sh
 $ cat > script <<EOF
@@ -670,7 +670,7 @@ echo foo
 foo
 ```
 
-When a script with a shebang is run, the system supplies the path to the script as an argument to the command in the shebang. So, with a shebang of `#!/usr/bin/env just --justfile`, the command will be `/usr/bin/env just --justfile PATH_TO_SCRIPT`. This allows `just` to locate and execute `justfile`. The shebang line itself will be ignored as a comment during execution.
+When a script with a shebang is executed, the system supplies the path to the script as an argument to the command in the shebang. So, with a shebang of `#!/usr/bin/env just --justfile`, the command will be `/usr/bin/env just --justfile PATH_TO_SCRIPT`.
 
 With the above shebang, `just` will change its working directory to the location of the script. If you'd rather leave the working directory unchanged, use `#!/usr/bin/env just --working-directory . --justfile`.
 

--- a/README.adoc
+++ b/README.adoc
@@ -653,7 +653,7 @@ $ just foo/build
 $ just foo/
 ```
 
-=== Just scripts
+=== Standalone Scripts
 
 Just can be used as an interpreter for standalone executable scripts.
 

--- a/justfile
+++ b/justfile
@@ -1,3 +1,7 @@
+#!/usr/bin/env just --justfile
+# ^ A shebang isn't required, but allows a justfile to be executed
+#   like a script, with `./justfile test`, for example.
+
 bt='0'
 
 export RUST_BACKTRACE=bt

--- a/src/compilation_error.rs
+++ b/src/compilation_error.rs
@@ -62,7 +62,6 @@ pub enum CompilationErrorKind<'a> {
   MixedLeadingWhitespace {
     whitespace: &'a str,
   },
-  OuterShebang,
   ParameterFollowsVariadicParameter {
     parameter: &'a str,
   },
@@ -228,9 +227,6 @@ impl<'a> Display for CompilationError<'a> {
           show_whitespace(expected),
           show_whitespace(found)
         )?;
-      }
-      OuterShebang => {
-        writeln!(f, "`#!` is reserved syntax outside of recipes")?;
       }
       UnknownDependency { recipe, unknown } => {
         writeln!(

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -135,7 +135,7 @@ impl<'a> Lexer<'a> {
       static ref BACKTICK: Regex = token(r"`[^`\n\r]*`");
       static ref COLON: Regex = token(r":");
       static ref COMMA: Regex = token(r",");
-      static ref COMMENT: Regex = token(r"#([^!\n\r][^\n\r]*)?\r?$");
+      static ref COMMENT: Regex = token(r"#([^\n\r][^\n\r]*)?\r?$");
       static ref EOF: Regex = token(r"\z");
       static ref EOL: Regex = token(r"\n|\r\n");
       static ref EQUALS: Regex = token(r"=");
@@ -322,8 +322,6 @@ impl<'a> Lexer<'a> {
           return Err(self.error(UnterminatedString));
         }
         (prefix, &self.rest[start..content_end + 1], StringToken)
-      } else if self.rest.starts_with("#!") {
-        return Err(self.error(OuterShebang));
       } else {
         return Err(self.error(UnknownStartOfToken));
       };
@@ -340,7 +338,7 @@ impl<'a> Lexer<'a> {
           _ => {
             return Err(last.error(Internal {
               message: format!("zero length token: {:?}", last),
-            }))
+            }));
           }
         }
       }
@@ -645,16 +643,6 @@ c: b
     column: 0,
     width:  None,
     kind:   InconsistentLeadingWhitespace{expected: "\t\t", found: "\t  "},
-  }
-
-  error_test! {
-    name: tokenize_outer_shebang,
-    input: "#!/usr/bin/env bash",
-    index:  0,
-    line:   0,
-    column: 0,
-    width:  None,
-    kind:   OuterShebang,
   }
 
   error_test! {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -579,28 +579,6 @@ wut:
 }
 
 integration_test! {
-  name:     outer_shebang,
-  justfile: r#"#!/lol/wut
-export FOO = "a"
-baz = "c"
-export BAR = "b"
-export ABC = FOO + BAR + baz
-
-wut:
-  #!/bin/sh
-  echo $FOO $BAR $ABC
-"#,
-  args:     (),
-  stdout:   "",
-  stderr:   "error: `#!` is reserved syntax outside of recipes
-  |
-1 | #!/lol/wut
-  | ^
-",
-  status:   EXIT_FAILURE,
-}
-
-integration_test! {
   name:     export_shebang,
   justfile: r#"
 export FOO = "a"


### PR DESCRIPTION
This was long overdue, since it was really just a matter of removing code.

With this change, justfiles can be used as scripts. Just write a justfile with a shebang line on top:

```make
#!/usr/bin/env just --justfile

foo:
  echo foo
```

and you can do:

```sh
$ ./justfile
echo foo
foo
```

You can use a shebang like this to avoid changing directories:

```
#!/usr/bin/env just --working-directory ./ --justfile
```

Fixes #367.