### PR TITLE
Use constants instead of literals in arg parser

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -11,7 +11,7 @@ pub(crate) use std::{
   ops::{Range, RangeInclusive},
   path::{Path, PathBuf},
   process::{self, Command},
-  str::Chars,
+  str::{self, Chars},
   sync::{Mutex, MutexGuard},
   usize, vec,
 };

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -69,7 +69,7 @@ impl<'a> Justfile<'a> {
       config.dry_run,
     )?;
 
-    if config.evaluate {
+    if config.subcommand == Subcommand::Evaluate {
       let mut width = 0;
       for name in scope.keys() {
         width = cmp::max(name.len(), width);

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,9 +1,10 @@
 #[derive(PartialEq)]
 pub(crate) enum Subcommand<'a> {
-  Edit,
-  Summary,
   Dump,
+  Edit,
+  Evaluate,
   List,
-  Show { name: &'a str },
   Run,
+  Show { name: &'a str },
+  Summary,
 }


### PR DESCRIPTION
- Differentiate between `arg`s, which are flags and options, and `cmd`s,
  which are exclusive subcommands

- Replace string literals, like "EVALUATE", with constants, like
  `cmd::EVALUATE`, since they're slightly less error prone.

- Remove `Config::evaluate` bool, handle like other subcommands