### PR TITLE
Check minimal version compatibility before publishing

### DIFF
--- a/justfile
+++ b/justfile
@@ -53,6 +53,9 @@ publish-check: lint clippy test
 	git branch | grep '* master'
 	git diff --no-ext-diff --quiet --exit-code
 	grep {{version}} CHANGELOG.md
+	cargo +nightly generate-lockfile -Z minimal-versions
+	cargo test
+	git checkout
 
 publish: publish-check
 	cargo publish


### PR DESCRIPTION
Checks that we build and pass tests with the minimal dependency versions declared declared in Cargo.toml, as part of the `publish-check` recipe run before publishing a new version of Just.

Fixed #459.