### PR TITLE
Fix `summary` feature conditional compilation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,5 +60,5 @@ mod warning;
 
 pub use crate::run::run;
 
-#[cfg(summary)]
+#[cfg(feature = "summary")]
 pub mod summary;


### PR DESCRIPTION
I used `#[cfg(summary)]`, but the actual syntax is `#[cfg(feature = "summary")]`.