### PR TITLE
Disable FreeBSD builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
 
     # *BSD
     #- env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
-    - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
+    #- env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
     #- env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
 
     # Other architectures


### PR DESCRIPTION
Just uses github.com/japaric/trust to for continuous integration and release building. trust uses github.com/rust-embedded/cross, which no longer supports FreeBSD. (See github.com/rust-embedded/cross/issues/274 for details.)

Sadly, it's probably too much work to dive in and fix the FreeBSD image for cross, so this commit disables the FreeBSD builds and releases on Travis. I don't think we've ever seen a build failure on BSD only, so losing the test coverage isn't a big deal.

It is unfortunate that we'll lose FreeBSD release builds though. I don't think Just is in the FreeBSd ports tree, so it would be nice if someone wanted to package it and get it in there.