### PR TITLE
Display alias with `--show NAME` if one exists

### DIFF
--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -141,6 +141,10 @@ impl<'a> Justfile<'a> where {
     Ok(())
   }
 
+  pub fn get_alias(&self, name: &str) -> Option<&Alias> {
+    self.aliases.get(name)
+  }
+
   pub fn get_recipe(&self, name: &str) -> Option<&Recipe<'a>> {
     if let Some(recipe) = self.recipes.get(name) {
       Some(recipe)

--- a/src/run.rs
+++ b/src/run.rs
@@ -446,18 +446,21 @@ pub fn run() {
   }
 
   if let Some(name) = matches.value_of("SHOW") {
-    match justfile.get_recipe(name) {
-      Some(recipe) => {
-        println!("{}", recipe);
-        process::exit(EXIT_SUCCESS);
+    if let Some(alias) = justfile.get_alias(name) {
+      let recipe = justfile.get_recipe(alias.target).unwrap();
+      println!("{}", alias);
+      println!("{}", recipe);
+      process::exit(EXIT_SUCCESS);
+    }
+    if let Some(recipe) = justfile.get_recipe(name) {
+      println!("{}", recipe);
+      process::exit(EXIT_SUCCESS);
+    } else {
+      eprintln!("Justfile does not contain recipe `{}`.", name);
+      if let Some(suggestion) = justfile.suggest(name) {
+        eprintln!("Did you mean `{}`?", suggestion);
       }
-      None => {
-        eprintln!("Justfile does not contain recipe `{}`.", name);
-        if let Some(suggestion) = justfile.suggest(name) {
-          eprintln!("Did you mean `{}`?", suggestion);
-        }
-        process::exit(EXIT_FAILURE)
-      }
+      process::exit(EXIT_FAILURE)
     }
   }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -276,7 +276,7 @@ integration_test! {
   justfile: "foo:\n    bar\nalias f := foo",
   args: ("--show", "f"),
   stdin:  "",
-  stdout: "foo:
+  stdout: "alias f := foo\nfoo:
     bar
 ",
   stderr: "",


### PR DESCRIPTION
Given the following justfile:

    alias b := build
    build:
        echo 'Building!'

Just will show the alias along with the recipe:

    $ just --show b
    alias b := build
    build:
        echo 'Building!'

Fixes #442 