### PR TITLE
Mention Make’s “phony target” workaround in the comparison

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -76,7 +76,7 @@ On MacOS, `just` can be installed using the https://brew.sh[Homebrew package man
 
 === Scoop
 
-On Windows, `just` can be installed using the https://scoop.sh[Scoop package manager]. Install Scoop using the instractions https://scoop.sh/[here], then run:
+On Windows, `just` can be installed using the https://scoop.sh[Scoop package manager]. Install Scoop using the instructions https://scoop.sh/[here], then run:
 
 ```powershell
 scoop install just
@@ -825,11 +825,11 @@ $ make test
 make: `test' is up to date.
 ```
 
-Make sees the recipe `test` and assumes that it produces a file called `test`. It then sees that this file exists and thus assumes that the recipe doesn't need to be run.
+Make assumes that the `test` recipe produces a file called `test`. Since this file exists and the recipe has no other dependencies, it thinks that it doesn't actually need to run the recipe.
 
-To be fair, this behavior is desirable when using make as a build system, but not when using it as a command runner. You can tell make to disable this behavior for specific targets using its link:https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html[`.PHONY` special built-in target name], but the syntax is verbose and can be hard to remember. The explicit list of phony targets, written separately from the recipe definitions, also introduces a risk of accidentally defining a new target without this behavior. In just, all recipes are automatically treated as if they had “phony targets”.
+To be fair, this behavior is desirable when using make as a build system, but not when using it as a command runner. You can disable this behavior for specific targets using make's built-in link:https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html[`.PHONY` target name], but the syntax is verbose and can be hard to remember. The explicit list of phony targets, written separately from the recipe definitions, also introduces the risk of accidentally defining a new non-phony target. In `just`, all recipes are treated as if they were phony.
 
-Other examples of make’s idiosyncrasies include having to understand the difference between `=` and `:=` assignment, the confusing error messages that can be produced if you mess up your makefile, having to use `$$` to write recipes that use environment variables, and incompatibilites between different flavors of make.
+Other examples of make’s idiosyncrasies include the difference between `=` and `:=` in assignments, the confusing error messages that are produced if you mess up your makefile, needing `$$` to use environment variables in recipes, and incompatibilities between different flavors of make.
 
 === What's the relationship between just and cargo build scripts?
 

--- a/README.adoc
+++ b/README.adoc
@@ -827,9 +827,9 @@ make: `test' is up to date.
 
 Make sees the recipe `test` and assumes that it produces a file called `test`. It then sees that this file exists and thus assumes that the recipe doesn't need to be run.
 
-To be fair, this behavior is desirable when using make as a build system, but not when using it as a command runner.
+To be fair, this behavior is desirable when using make as a build system, but not when using it as a command runner. You can tell make to disable this behavior for specific targets using its link:https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html[`.PHONY` special built-in target name], but the syntax is verbose and can be hard to remember. The explicit list of phony targets, written separately from the recipe definitions, also introduces a risk of accidentally defining a new target without this behavior. In just, all recipes are automatically treated as if they had “phony targets”.
 
-Some other examples include having to understand the difference between `=` and `:=` assignment, the confusing error messages that can be produced if you mess up your makefile, having to use `$$` to write recipes that use environment variables, and incompatibilites between different flavors of make.
+Other examples of make’s idiosyncrasies include having to understand the difference between `=` and `:=` assignment, the confusing error messages that can be produced if you mess up your makefile, having to use `$$` to write recipes that use environment variables, and incompatibilites between different flavors of make.
 
 === What's the relationship between just and cargo build scripts?
 

--- a/README.adoc
+++ b/README.adoc
@@ -807,29 +807,29 @@ Before merging a particularly large or gruesome change, Janus should be run to m
 
 == Frequently Asked Questions
 
-=== What are the idiosyncrasies of make that just avoids?
+=== What are the idiosyncrasies of Make that Just avoids?
 
-Make has some behaviors which are either confusing, complicated, or make it unsuitable for use as a general command runner.
+Make has some behaviors which are confusing, complicated, or make it unsuitable for use as a general command runner.
 
-One example is that sometimes make won't run the commands in a recipe. For example, if you have a file called `test` and the following makefile that runs it:
+One example is that under some circumstances, Make won't actually run the commands in a recipe. For example, if you have a file called `test` and the following makefile:
 
 ```make
 test:
   ./test
 ```
 
-Make will actually refuse to run it:
+Make will refuse to run your tests:
 
 ```sh
 $ make test
 make: `test' is up to date.
 ```
 
-Make assumes that the `test` recipe produces a file called `test`. Since this file exists and the recipe has no other dependencies, it thinks that it doesn't actually need to run the recipe.
+Make assumes that the `test` recipe produces a file called `test`. Since this file exists and the recipe has no other dependencies, Make thinks that it doesn't have anything to do and exits.
 
-To be fair, this behavior is desirable when using make as a build system, but not when using it as a command runner. You can disable this behavior for specific targets using make's built-in link:https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html[`.PHONY` target name], but the syntax is verbose and can be hard to remember. The explicit list of phony targets, written separately from the recipe definitions, also introduces the risk of accidentally defining a new non-phony target. In `just`, all recipes are treated as if they were phony.
+To be fair, this behavior is desirable when using Make as a build system, but not when using it as a command runner. You can disable this behavior for specific targets using Make's built-in link:https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html[`.PHONY` target name], but the syntax is verbose and can be hard to remember. The explicit list of phony targets, written separately from the recipe definitions, also introduces the risk of accidentally defining a new non-phony target. In `just`, all recipes are treated as if they were phony.
 
-Other examples of make’s idiosyncrasies include the difference between `=` and `:=` in assignments, the confusing error messages that are produced if you mess up your makefile, needing `$$` to use environment variables in recipes, and incompatibilities between different flavors of make.
+Other examples of Make’s idiosyncrasies include the difference between `=` and `:=` in assignments, the confusing error messages that are produced if you mess up your makefile, needing `$$` to use environment variables in recipes, and incompatibilities between different flavors of Make.
 
 === What's the relationship between just and cargo build scripts?
 


### PR DESCRIPTION
I think mentioning `.PHONY` is necessary to be fair to Make. Someone might decide that using phony targets in Make is the best solution for them (e.g. due to portability), despite Make having worse error messages and so on, and we shouldn’t hide this option from them. But I tried to mention the reasons one might prefer Just’s implementation of phony targets.