### PR TITLE
Omit aliases that begin with `_` from --list`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -608,7 +608,7 @@ Run `just --help` to see all the options.
 
 === Private Recipes
 
-Recipes whose name starts with a `_` are omitted from `just --list`:
+Recipes and aliases whose name starts with a `_` are omitted from `just --list`:
 
 ```make
 test: _test-helper

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -4,6 +4,7 @@ pub struct Alias<'a> {
   pub name: &'a str,
   pub target: &'a str,
   pub line_number: usize,
+  pub private: bool,
 }
 
 impl<'a> Display for Alias<'a> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -372,6 +372,7 @@ impl<'a> Parser<'a> {
       Alias {
         name: name.lexeme,
         line_number: name.line,
+        private: name.lexeme.starts_with('_'),
         target,
       },
     );

--- a/src/run.rs
+++ b/src/run.rs
@@ -358,6 +358,10 @@ pub fn run() {
     // Construct a target to alias map.
     let mut recipe_aliases: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
     for alias in justfile.aliases.values() {
+      if alias.private {
+        continue;
+      }
+
       if !recipe_aliases.contains_key(alias.target) {
         recipe_aliases.insert(alias.target, vec![alias.name]);
       } else {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -133,6 +133,17 @@ integration_test! {
 }
 
 integration_test! {
+  name: alias_listing_private,
+  justfile: "foo PARAM='foo':\n  echo {{PARAM}}\nalias _f = foo",
+  args: ("--list"),
+  stdout: "Available recipes:
+    foo PARAM='foo'
+",
+  stderr: "",
+  status: EXIT_SUCCESS,
+}
+
+integration_test! {
   name: alias,
   justfile: "foo:\n  echo foo\nalias f = foo",
   args: ("f"),


### PR DESCRIPTION
It seems reasonable to treat aliases that start with `_` as private, the same as recipes.