### PR TITLE
Allow arbitrary expressions as default arguments

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -63,6 +63,7 @@ value         : NAME '(' arguments? ')'
               | RAW_STRING
               | BACKTICK
               | NAME
+              | '(' expression ')'
 
 arguments     : expression ',' arguments
               | expression ','?
@@ -70,8 +71,7 @@ arguments     : expression ',' arguments
 recipe        : '@'? NAME parameter* ('+' parameter)? ':' dependencies? body?
 
 parameter     : NAME
-              | NAME '=' STRING
-              | NAME '=' RAW_STRING
+              | NAME '=' value
 
 dependencies  : NAME+
 

--- a/README.adoc
+++ b/README.adoc
@@ -480,7 +480,9 @@ cd my-awesome-project && make
 Parameters may have default values:
 
 ```make
-test target tests='all':
+default = 'all'
+
+test target tests=default:
     @echo 'Testing {{target}}:{{tests}}...'
     ./test --tests {{tests}} {{target}}
 ```
@@ -499,6 +501,15 @@ Or supplied:
 $ just test server unit
 Testing server:unit...
 ./test --tests unit server
+```
+
+Default values may be arbitrary expressions, but concatinations must be quoted, like so:
+
+```make
+arch = "wasm"
+
+test triple=(arch + "-unknown-unknown"):
+  ./test {{triple}}
 ```
 
 The last parameter of a recipe may be variadic, indicated with a `+` before the argument name:

--- a/README.adoc
+++ b/README.adoc
@@ -503,7 +503,7 @@ Testing server:unit...
 ./test --tests unit server
 ```
 
-Default values may be arbitrary expressions, but concatinations must be quoted, like so:
+Default values may be arbitrary expressions, but concatenations must be parenthesized:
 
 ```make
 arch = "wasm"

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -1,5 +1,6 @@
 use crate::common::*;
 
+#[derive(Debug)]
 pub struct Alias<'a> {
   pub name: &'a str,
   pub target: &'a str,

--- a/src/assignment_evaluator.rs
+++ b/src/assignment_evaluator.rs
@@ -83,7 +83,7 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
     Ok(())
   }
 
-  fn evaluate_expression(
+  pub fn evaluate_expression(
     &mut self,
     expression: &Expression<'a>,
     arguments: &BTreeMap<&str, Cow<str>>,
@@ -120,7 +120,7 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
         };
         evaluate_function(token, name, &context, &call_arguments)
       }
-      Expression::String { ref cooked_string } => Ok(cooked_string.cooked.clone()),
+      Expression::String { ref cooked_string } => Ok(cooked_string.cooked.to_string()),
       Expression::Backtick { raw, ref token } => {
         if self.dry_run {
           Ok(format!("`{}`", raw))
@@ -131,6 +131,7 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
       Expression::Concatination { ref lhs, ref rhs } => {
         Ok(self.evaluate_expression(lhs, arguments)? + &self.evaluate_expression(rhs, arguments)?)
       }
+      Expression::Group { ref expression } => self.evaluate_expression(&expression, arguments),
     }
   }
 

--- a/src/assignment_resolver.rs
+++ b/src/assignment_resolver.rs
@@ -56,7 +56,7 @@ impl<'a: 'b, 'b> AssignmentResolver<'a, 'b> {
   }
 
   fn resolve_expression(&mut self, expression: &Expression<'a>) -> CompilationResult<'a, ()> {
-    match *expression {
+    match expression {
       Expression::Variable { name, ref token } => {
         if self.evaluated.contains(name) {
           return Ok(());
@@ -83,6 +83,7 @@ impl<'a: 'b, 'b> AssignmentResolver<'a, 'b> {
         self.resolve_expression(rhs)?;
       }
       Expression::String { .. } | Expression::Backtick { .. } => {}
+      Expression::Group { expression } => self.resolve_expression(expression)?,
     }
     Ok(())
   }

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -1,5 +1,6 @@
 use crate::common::*;
 
+#[derive(Debug)]
 pub struct Justfile<'a> {
   pub recipes: BTreeMap<&'a str, Recipe<'a>>,
   pub assignments: BTreeMap<&'a str, Expression<'a>>,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -617,6 +617,12 @@ c: b
     "#$#$.",
   }
 
+  summary_test! {
+    multiple_recipes,
+    "a:\n  foo\nb:",
+    "N:$>^_$<N:.",
+  }
+
   error_test! {
     name:  tokenize_space_then_tab,
     input: "a:

--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -2,7 +2,7 @@ use crate::common::*;
 
 #[derive(PartialEq, Debug)]
 pub struct Parameter<'a> {
-  pub default: Option<String>,
+  pub default: Option<Expression<'a>>,
   pub name: &'a str,
   pub token: Token<'a>,
   pub variadic: bool,
@@ -16,11 +16,7 @@ impl<'a> Display for Parameter<'a> {
     }
     write!(f, "{}", color.parameter().paint(self.name))?;
     if let Some(ref default) = self.default {
-      let escaped = default
-        .chars()
-        .flat_map(char::escape_default)
-        .collect::<String>();;
-      write!(f, r#"='{}'"#, color.string().paint(&escaped))?;
+      write!(f, "={}", color.string().paint(&default.to_string()))?;
     }
     Ok(())
   }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,18 +49,6 @@ impl<'a> Parser<'a> {
     }
   }
 
-  /// I think this is used in an incoming PR:
-  ///   https://github.com/casey/just/issues/389
-  #[allow(dead_code)]
-  fn accept_any(&mut self, kinds: &[TokenKind]) -> Option<Token<'a>> {
-    for kind in kinds {
-      if self.peek(*kind) {
-        return self.tokens.next();
-      }
-    }
-    None
-  }
-
   fn accepted(&mut self, kind: TokenKind) -> bool {
     self.accept(kind).is_some()
   }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,6 +49,9 @@ impl<'a> Parser<'a> {
     }
   }
 
+  /// I think this is used in an incoming PR:
+  ///   https://github.com/casey/just/issues/389
+  #[allow(dead_code)]
   fn accept_any(&mut self, kinds: &[TokenKind]) -> Option<Token<'a>> {
     for kind in kinds {
       if self.peek(*kind) {
@@ -137,12 +140,7 @@ impl<'a> Parser<'a> {
 
       let default;
       if self.accepted(Equals) {
-        if let Some(string) = self.accept_any(&[StringToken, RawString]) {
-          default = Some(CookedString::new(&string)?.cooked);
-        } else {
-          let unexpected = self.tokens.next().unwrap();
-          return Err(self.unexpected_token(&unexpected, &[StringToken, RawString]));
-        }
+        default = Some(self.value()?);
       } else {
         default = None
       }
@@ -243,6 +241,10 @@ impl<'a> Parser<'a> {
       }
     }
 
+    while lines.last().map(Vec::is_empty).unwrap_or(false) {
+      lines.pop();
+    }
+
     self.recipes.insert(
       name.lexeme,
       Recipe {
@@ -262,9 +264,10 @@ impl<'a> Parser<'a> {
     Ok(())
   }
 
-  fn expression(&mut self) -> CompilationResult<'a, Expression<'a>> {
+  fn value(&mut self) -> CompilationResult<'a, Expression<'a>> {
     let first = self.tokens.next().unwrap();
-    let lhs = match first.kind {
+
+    match first.kind {
       Name => {
         if self.peek(ParenL) {
           if let Some(token) = self.expect(ParenL) {
@@ -274,30 +277,46 @@ impl<'a> Parser<'a> {
           if let Some(token) = self.expect(ParenR) {
             return Err(self.unexpected_token(&token, &[Name, StringToken, ParenR]));
           }
-          Expression::Call {
+          Ok(Expression::Call {
             name: first.lexeme,
             token: first,
             arguments,
-          }
+          })
         } else {
-          Expression::Variable {
+          Ok(Expression::Variable {
             name: first.lexeme,
             token: first,
-          }
+          })
         }
       }
-      Backtick => Expression::Backtick {
+      Backtick => Ok(Expression::Backtick {
         raw: &first.lexeme[1..first.lexeme.len() - 1],
         token: first,
-      },
-      RawString | StringToken => Expression::String {
+      }),
+      RawString | StringToken => Ok(Expression::String {
         cooked_string: CookedString::new(&first)?,
-      },
-      _ => return Err(self.unexpected_token(&first, &[Name, StringToken])),
-    };
+      }),
+      ParenL => {
+        let expression = self.expression()?;
+
+        if let Some(token) = self.expect(ParenR) {
+          return Err(self.unexpected_token(&token, &[ParenR]));
+        }
+
+        Ok(Expression::Group {
+          expression: Box::new(expression),
+        })
+      }
+      _ => Err(self.unexpected_token(&first, &[Name, StringToken])),
+    }
+  }
+
+  fn expression(&mut self) -> CompilationResult<'a, Expression<'a>> {
+    let lhs = self.value()?;
 
     if self.accepted(Plus) {
       let rhs = self.expression()?;
+
       Ok(Expression::Concatination {
         lhs: Box::new(lhs),
         rhs: Box::new(rhs),
@@ -463,6 +482,8 @@ impl<'a> Parser<'a> {
       }));
     }
 
+    AssignmentResolver::resolve_assignments(&self.assignments, &self.assignment_tokens)?;
+
     RecipeResolver::resolve_recipes(&self.recipes, &self.assignments, self.text)?;
 
     for recipe in self.recipes.values() {
@@ -485,8 +506,6 @@ impl<'a> Parser<'a> {
     }
 
     AliasResolver::resolve_aliases(&self.aliases, &self.recipes, &self.alias_tokens)?;
-
-    AssignmentResolver::resolve_assignments(&self.assignments, &self.assignment_tokens)?;
 
     Ok(Justfile {
       recipes: self.recipes,
@@ -513,8 +532,16 @@ mod test {
         let actual = format!("{:#}", justfile);
         if actual != expected {
           println!("got:\n\"{}\"\n", actual);
-          println!("\texpected:\n\"{}\"", expected);
+          println!("expected:\n\"{}\"", expected);
           assert_eq!(actual, expected);
+        }
+        println!("Re-parsing...");
+        let reparsed = parse_success(&actual);
+        let redumped = format!("{:#}", reparsed);
+        if redumped != actual {
+          println!("reparsed:\n\"{}\"\n", redumped);
+          println!("expected:\n\"{}\"", actual);
+          assert_eq!(redumped, actual);
         }
       }
     };
@@ -539,7 +566,18 @@ foo a="b\t":
 
 
   "#,
-    r#"foo a='b\t':"#,
+    r#"foo a="b\t":"#,
+  }
+
+  summary_test! {
+  parse_multiple,
+    r#"
+a:
+b:
+"#,
+    r#"a:
+
+b:"#,
   }
 
   summary_test! {
@@ -561,7 +599,7 @@ foo +a="Hello":
 
 
   "#,
-    r#"foo +a='Hello':"#,
+    r#"foo +a="Hello":"#,
   }
 
   summary_test! {
@@ -572,7 +610,7 @@ foo a='b\t':
 
 
   "#,
-    r#"foo a='b\\t':"#,
+    r#"foo a='b\t':"#,
   }
 
   summary_test! {
@@ -671,7 +709,7 @@ install:
 \t\treturn
 \tfi
 ",
-    "practicum = \"hello\"
+    "practicum = 'hello'
 
 install:
     #!/bin/sh
@@ -765,10 +803,76 @@ x = env_var('foo',)
 
 a:
   {{env_var_or_default('foo' + 'bar', 'baz',)}} {{env_var(env_var("baz"))}}"#,
-    r#"x = env_var("foo")
+    r#"x = env_var('foo')
 
 a:
-    {{env_var_or_default("foo" + "bar", "baz")}} {{env_var(env_var("baz"))}}"#,
+    {{env_var_or_default('foo' + 'bar', 'baz')}} {{env_var(env_var("baz"))}}"#,
+  }
+
+  summary_test! {
+    parameter_default_string,
+    r#"
+f x="abc":
+"#,
+    r#"f x="abc":"#,
+  }
+
+  summary_test! {
+    parameter_default_raw_string,
+    r#"
+f x='abc':
+"#,
+    r#"f x='abc':"#,
+  }
+
+  summary_test! {
+    parameter_default_backtick,
+    r#"
+f x=`echo hello`:
+"#,
+    r#"f x=`echo hello`:"#,
+  }
+
+  summary_test! {
+    parameter_default_concatination_string,
+    r#"
+f x=(`echo hello` + "foo"):
+"#,
+    r#"f x=(`echo hello` + "foo"):"#,
+  }
+
+  summary_test! {
+    parameter_default_concatination_variable,
+    r#"
+x = "10"
+f y=(`echo hello` + x) +z="foo":
+"#,
+    r#"x = "10"
+
+f y=(`echo hello` + x) +z="foo":"#,
+  }
+
+  summary_test! {
+    parameter_default_multiple,
+    r#"
+x = "10"
+f y=(`echo hello` + x) +z=("foo" + "bar"):
+"#,
+    r#"x = "10"
+
+f y=(`echo hello` + x) +z=("foo" + "bar"):"#,
+  }
+
+  summary_test! {
+    concatination_in_group,
+    "x = ('0' + '1')",
+    "x = ('0' + '1')",
+  }
+
+  summary_test! {
+    string_in_group,
+    "x = ('0'   )",
+    "x = ('0')",
   }
 
   compilation_error_test! {
@@ -848,7 +952,7 @@ a:
     line:   0,
     column: 10,
     width:  Some(1),
-    kind:   UnexpectedToken{expected: vec![StringToken, RawString], found: Eol},
+    kind:   UnexpectedToken{expected: vec![Name, StringToken], found: Eol},
   }
 
   compilation_error_test! {
@@ -858,27 +962,7 @@ a:
     line:   0,
     column: 10,
     width:  Some(0),
-    kind:   UnexpectedToken{expected: vec![StringToken, RawString], found: Eof},
-  }
-
-  compilation_error_test! {
-    name:   missing_default_colon,
-    input:  "hello arg=:",
-    index:  10,
-    line:   0,
-    column: 10,
-    width:  Some(1),
-    kind:   UnexpectedToken{expected: vec![StringToken, RawString], found: Colon},
-  }
-
-  compilation_error_test! {
-    name:   missing_default_backtick,
-    input:  "hello arg=`hello`",
-    index:  10,
-    line:   0,
-    column: 10,
-    width:  Some(7),
-    kind:   UnexpectedToken{expected: vec![StringToken, RawString], found: Backtick},
+    kind:   UnexpectedToken{expected: vec![Name, StringToken], found: Eof},
   }
 
   compilation_error_test! {
@@ -1064,5 +1148,34 @@ a:
     for justfile in justfiles {
       parse_success(&justfile);
     }
+  }
+
+  #[test]
+  fn empty_recipe_lines() {
+    let text = "a:";
+    let justfile = parse_success(&text);
+
+    assert_eq!(justfile.recipes["a"].lines.len(), 0);
+  }
+
+  #[test]
+  fn simple_recipe_lines() {
+    let text = "a:\n foo";
+    let justfile = parse_success(&text);
+
+    assert_eq!(justfile.recipes["a"].lines.len(), 1);
+  }
+
+  #[test]
+  fn complex_recipe_lines() {
+    let text = "a:
+  foo
+
+b:
+";
+
+    let justfile = parse_success(&text);
+
+    assert_eq!(justfile.recipes["a"].lines.len(), 1);
   }
 }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -18,7 +18,7 @@ use std::{
   path::Path,
 };
 
-use crate::{expression, fragment, justfile::Justfile, parser::Parser, recipe};
+use crate::{expression, fragment, justfile::Justfile, parameter, parser::Parser, recipe};
 
 pub fn summary(path: impl AsRef<Path>) -> Result<Result<Summary, String>, io::Error> {
   let path = path.as_ref();
@@ -83,6 +83,7 @@ pub struct Recipe {
   pub private: bool,
   pub quiet: bool,
   pub shebang: bool,
+  pub parameters: Vec<Parameter>,
 }
 
 impl Recipe {
@@ -93,7 +94,27 @@ impl Recipe {
       quiet: recipe.quiet,
       dependencies: recipe.dependencies.into_iter().map(str::to_owned).collect(),
       lines: recipe.lines.into_iter().map(Line::new).collect(),
+      parameters: recipe.parameters.into_iter().map(Parameter::new).collect(),
       aliases,
+    }
+  }
+}
+
+#[derive(Eq, PartialEq, Hash, Ord, PartialOrd, Debug, Clone)]
+pub struct Parameter {
+  pub variadic: bool,
+  pub name: String,
+  pub default: Option<Expression>,
+}
+
+impl Parameter {
+  fn new(parameter: parameter::Parameter) -> Parameter {
+    Parameter {
+      variadic: parameter.variadic,
+      name: parameter.name.to_owned(),
+      default: parameter
+        .default
+        .map(|expression| Expression::new(expression)),
     }
   }
 }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -46,7 +46,7 @@ impl Summary {
     for alias in justfile.aliases.values() {
       aliases
         .entry(alias.target)
-        .or_insert(Vec::new())
+        .or_insert_with(Vec::new)
         .push(alias.name.to_string());
     }
 
@@ -57,7 +57,7 @@ impl Summary {
         .map(|(name, recipe)| {
           (
             name.to_string(),
-            Recipe::new(recipe, aliases.remove(name).unwrap_or(Vec::new())),
+            Recipe::new(recipe, aliases.remove(name).unwrap_or_default()),
           )
         })
         .collect(),
@@ -184,11 +184,12 @@ impl Expression {
         rhs: Box::new(Expression::new(*rhs)),
       },
       String { cooked_string } => Expression::String {
-        text: cooked_string.cooked,
+        text: cooked_string.cooked.to_string(),
       },
       Variable { name, .. } => Expression::Variable {
         name: name.to_owned(),
       },
+      Group { expression } => Expression::new(*expression),
     }
   }
 }

--- a/tests/interrupts.rs
+++ b/tests/interrupts.rs
@@ -1,7 +1,6 @@
 use executable_path::executable_path;
 use std::{
   process::Command,
-  thread,
   time::{Duration, Instant},
 };
 use tempdir::TempDir;
@@ -33,7 +32,7 @@ fn interrupt_test(justfile: &str) {
     .spawn()
     .expect("just invocation failed");
 
-  thread::sleep(Duration::new(1, 0));
+  while start.elapsed() < Duration::from_millis(500) {}
 
   kill(child.id());
 
@@ -41,11 +40,11 @@ fn interrupt_test(justfile: &str) {
 
   let elapsed = start.elapsed();
 
-  if elapsed > Duration::new(4, 0) {
+  if elapsed > Duration::from_secs(2) {
     panic!("process returned too late: {:?}", elapsed);
   }
 
-  if elapsed < Duration::new(1, 0) {
+  if elapsed < Duration::from_millis(100) {
     panic!("process returned too early : {:?}", elapsed);
   }
 
@@ -59,7 +58,7 @@ fn interrupt_shebang() {
     "
 default:
   #!/usr/bin/env sh
-  sleep 2
+  sleep 1
 ",
   );
 }
@@ -70,7 +69,7 @@ fn interrupt_line() {
   interrupt_test(
     "
 default:
-  @sleep 2
+  @sleep 1
 ",
   );
 }
@@ -80,7 +79,7 @@ default:
 fn interrupt_backtick() {
   interrupt_test(
     "
-foo = `sleep 2`
+foo = `sleep 1`
 
 default:
   @echo hello


### PR DESCRIPTION
Concatenation and variadic arguments conflict, since they both use `+`. To get around this, parenthesis are added to the language, and default arguments expressions that contain concatenations must be parenthesized.

Fixes #391 and #336. Also fixes #396, since it tests that all justfiles can be dumped and reparsed.