### PR TITLE
Pass stdin handle to backtick process

### DIFF
--- a/src/assignment_evaluator.rs
+++ b/src/assignment_evaluator.rs
@@ -141,9 +141,11 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
   ) -> RunResult<'a, String> {
     let mut cmd = Command::new(self.shell);
 
+    cmd.arg("-cu").arg(raw);
+
     cmd.export_environment_variables(self.scope, dotenv, self.exports)?;
 
-    cmd.arg("-cu").arg(raw);
+    cmd.stdin(process::Stdio::inherit());
 
     cmd.stderr(if self.quiet {
       process::Stdio::null()


### PR DESCRIPTION
Backtick processes are launched (via the `brev` crate) using `Command::output`, which by default prevents stdin from being inherited.

This diff passes stdin through. This allows backtick commands to read from stdin, and so fixes #376 and #374.

In particular, this allows:

```make
password := `read PASSWORD && echo $PASSWORD`

ssh:
  echo {{password}}
```

To support this change, integration tests are modified to take an additional string argument, which is written to the `just` child process's stdin. Existing tests are passed `""`, and a few tests have been added that read from stdin and echo it, to make sure that it actually works.

cc: @slisznia 