### PR TITLE
Make summary function non-generic

### DIFF
--- a/src/summary.rs
+++ b/src/summary.rs
@@ -20,9 +20,7 @@ use std::{
 
 use crate::{expression, fragment, justfile::Justfile, parameter, parser::Parser, recipe};
 
-pub fn summary(path: impl AsRef<Path>) -> Result<Result<Summary, String>, io::Error> {
-  let path = path.as_ref();
-
+pub fn summary(path: &Path) -> Result<Result<Summary, String>, io::Error> {
   let text = fs::read_to_string(path)?;
 
   match Parser::parse(&text) {


### PR DESCRIPTION
The summary function needs to take its arguments as non-generic types, so it can be consumed by further generic nonsense in Janus, the ecosystem-wide test tool.