### PR TITLE
Use more indented strings in integration tests

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -238,36 +238,36 @@ integration_test! {
 integration_test! {
   name: duplicate_alias,
   justfile: "alias foo := bar\nalias foo := baz\n",
-  stdout: "" ,
-  stderr: "error: Alias `foo` first defined on line `1` is redefined on line `2`
-  |
-2 | alias foo := baz
-  |       ^^^
-",
+  stderr: "
+    error: Alias `foo` first defined on line `1` is redefined on line `2`
+      |
+    2 | alias foo := baz
+      |       ^^^
+  ",
   status: EXIT_FAILURE,
 }
 
 integration_test! {
   name: unknown_alias_target,
   justfile: "alias foo := bar\n",
-  stdout: "",
-  stderr: "error: Alias `foo` has an unknown target `bar`
-  |
-1 | alias foo := bar
-  |       ^^^
-",
+  stderr: "
+    error: Alias `foo` has an unknown target `bar`
+      |
+    1 | alias foo := bar
+      |       ^^^
+  ",
   status: EXIT_FAILURE,
 }
 
 integration_test! {
   name: alias_shadows_recipe,
   justfile: "bar:\n  echo bar\nalias foo := bar\nfoo:\n  echo foo",
-  stdout: "",
-  stderr: "error: Alias `foo` defined on `3` shadows recipe defined on `4`
-  |
-3 | alias foo := bar
-  |       ^^^
-",
+  stderr: "
+    error: Alias `foo` defined on `3` shadows recipe defined on `4`
+      |
+    3 | alias foo := bar
+      |       ^^^
+  ",
   status: EXIT_FAILURE,
 }
 
@@ -275,21 +275,23 @@ integration_test! {
   name: alias_show,
   justfile: "foo:\n    bar\nalias f := foo",
   args: ("--show", "f"),
-  stdout: "alias f := foo\nfoo:
-    bar
-",
+  stdout: "
+    alias f := foo
+    foo:
+        bar
+  ",
 }
 
 integration_test! {
   name: alias_show_missing_target,
   justfile: "alias f := foo",
   args: ("--show", "f"),
-  stdout: "",
-  stderr: "error: Alias `f` has an unknown target `foo`
-  |
-1 | alias f := foo
-  |       ^
-",
+  stderr: "
+    error: Alias `f` has an unknown target `foo`
+      |
+    1 | alias f := foo
+      |       ^
+  ",
   status: EXIT_FAILURE,
 }
 
@@ -387,9 +389,10 @@ bar := hello + hello
 recipe:
  echo {{hello + "bar" + bar}}"#,
   args:     ("--show", "recipe"),
-  stdout:   r#"recipe:
-    echo {{hello + "bar" + bar}}
-"#,
+  stdout:   r#"
+    recipe:
+        echo {{hello + "bar" + bar}}
+  "#,
 }
 
 integration_test! {
@@ -401,7 +404,6 @@ hello:
 recipe:
   @exit 100",
   args:     ("recipe"),
-  stdout:   "",
   stderr:   "error: Recipe `recipe` failed on line 6 with exit code 100\n",
   status:   100,
 }
@@ -409,12 +411,12 @@ recipe:
 integration_test! {
   name:     unknown_dependency,
   justfile: "bar:\nhello:\nfoo: bar baaaaaaaz hello",
-  stdout:   "",
-  stderr:   "error: Recipe `foo` has unknown dependency `baaaaaaaz`
-  |
-3 | foo: bar baaaaaaaz hello
-  |          ^^^^^^^^^
-",
+  stderr:   "
+    error: Recipe `foo` has unknown dependency `baaaaaaaz`
+      |
+    3 | foo: bar baaaaaaaz hello
+      |          ^^^^^^^^^
+  ",
   status:   EXIT_FAILURE,
 }
 
@@ -435,36 +437,36 @@ integration_test! {
 integration_test! {
   name:     backtick_code_assignment,
   justfile: "b := a\na := `exit 100`\nbar:\n echo '{{`exit 200`}}'",
-  stdout:   "",
-  stderr:   "error: Backtick failed with exit code 100
-  |
-2 | a := `exit 100`
-  |      ^^^^^^^^^^
-",
+  stderr:   "
+    error: Backtick failed with exit code 100
+      |
+    2 | a := `exit 100`
+      |      ^^^^^^^^^^
+  ",
   status:   100,
 }
 
 integration_test! {
   name:     backtick_code_interpolation,
   justfile: "b := a\na := `echo hello`\nbar:\n echo '{{`exit 200`}}'",
-  stdout:   "",
-  stderr:   "error: Backtick failed with exit code 200
-  |
-4 |  echo '{{`exit 200`}}'
-  |          ^^^^^^^^^^
-",
+  stderr:   "
+    error: Backtick failed with exit code 200
+      |
+    4 |  echo '{{`exit 200`}}'
+      |          ^^^^^^^^^^
+  ",
   status:   200,
 }
 
 integration_test! {
   name:     backtick_code_interpolation_mod,
   justfile: "f:\n 無{{`exit 200`}}",
-  stdout:   "",
-  stderr:   "error: Backtick failed with exit code 200
-  |
-2 |  無{{`exit 200`}}
-  |      ^^^^^^^^^^
-",
+  stderr:   "
+    error: Backtick failed with exit code 200
+      |
+    2 |  無{{`exit 200`}}
+      |      ^^^^^^^^^^
+  ",
   status:   200,
 }
 
@@ -474,12 +476,11 @@ integration_test! {
 backtick-fail:
 \techo {{`exit 200`}}
 ",
-  stdout:   "",
   stderr:   "    error: Backtick failed with exit code 200
       |
     3 |     echo {{`exit 200`}}
       |            ^^^^^^^^^^
-",
+  ",
   status:   200,
 }
 
@@ -489,7 +490,6 @@ integration_test! {
 backtick-fail:
 \techo {{\t`exit 200`}}
 ",
-  stdout:   "",
   stderr:   "error: Backtick failed with exit code 200
   |
 3 |     echo {{    `exit 200`}}
@@ -504,12 +504,12 @@ integration_test! {
 backtick-fail:
 \techo {{\t`exit\t\t200`}}
 ",
-  stdout:   "",
-  stderr:   "error: Backtick failed with exit code 200
-  |
-3 |     echo {{    `exit        200`}}
-  |                ^^^^^^^^^^^^^^^^^
-",
+  stderr:   "
+    error: Backtick failed with exit code 200
+      |
+    3 |     echo {{    `exit        200`}}
+      |                ^^^^^^^^^^^^^^^^^
+  ",
   status:   200,
 }
 
@@ -519,12 +519,12 @@ integration_test! {
 backtick-fail:
 \techo 😬{{`exit 200`}}
 ",
-  stdout:   "",
-  stderr:   "error: Backtick failed with exit code 200
-  |
-3 |     echo 😬{{`exit 200`}}
-  |              ^^^^^^^^^^
-",
+  stderr: "
+    error: Backtick failed with exit code 200
+      |
+    3 |     echo 😬{{`exit 200`}}
+      |              ^^^^^^^^^^
+  ",
   status:   200,
 }
 
@@ -534,24 +534,24 @@ integration_test! {
 backtick-fail:
 \techo \t\t\t😬鎌鼬{{\t\t`exit 200 # \t\t\tabc`}}\t\t\t😬鎌鼬
 ",
-  stdout:   "",
-  stderr:   "error: Backtick failed with exit code 200
-  |
-3 |     echo             😬鎌鼬{{        `exit 200 #             abc`}}            😬鎌鼬
-  |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-",
+  stderr: "
+    error: Backtick failed with exit code 200
+      |
+    3 |     echo             😬鎌鼬{{        `exit 200 #             abc`}}            😬鎌鼬
+      |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ",
   status:   200,
 }
 
 integration_test! {
   name:     backtick_code_long,
   justfile: "\n\n\n\n\n\nb := a\na := `echo hello`\nbar:\n echo '{{`exit 200`}}'",
-  stdout:   "",
-  stderr:   "error: Backtick failed with exit code 200
-   |
-10 |  echo '{{`exit 200`}}'
-   |          ^^^^^^^^^^
-",
+  stderr:   "
+    error: Backtick failed with exit code 200
+       |
+    10 |  echo '{{`exit 200`}}'
+       |          ^^^^^^^^^^
+  ",
   status:   200,
 }
 
@@ -562,11 +562,12 @@ integration_test! {
  echo hello
  echo {{`exit 123`}}",
   stdout:   "",
-  stderr:   "error: Backtick failed with exit code 123
-  |
-4 |  echo {{`exit 123`}}
-  |         ^^^^^^^^^^
-",
+  stderr:   "
+    error: Backtick failed with exit code 123
+      |
+    4 |  echo {{`exit 123`}}
+      |         ^^^^^^^^^^
+  ",
   status:   123,
 }
 
@@ -576,11 +577,13 @@ integration_test! {
  echo hello
  echo {{`exit 123`}}",
   stdout:   "hello\n",
-  stderr:   "echo hello\nerror: Backtick failed with exit code 123
-  |
-3 |  echo {{`exit 123`}}
-  |         ^^^^^^^^^^
-",
+  stderr:   "
+    echo hello
+    error: Backtick failed with exit code 123
+      |
+    3 |  echo {{`exit 123`}}
+      |         ^^^^^^^^^^
+  ",
   status:   123,
 }
 
@@ -591,11 +594,12 @@ integration_test! {
  echo {{`exit 111`}}
 a := `exit 222`",
   stdout:   "",
-  stderr:   "error: Backtick failed with exit code 222
-  |
-4 | a := `exit 222`
-  |      ^^^^^^^^^^
-",
+  stderr:   "
+    error: Backtick failed with exit code 222
+      |
+    4 | a := `exit 222`
+      |      ^^^^^^^^^^
+  ",
   status:   222,
 }
 
@@ -606,7 +610,6 @@ integration_test! {
  echo {{`exit 111`}}
 a := `exit 222`",
   args:     ("--set", "foo", "bar", "--set", "baz", "bob", "--set", "a", "b", "a", "b"),
-  stdout:   "",
   stderr:   "error: Variables `baz` and `foo` overridden on the command line but not present \
     in justfile\n",
   status:   EXIT_FAILURE,
@@ -619,7 +622,6 @@ integration_test! {
  echo {{`exit 111`}}
 a := `exit 222`",
   args:     ("foo=bar", "baz=bob", "a=b", "a", "b"),
-  stdout:   "",
   stderr:   "error: Variables `baz` and `foo` overridden on the command line but not present \
     in justfile\n",
   status:   EXIT_FAILURE,
@@ -632,7 +634,6 @@ integration_test! {
  echo {{`exit 111`}}
 a := `exit 222`",
   args:     ("foo=bar", "a=b", "a", "b"),
-  stdout:   "",
   stderr:   "error: Variable `foo` overridden on the command line but not present in justfile\n",
   status:   EXIT_FAILURE,
 }
@@ -1143,10 +1144,11 @@ a Z="\t z":
 _private-recipe:
 "#,
   args:     ("--list"),
-  stdout:   r#"Available recipes:
-    a Z="\t z"
-    hello a b='B	' c='C' # this does a thing
-"#,
+  stdout:   r#"
+    Available recipes:
+        a Z="\t z"
+        hello a b='B	' c='C' # this does a thing
+  "#,
 }
 
 integration_test! {
@@ -1164,10 +1166,11 @@ a Z="\t z":
 _private-recipe:
 "#,
   args:     ("--list"),
-  stdout:   r#"Available recipes:
-    a Z="\t z"          # something else
-    hello a b='B	' c='C' # this does a thing
-"#,
+  stdout:   r#"
+    Available recipes:
+        a Z="\t z"          # something else
+        hello a b='B	' c='C' # this does a thing
+  "#,
 }
 
 integration_test! {
@@ -1189,11 +1192,12 @@ this-recipe-is-very-very-very-important Z="\t z":
 _private-recipe:
 "#,
   args:     ("--list"),
-  stdout:   r#"Available recipes:
-    hello a b='B	' c='C' # this does a thing
-    this-recipe-is-very-very-very-important Z="\t z" # something else
-    x a b='B	' c='C'     # this does another thing
-"#,
+  stdout:   r#"
+    Available recipes:
+        hello a b='B	' c='C' # this does a thing
+        this-recipe-is-very-very-very-important Z="\t z" # something else
+        x a b='B	' c='C'     # this does another thing
+  "#,
 }
 
 integration_test! {
@@ -1654,12 +1658,14 @@ a:
   ' + "b"}}'
 "#,
   args:     ("a"),
-  stdout:   "a
-  b
-",
-  stderr:   "echo 'a
-  b'
-",
+  stdout:   "
+    a
+      b
+  ",
+  stderr:   "
+    echo 'a
+      b'
+  ",
 }
 
 integration_test! {
@@ -1797,10 +1803,13 @@ a B C +D='hello':
   echo {{B}} {{C}} {{D}}
 ",
   args:     ("--color", "always", "--list"),
-  stdout:   "Available recipes:\n    a \
+  stdout:   "
+    Available recipes:
+        a \
     \u{1b}[36mB\u{1b}[0m \u{1b}[36mC\u{1b}[0m \u{1b}[35m+\
     \u{1b}[0m\u{1b}[36mD\u{1b}[0m=\u{1b}[32m'hello'\u{1b}[0m \
-     \u{1b}[34m#\u{1b}[0m \u{1b}[34mcomment\u{1b}[0m\n",
+     \u{1b}[34m#\u{1b}[0m \u{1b}[34mcomment\u{1b}[0m
+  ",
 }
 
 integration_test! {
@@ -1981,73 +1990,73 @@ foo a=arch() o=os() f=os_family():
 }
 
 integration_test! {
-   name:     unterminated_interpolation_eol,
-   justfile: "
+  name:     unterminated_interpolation_eol,
+  justfile: "
 foo:
   echo {{
 ",
-   stdout:   "",
-   stderr:   r#"error: Unterminated interpolation
-  |
-3 |   echo {{
-  |        ^^
-"#,
-   status:   EXIT_FAILURE,
+  stderr:   r#"
+    error: Unterminated interpolation
+      |
+    3 |   echo {{
+      |        ^^
+  "#,
+  status:   EXIT_FAILURE,
 }
 
 integration_test! {
-   name:     unterminated_interpolation_eof,
-   justfile: "
+  name:     unterminated_interpolation_eof,
+  justfile: "
 foo:
   echo {{",
-   stdout:   "",
-   stderr:   r#"error: Unterminated interpolation
-  |
-3 |   echo {{
-  |        ^^
-"#,
-   status:   EXIT_FAILURE,
+  stderr:   r#"
+    error: Unterminated interpolation
+      |
+    3 |   echo {{
+      |        ^^
+  "#,
+  status:   EXIT_FAILURE,
 }
 
 integration_test! {
-   name:     unterminated_backtick,
-   justfile: "
+  name:     unterminated_backtick,
+  justfile: "
 foo a=\t`echo blaaaaaah:
   echo {{a}}",
-   stdout:   "",
-   stderr:   r#"error: Unterminated backtick
-  |
-2 | foo a=    `echo blaaaaaah:
-  |           ^
-"#,
-   status:   EXIT_FAILURE,
+  stderr:   r#"
+    error: Unterminated backtick
+      |
+    2 | foo a=    `echo blaaaaaah:
+      |           ^
+  "#,
+  status:   EXIT_FAILURE,
 }
 
 integration_test! {
-   name:     unknown_start_of_token,
-   justfile: "
+  name:     unknown_start_of_token,
+  justfile: "
 assembly_source_files = $(wildcard src/arch/$(arch)/*.s)
 ",
-   stdout:   "",
-   stderr:   r#"error: Unknown start of token:
-  |
-2 | assembly_source_files = $(wildcard src/arch/$(arch)/*.s)
-  |                         ^
-"#,
+  stderr:   r#"
+    error: Unknown start of token:
+      |
+    2 | assembly_source_files = $(wildcard src/arch/$(arch)/*.s)
+      |                         ^
+  "#,
    status:   EXIT_FAILURE,
 }
 
 integration_test! {
-   name:     backtick_variable_cat,
-   justfile: "
+  name:     backtick_variable_cat,
+  justfile: "
 stdin := `cat`
 
 default:
   echo {{stdin}}
 ",
-   stdin:    "STDIN",
-   stdout:   "STDIN\n",
-   stderr:   "echo STDIN\n",
+  stdin:    "STDIN",
+  stdout:   "STDIN\n",
+  stderr:   "echo STDIN\n",
 }
 
 integration_test! {
@@ -2062,18 +2071,21 @@ default stdin = `cat`:
 }
 
 integration_test! {
-   name:     backtick_default_cat_justfile,
-   justfile: "
+  name:     backtick_default_cat_justfile,
+  justfile: "
 default stdin = `cat justfile`:
   echo '{{stdin}}'
 ",
-   stdout:   "
-default stdin = `cat justfile`:
-  echo {{stdin}}
-",
-   stderr:   "echo '
-default stdin = `cat justfile`:
-  echo '{{stdin}}''\n",
+  stdout:   "
+
+    default stdin = `cat justfile`:
+      echo {{stdin}}
+  ",
+  stderr:   "
+    echo '
+    default stdin = `cat justfile`:
+      echo '{{stdin}}''
+  ",
 }
 
 integration_test! {


### PR DESCRIPTION
An alternate version of #477 by @aquarhead, which contains all the string formatting changes but uses the internal implementation of `unindent()`.