### PR TITLE
Remove unnecessary installation of dash shell on ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,8 @@ matrix:
     # OSX
     #- env: TARGET=i686-apple-darwin
     #  os: osx
-    #  before_install:
-    #    - set -e
-    #    - brew install dash
     - env: TARGET=x86_64-apple-darwin
       os: osx
-      before_install:
-        - set -e
-        - brew update
-        - brew install dash
 
     # *BSD
     #- env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
@@ -63,9 +56,6 @@ matrix:
     #- env: TARGET=x86_64-apple-darwin
     #  os: osx
     #  rust: nightly
-    #  before_install:
-    #    - set -e
-    #    - brew install dash
 
 before_install: set -e
 


### PR DESCRIPTION
The integration tests no longer run with dash, so don't install in CI.