### PR TITLE
Add repository attribute in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = "🤖 Just a command runner"
 authors     = ["Casey Rodarmor <casey@rodarmor.com>"]
 license     = "CC0-1.0"
 homepage    = "https://github.com/casey/just"
+repository  = "https://github.com/casey/just.git"
 readme      = "crates-io-readme.md"
 edition     = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "🤖 Just a command runner"
 authors     = ["Casey Rodarmor <casey@rodarmor.com>"]
 license     = "CC0-1.0"
 homepage    = "https://github.com/casey/just"
-repository  = "https://github.com/casey/just.git"
+repository  = "https://github.com/casey/just"
 readme      = "crates-io-readme.md"
 edition     = "2018"
 


### PR DESCRIPTION
docs.rs shows the GitHub page iff `package.repository` is provided in Cargo.toml

Otherwise it just shows "Homepage", and doesn't display stars, issues, etc.