### PR TITLE
Avoid fs::canonicalize

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -32,7 +32,7 @@ pub(crate) use snafu::{ResultExt, Snafu};
 pub(crate) use unicode_width::UnicodeWidthChar;
 
 // modules
-pub(crate) use crate::{config_error, keyword, search_error, setting};
+pub(crate) use crate::{config_error, keyword, setting};
 
 // functions
 pub(crate) use crate::{default::default, empty::empty, load_dotenv::load_dotenv, output::output};

--- a/src/config_error.rs
+++ b/src/config_error.rs
@@ -9,8 +9,6 @@ pub(crate) enum ConfigError {
     message
   ))]
   Internal { message: String },
-  #[snafu(display("Could not canonicalize justfile path `{}`: {}", path.display(), source))]
-  JustfilePathCanonicalize { path: PathBuf, source: io::Error },
   #[snafu(display("Failed to get current directory: {}", source))]
   CurrentDir { source: io::Error },
   #[snafu(display(

--- a/src/search_error.rs
+++ b/src/search_error.rs
@@ -12,9 +12,7 @@ pub(crate) enum SearchError {
         .map(|candidate| candidate.file_name().unwrap().to_string_lossy())
     ),
   ))]
-  MultipleCandidates {
-    candidates: Vec<PathBuf>,
-  },
+  MultipleCandidates { candidates: Vec<PathBuf> },
   #[snafu(display(
     "I/O error reading directory `{}`: {}",
     directory.display(),
@@ -26,13 +24,8 @@ pub(crate) enum SearchError {
   },
   #[snafu(display("No justfile found"))]
   NotFound,
-  Canonicalize {
-    path: PathBuf,
-    source: io::Error,
-  },
-  JustfileHadNoParent {
-    path: PathBuf,
-  },
+  #[snafu(display("Justfile path had no parent: {}", path.display()))]
+  JustfileHadNoParent { path: PathBuf },
 }
 
 impl Error for SearchError {}


### PR DESCRIPTION
Previously, we used `fs::canonicalize` to ensure paths used in search
were absolute. This lead to bad behavior when the justfile was symbolic
link to a file in another directory. Additionally, on Windows, this
produced paths in extended length syntax, which, I believe, has
compatibility issues.

This diff replaces uses of `fs::canonicalize`  with a simpler algorithm
that roots path in the invocation directory (which will be a no-op if
said path is already absolute), uses `Path::components` to remove extra
`/` and `.`, and resolves instances of `..` without following symlinks,
i.e. by removing the `..`, and the component that proceeds it.

Fixes #538.