### PR TITLE
Move `cd` out of Config::from_matches

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ pub(crate) struct Config<'a> {
   pub(crate) justfile: Option<&'a Path>,
   pub(crate) working_directory: Option<&'a Path>,
   pub(crate) invocation_directory: Result<PathBuf, String>,
+  pub(crate) search_directory: Option<&'a Path>,
 }
 
 mod cmd {
@@ -248,6 +249,8 @@ impl<'a> Config<'a> {
       overrides.insert(name, value);
     }
 
+    let mut search_directory = None;
+
     let arguments = raw_arguments
       .into_iter()
       .skip_while(is_override)
@@ -261,9 +264,7 @@ impl<'a> Config<'a> {
 
             let (dir, recipe) = argument.split_at(i + 1);
 
-            if let Err(error) = env::set_current_dir(dir) {
-              die!("Error changing directory: {}", error);
-            }
+            search_directory = Some(Path::new(dir));
 
             if recipe.is_empty() {
               return None;
@@ -300,6 +301,7 @@ impl<'a> Config<'a> {
       shell: matches.value_of(arg::SHELL).unwrap(),
       justfile: matches.value_of(arg::JUSTFILE).map(Path::new),
       working_directory: matches.value_of(arg::WORKING_DIRECTORY).map(Path::new),
+      search_directory,
       invocation_directory,
       subcommand,
       verbosity,
@@ -326,6 +328,7 @@ impl<'a> Default for Config<'a> {
       working_directory: None,
       invocation_directory: env::current_dir()
         .map_err(|e| format!("Error getting current directory: {}", e)),
+      search_directory: None,
     }
   }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -55,6 +55,16 @@ pub fn run() -> Result<(), i32> {
 
   let justfile = config.justfile;
 
+  if let Some(directory) = config.search_directory {
+    if let Err(error) = env::set_current_dir(&directory) {
+      die!(
+        "Error changing directory to {}: {}",
+        directory.display(),
+        error
+      );
+    }
+  }
+
   let mut working_directory = config.working_directory.map(PathBuf::from);
 
   if let (Some(justfile), None) = (justfile, working_directory.as_ref()) {


### PR DESCRIPTION
Move `env::set_current_dir` outside of `Config::from_matches()` and into
`run()`. It's a bit cleaner this way, and sets us up to make the just
process not change its own directory at all, instead explicitly changing
the working directory of its child processes.