### PR TITLE
Bump version: v0.4.1 -> v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.4.2] - 2019-04-12
+### Changed
+- Regex-based lexer replaced with much nicer character-at-a-time lexer (#406)
+
 ## [v0.4.1] - 2019-04-12
 ### Changed
 - Make summary function non-generic (#404)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "just"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "just"
-version     = "0.4.1"
+version     = "0.4.2"
 description = "🤖 Just a command runner"
 authors     = ["Casey Rodarmor <casey@rodarmor.com>"]
 license     = "CC0-1.0"

--- a/justfile
+++ b/justfile
@@ -39,10 +39,12 @@ watch COMMAND='test':
 version = `sed -En 's/version[[:space:]]*=[[:space:]]*"([^"]+)"/v\1/p' Cargo.toml | head -1`
 
 # publish to crates.io
-publish: lint clippy test
+publish-check: lint clippy test
 	git branch | grep '* master'
 	git diff --no-ext-diff --quiet --exit-code
 	grep {{version}} CHANGELOG.md
+
+publish: publish-check
 	cargo publish
 	git tag -a {{version}} -m 'Release {{version}}'
 	git push github {{version}}

--- a/src/run.rs
+++ b/src/run.rs
@@ -207,8 +207,7 @@ pub fn run() {
     let i = argument
       .char_indices()
       .skip(1)
-      .filter(|&(_, c)| c == '=')
-      .next()
+      .find(|&(_, c)| c == '=')
       .unwrap()
       .0;
 


### PR DESCRIPTION
Bump version to v0.4.2. The only new change is the new lexer.