### PR TITLE
Improve `done` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -51,11 +51,11 @@ publish: publish-check
 
 # clean up feature branch BRANCH
 done BRANCH:
-	git checkout {{BRANCH}}
-	git pull --rebase github master
 	git checkout master
+	git diff --no-ext-diff --quiet --exit-code
 	git pull --rebase github master
-	git branch -d {{BRANCH}}
+	git diff --no-ext-diff --quiet --exit-code {{BRANCH}}
+	git branch -D {{BRANCH}}
 
 # install just from crates.io
 install:


### PR DESCRIPTION
The old version would often fail to rebase the soon-to-be-deleted feature branch if it had been squash-merged into master.

This version just checks that the up-to-date master branch matches and uses `-D` to delete the feature branch. This guarantees that we don't lose any work, and avoids bad rebases from squash merges to master.