### PR TITLE
Add context to deprecation warnings

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -46,7 +46,7 @@ pub(crate) use crate::{
   recipe_context::RecipeContext, recipe_resolver::RecipeResolver, runtime_error::RuntimeError,
   search_error::SearchError, shebang::Shebang, state::State, string_literal::StringLiteral,
   token::Token, token_kind::TokenKind, use_color::UseColor, variables::Variables,
-  verbosity::Verbosity,
+  verbosity::Verbosity, warning::Warning,
 };
 
 pub(crate) type CompilationResult<'a, T> = Result<T, CompilationError<'a>>;

--- a/src/compilation_error.rs
+++ b/src/compilation_error.rs
@@ -1,6 +1,6 @@
 use crate::common::*;
 
-use crate::misc::{maybe_s, show_whitespace, write_error_context, Or};
+use crate::misc::{maybe_s, show_whitespace, write_message_context, Or};
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct CompilationError<'a> {
@@ -211,8 +211,9 @@ impl<'a> Display for CompilationError<'a> {
 
     write!(f, "{}", message.suffix())?;
 
-    write_error_context(
+    write_message_context(
       f,
+      Color::fmt(f).error(),
       self.text,
       self.offset,
       self.line,

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -6,7 +6,7 @@ pub(crate) struct Justfile<'a> {
   pub(crate) assignments: BTreeMap<&'a str, Expression<'a>>,
   pub(crate) exports: BTreeSet<&'a str>,
   pub(crate) aliases: BTreeMap<&'a str, Alias<'a>>,
-  pub(crate) deprecated_equals: bool,
+  pub(crate) warnings: Vec<Warning<'a>>,
 }
 
 impl<'a> Justfile<'a> where {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ mod token_kind;
 mod use_color;
 mod variables;
 mod verbosity;
+mod warning;
 
 pub use crate::run::run;
 

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -55,8 +55,9 @@ pub(crate) fn conjoin<T: Display>(
   Ok(())
 }
 
-pub(crate) fn write_error_context(
+pub(crate) fn write_message_context(
   f: &mut Formatter,
+  color: Color,
   text: &str,
   offset: usize,
   line: usize,
@@ -66,7 +67,6 @@ pub(crate) fn write_error_context(
   let width = if width == 0 { 1 } else { width };
 
   let line_number = line.ordinal();
-  let red = Color::fmt(f).error();
   match text.lines().nth(line) {
     Some(line) => {
       let mut i = 0;
@@ -102,10 +102,10 @@ pub(crate) fn write_error_context(
         " {0:1$}{2}{3:^<4$}{5}",
         "",
         space_column,
-        red.prefix(),
+        color.prefix(),
         "",
         space_width,
-        red.suffix()
+        color.suffix()
       )?;
     }
     None => {

--- a/src/run.rs
+++ b/src/run.rs
@@ -318,22 +318,12 @@ pub fn run() {
     }
   });
 
-  if justfile.deprecated_equals {
-    let warning = color.warning().stderr();
-    let message = color.message().stderr();
-
-    eprintln!(
-      "{}",
-      warning.paint(
-        "warning: `=` in assignments, exports, and aliases is being phased out on favor of `:=`"
-      )
-    );
-
-    eprintln!(
-      "{}",
-      message
-        .paint("Please see this issue for more details: https://github.com/casey/just/issues/379")
-    );
+  for warning in &justfile.warnings {
+    if color.stderr().active() {
+      eprintln!("{:#}", warning);
+    } else {
+      eprintln!("{}", warning);
+    }
   }
 
   if matches.is_present("SUMMARY") {

--- a/src/runtime_error.rs
+++ b/src/runtime_error.rs
@@ -1,6 +1,6 @@
 use crate::common::*;
 
-use crate::misc::{maybe_s, ticks, write_error_context, And, Or, Tick};
+use crate::misc::{maybe_s, ticks, write_message_context, And, Or, Tick};
 
 #[derive(Debug)]
 pub(crate) enum RuntimeError<'a> {
@@ -387,8 +387,9 @@ impl<'a> Display for RuntimeError<'a> {
     write!(f, "{}", message.suffix())?;
 
     if let Some(token) = error_token {
-      write_error_context(
+      write_message_context(
         f,
+        Color::fmt(f).error(),
         token.text,
         token.offset,
         token.line,

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -1,0 +1,56 @@
+use crate::common::*;
+use crate::misc::write_message_context;
+
+use Warning::*;
+
+#[derive(Debug)]
+pub(crate) enum Warning<'a> {
+  DeprecatedEquals { equals: Token<'a> },
+}
+
+impl Warning<'_> {
+  fn context(&self) -> Option<&Token> {
+    match self {
+      DeprecatedEquals { equals } => Some(equals),
+    }
+  }
+}
+
+impl Display for Warning<'_> {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    let warning = Color::fmt(f).warning();
+    let message = Color::fmt(f).message();
+
+    write!(f, "{} {}", warning.paint("warning:"), message.prefix())?;
+
+    match self {
+      DeprecatedEquals { .. } => {
+        writeln!(
+          f,
+          "`=` in assignments, exports, and aliases is being phased out on favor of `:=`"
+        )?;
+        write!(
+          f,
+          "Please see this issue for more details: https://github.com/casey/just/issues/379"
+        )?;
+      }
+    }
+
+    write!(f, "{}", message.suffix())?;
+
+    if let Some(token) = self.context() {
+      writeln!(f)?;
+      write_message_context(
+        f,
+        Color::fmt(f).warning(),
+        token.text,
+        token.offset,
+        token.line,
+        token.column,
+        token.lexeme().len(),
+      )?;
+    }
+
+    Ok(())
+  }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2414,6 +2414,9 @@ default:
    stdout:   "bar\n",
    stderr:   "warning: `=` in assignments, exports, and aliases is being phased out on favor of `:=`
 Please see this issue for more details: https://github.com/casey/just/issues/379
+  |
+3 | foo = 'bar'
+  |     ^
 echo bar
 ",
    status:   EXIT_SUCCESS,
@@ -2434,6 +2437,9 @@ default:
    stdout:   "bar\n",
    stderr:   "warning: `=` in assignments, exports, and aliases is being phased out on favor of `:=`
 Please see this issue for more details: https://github.com/casey/just/issues/379
+  |
+3 | export FOO = 'bar'
+  |            ^
 echo $FOO
 ",
    status:   EXIT_SUCCESS,
@@ -2454,6 +2460,9 @@ default:
    stdout:   "default\n",
    stderr:   "warning: `=` in assignments, exports, and aliases is being phased out on favor of `:=`
 Please see this issue for more details: https://github.com/casey/just/issues/379
+  |
+3 | alias foo = default
+  |           ^
 echo default
 ",
    status:   EXIT_SUCCESS,


### PR DESCRIPTION
Previously, warnings upon encountering a deprecated use `=` in assignments, exports, and alaises would print an message without any indication of where the offending `=` was. This diff adds a proper `Warning` enum, and uses it to report context, as is done with compilation and runtime errors.