### PR TITLE
Make `--show` work with aliases

### DIFF
--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -91,16 +91,7 @@ impl<'a> Justfile<'a> where {
     let mut rest = arguments;
 
     while let Some((argument, mut tail)) = rest.split_first() {
-      let get_recipe = |name| {
-        if let Some(recipe) = self.recipes.get(name) {
-          Some(recipe)
-        } else if let Some(alias) = self.aliases.get(name) {
-          self.recipes.get(alias.target)
-        } else {
-          None
-        }
-      };
-      if let Some(recipe) = get_recipe(argument) {
+      if let Some(recipe) = self.get_recipe(argument) {
         if recipe.parameters.is_empty() {
           grouped.push((recipe, &tail[0..0]));
         } else {
@@ -148,6 +139,16 @@ impl<'a> Justfile<'a> where {
     }
 
     Ok(())
+  }
+
+  pub fn get_recipe(&self, name: &str) -> Option<&Recipe<'a>> {
+    if let Some(recipe) = self.recipes.get(name) {
+      Some(recipe)
+    } else if let Some(alias) = self.aliases.get(name) {
+      self.recipes.get(alias.target)
+    } else {
+      None
+    }
   }
 
   fn run_recipe<'b>(

--- a/src/run.rs
+++ b/src/run.rs
@@ -449,7 +449,7 @@ pub fn run() {
   }
 
   if let Some(name) = matches.value_of("SHOW") {
-    match justfile.recipes.get(name) {
+    match justfile.get_recipe(name) {
       Some(recipe) => {
         println!("{}", recipe);
         process::exit(EXIT_SUCCESS);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -273,6 +273,18 @@ integration_test! {
 }
 
 integration_test! {
+  name: alias_show,
+  justfile: "foo:\n  bar\nalias f := foo",
+  args: ("--show", "f"),
+  stdin:  "",
+  stdout: "foo:
+  bar
+",
+  stderr: "",
+  status: EXIT_SUCCESS,
+}
+
+integration_test! {
   name:     default,
   justfile: "default:\n echo hello\nother: \n echo bar",
   args:     (),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -274,14 +274,28 @@ integration_test! {
 
 integration_test! {
   name: alias_show,
-  justfile: "foo:\n  bar\nalias f := foo",
+  justfile: "foo:\n    bar\nalias f := foo",
   args: ("--show", "f"),
   stdin:  "",
   stdout: "foo:
-  bar
+    bar
 ",
   stderr: "",
   status: EXIT_SUCCESS,
+}
+
+integration_test! {
+  name: alias_show_missing_target,
+  justfile: "alias f := foo",
+  args: ("--show", "f"),
+  stdin:  "",
+  stdout: "",
+  stderr: "error: Alias `f` has an unknown target `foo`
+  |
+1 | alias f := foo
+  |       ^
+",
+  status: EXIT_FAILURE,
 }
 
 integration_test! {


### PR DESCRIPTION
Fixes #420. I opened issue #442 for also displaying the alias itself, which should be done in a follow-up PR.