### PR TITLE
Reduce usage of brev

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -509,7 +509,6 @@ impl<'a> Parser<'a> {
 mod test {
   use super::*;
   use crate::testing::parse_success;
-  use brev;
 
   macro_rules! summary_test {
     ($name:ident, $input:expr, $expected:expr $(,)*) => {
@@ -1127,7 +1126,7 @@ f y=(`echo hello` + x) +z=("foo" + "bar"):"#,
     let mut justfiles = vec![];
     let mut current = None;
 
-    for line in brev::slurp("README.adoc").lines() {
+    for line in fs::read_to_string("README.adoc").unwrap().lines() {
       if let Some(mut justfile) = current {
         if line == "```" {
           justfiles.push(justfile);

--- a/src/run.rs
+++ b/src/run.rs
@@ -22,18 +22,6 @@ fn edit<P: convert::AsRef<ffi::OsStr>>(path: P) -> ! {
   }
 }
 
-trait Slurp {
-  fn slurp(&mut self) -> Result<String, io::Error>;
-}
-
-impl Slurp for fs::File {
-  fn slurp(&mut self) -> io::Result<String> {
-    let mut destination = String::new();
-    self.read_to_string(&mut destination)?;
-    Ok(destination)
-  }
-}
-
 pub fn run() {
   #[cfg(windows)]
   enable_ansi_support().ok();
@@ -274,9 +262,7 @@ pub fn run() {
       edit(justfile);
     }
 
-    text = fs::File::open(justfile)
-      .unwrap_or_else(|error| die!("Error opening justfile: {}", error))
-      .slurp()
+    text = fs::read_to_string(justfile)
       .unwrap_or_else(|error| die!("Error reading justfile: {}", error));
 
     if let Err(error) = env::set_current_dir(&directory) {
@@ -323,10 +309,8 @@ pub fn run() {
       edit(name);
     }
 
-    text = fs::File::open(name)
-      .unwrap_or_else(|error| die!("Error opening justfile: {}", error))
-      .slurp()
-      .unwrap_or_else(|error| die!("Error reading justfile: {}", error));
+    text =
+      fs::read_to_string(name).unwrap_or_else(|error| die!("Error reading justfile: {}", error));
   }
 
   let justfile = Parser::parse(&text).unwrap_or_else(|error| {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -56,11 +56,11 @@ fn integration_test(
 
   let mut justfile_path = tmp.path().to_path_buf();
   justfile_path.push("justfile");
-  brev::dump(justfile_path, justfile);
+  fs::write(justfile_path, justfile).unwrap();
 
   let mut dotenv_path = tmp.path().to_path_buf();
   dotenv_path.push(".env");
-  brev::dump(dotenv_path, "DOTENV_KEY=dotenv-value");
+  fs::write(dotenv_path, "DOTENV_KEY=dotenv-value").unwrap();
 
   let mut child = Command::new(&executable_path("just"))
     .current_dir(tmp.path())

--- a/tests/interrupts.rs
+++ b/tests/interrupts.rs
@@ -2,6 +2,7 @@
 mod unix {
   use executable_path::executable_path;
   use std::{
+    fs,
     process::Command,
     time::{Duration, Instant},
   };
@@ -23,7 +24,7 @@ mod unix {
 
     let mut justfile_path = tmp.path().to_path_buf();
     justfile_path.push("justfile");
-    brev::dump(justfile_path, justfile);
+    fs::write(justfile_path, justfile).unwrap();
 
     let start = Instant::now();
 

--- a/tests/invocation_directory.rs
+++ b/tests/invocation_directory.rs
@@ -1,7 +1,5 @@
 use executable_path::executable_path;
-use std::path::Path;
-use std::process;
-use std::str;
+use std::{fs, path::Path, process, str};
 use tempdir::TempDir;
 
 #[cfg(unix)]
@@ -34,14 +32,15 @@ fn test_invocation_directory() {
 
   let mut justfile_path = tmp.path().to_path_buf();
   justfile_path.push("justfile");
-  brev::dump(
+  fs::write(
     justfile_path,
     "default:\n @cd {{invocation_directory()}}\n @echo {{invocation_directory()}}",
-  );
+  )
+  .unwrap();
 
   let mut subdir = tmp.path().to_path_buf();
   subdir.push("subdir");
-  brev::mkdir(&subdir);
+  fs::create_dir(&subdir).unwrap();
 
   let output = process::Command::new(&executable_path("just"))
     .current_dir(&subdir)

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -26,7 +26,7 @@ fn test_justfile_search() {
     .expect("test justfile search: failed to create temporary directory");
   let mut path = tmp.path().to_path_buf();
   path.push("justfile");
-  brev::dump(&path, "default:\n\techo ok");
+  fs::write(&path, "default:\n\techo ok").unwrap();
   path.pop();
 
   path.push("a");
@@ -47,7 +47,7 @@ fn test_capitalized_justfile_search() {
     .expect("test justfile search: failed to create temporary directory");
   let mut path = tmp.path().to_path_buf();
   path.push("Justfile");
-  brev::dump(&path, "default:\n\techo ok");
+  fs::write(&path, "default:\n\techo ok").unwrap();
   path.pop();
 
   path.push("a");
@@ -68,16 +68,16 @@ fn test_capitalization_priority() {
     .expect("test justfile search: failed to create temporary directory");
   let mut path = tmp.path().to_path_buf();
   path.push("justfile");
-  brev::dump(&path, "default:\n\techo ok");
+  fs::write(&path, "default:\n\techo ok").unwrap();
   path.pop();
   path.push("Justfile");
-  brev::dump(&path, "default:\n\techo fail");
+  fs::write(&path, "default:\n\techo fail").unwrap();
   path.pop();
 
   // if we see "default\n\techo fail" in `justfile` then we're running
   // in a case insensitive filesystem, so just bail
   path.push("justfile");
-  if brev::slurp(&path) == "default:\n\techo fail" {
+  if fs::read_to_string(&path).unwrap() == "default:\n\techo fail" {
     return;
   }
   path.pop();
@@ -100,14 +100,14 @@ fn test_upwards_path_argument() {
     .expect("test justfile search: failed to create temporary directory");
   let mut path = tmp.path().to_path_buf();
   path.push("justfile");
-  brev::dump(&path, "default:\n\techo ok");
+  fs::write(&path, "default:\n\techo ok").unwrap();
   path.pop();
 
   path.push("a");
   fs::create_dir(&path).expect("test justfile search: failed to create intermediary directory");
 
   path.push("justfile");
-  brev::dump(&path, "default:\n\techo bad");
+  fs::write(&path, "default:\n\techo bad").unwrap();
   path.pop();
 
   search_test(&path, &["../"]);
@@ -120,14 +120,14 @@ fn test_downwards_path_argument() {
     .expect("test justfile search: failed to create temporary directory");
   let mut path = tmp.path().to_path_buf();
   path.push("justfile");
-  brev::dump(&path, "default:\n\techo bad");
+  fs::write(&path, "default:\n\techo bad").unwrap();
   path.pop();
 
   path.push("a");
   fs::create_dir(&path).expect("test justfile search: failed to create intermediary directory");
 
   path.push("justfile");
-  brev::dump(&path, "default:\n\techo ok");
+  fs::write(&path, "default:\n\techo ok").unwrap();
   path.pop();
   path.pop();
 


### PR DESCRIPTION
`fs::write` and `fs::read_to_string` obviate the need for `brev::dump` and `brev::slurp`. `brev::output` is still useful though.