### PR TITLE
Note need to publish with nightly cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,6 @@ pretty_assertions = "0.6"
 
 # Until github.com/rust-lang/cargo/pull/7333 makes it into stable,
 # this version-less dev-dependency will interfere with publishing
-# to crates.io.
+# to crates.io. In the meantime, we can publish with nighlty cargo.
 [dev-dependencies.test-utilities]
 path = "test-utilities"

--- a/justfile
+++ b/justfile
@@ -58,7 +58,7 @@ publish-check: lint clippy test
 	git checkout Cargo.lock
 
 publish: publish-check
-	cargo publish
+	cargo +nightly publish
 	git tag -a {{version}} -m 'Release {{version}}'
 	git push github {{version}}
 


### PR DESCRIPTION
Until github.com/rust-lang/cargo/pull/7333 makes it into stable rust,
we'll be forced to publish using nightly, due to our unpublished dev
dependency on `test-utilities`.