### PR TITLE
Rename: Parser -> Analyzer

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -3,7 +3,7 @@ use crate::common::*;
 use CompilationErrorKind::*;
 use TokenKind::*;
 
-pub(crate) struct Parser<'a> {
+pub(crate) struct Analyzer<'a> {
   text: &'a str,
   tokens: itertools::PutBackN<vec::IntoIter<Token<'a>>>,
   recipes: BTreeMap<&'a str, Recipe<'a>>,
@@ -15,16 +15,16 @@ pub(crate) struct Parser<'a> {
   warnings: Vec<Warning<'a>>,
 }
 
-impl<'a> Parser<'a> {
+impl<'a> Analyzer<'a> {
   pub(crate) fn parse(text: &'a str) -> CompilationResult<'a, Justfile> {
     let mut tokens = Lexer::lex(text)?;
     tokens.retain(|token| token.kind != Whitespace);
-    let parser = Parser::new(text, tokens);
-    parser.justfile()
+    let analyzer = Analyzer::new(text, tokens);
+    analyzer.justfile()
   }
 
-  pub(crate) fn new(text: &'a str, tokens: Vec<Token<'a>>) -> Parser<'a> {
-    Parser {
+  pub(crate) fn new(text: &'a str, tokens: Vec<Token<'a>>) -> Analyzer<'a> {
+    Analyzer {
       tokens: itertools::put_back_n(tokens),
       recipes: empty(),
       assignments: empty(),

--- a/src/common.rs
+++ b/src/common.rs
@@ -37,16 +37,17 @@ pub(crate) use crate::{
 
 // structs and enums
 pub(crate) use crate::{
-  alias::Alias, alias_resolver::AliasResolver, assignment_evaluator::AssignmentEvaluator,
-  assignment_resolver::AssignmentResolver, color::Color, compilation_error::CompilationError,
-  compilation_error_kind::CompilationErrorKind, config::Config, config_error::ConfigError,
-  count::Count, enclosure::Enclosure, expression::Expression, fragment::Fragment,
-  function::Function, function_context::FunctionContext, functions::Functions,
-  interrupt_guard::InterruptGuard, interrupt_handler::InterruptHandler, justfile::Justfile,
-  lexer::Lexer, list::List, output_error::OutputError, parameter::Parameter, parser::Parser,
-  platform::Platform, position::Position, recipe::Recipe, recipe_context::RecipeContext,
-  recipe_resolver::RecipeResolver, runtime_error::RuntimeError, search_error::SearchError,
-  shebang::Shebang, show_whitespace::ShowWhitespace, state::State, string_literal::StringLiteral,
+  alias::Alias, alias_resolver::AliasResolver, analyzer::Analyzer,
+  assignment_evaluator::AssignmentEvaluator, assignment_resolver::AssignmentResolver, color::Color,
+  compilation_error::CompilationError, compilation_error_kind::CompilationErrorKind,
+  config::Config, config_error::ConfigError, count::Count, enclosure::Enclosure,
+  expression::Expression, fragment::Fragment, function::Function,
+  function_context::FunctionContext, functions::Functions, interrupt_guard::InterruptGuard,
+  interrupt_handler::InterruptHandler, justfile::Justfile, lexer::Lexer, list::List,
+  output_error::OutputError, parameter::Parameter, platform::Platform, position::Position,
+  recipe::Recipe, recipe_context::RecipeContext, recipe_resolver::RecipeResolver,
+  runtime_error::RuntimeError, search_error::SearchError, shebang::Shebang,
+  show_whitespace::ShowWhitespace, state::State, string_literal::StringLiteral,
   subcommand::Subcommand, token::Token, token_kind::TokenKind, use_color::UseColor,
   variables::Variables, verbosity::Verbosity, warning::Warning,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod die;
 
 mod alias;
 mod alias_resolver;
+mod analyzer;
 mod assignment_evaluator;
 mod assignment_resolver;
 mod color;
@@ -41,7 +42,6 @@ mod ordinal;
 mod output;
 mod output_error;
 mod parameter;
-mod parser;
 mod platform;
 mod platform_interface;
 mod position;

--- a/src/run.rs
+++ b/src/run.rs
@@ -131,7 +131,7 @@ pub fn run() -> Result<(), i32> {
     }
   }
 
-  let justfile = match Parser::parse(&text) {
+  let justfile = match Analyzer::parse(&text) {
     Err(error) => {
       if config.color.stderr().active() {
         eprintln!("{:#}", error);

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,7 +1,7 @@
 use crate::common::*;
 
 pub(crate) fn parse(text: &str) -> Justfile {
-  match Parser::parse(text) {
+  match Analyzer::parse(text) {
     Ok(justfile) => justfile,
     Err(error) => panic!("Expected successful parse but got error:\n {}", error),
   }
@@ -42,7 +42,7 @@ macro_rules! error_test {
         kind,
       };
 
-      match Parser::parse(text) {
+      match Analyzer::parse(text) {
         Ok(_) => panic!("Compilation succeeded but expected: {}\n{}", expected, text),
         Err(actual) => {
           use pretty_assertions::assert_eq;


### PR DESCRIPTION
This change is in preparation for a future change, which will replace
the current `Parser`, which both parses and performs multiple kinds of
analysis, with a separate parser, which will produce an AST, and
one or more analyzers, which perform the other consistency checks that
are performed by the current parser.