### PR TITLE
Add `--init` subcommand

### DIFF
--- a/src/config_error.rs
+++ b/src/config_error.rs
@@ -16,8 +16,9 @@ pub(crate) enum ConfigError {
   ))]
   SearchDirConflict,
   #[snafu(display(
-    "`{}` used with unexpected arguments: {}",
+    "`{}` used with unexpected {}: {}",
     subcommand,
+    Count("argument", arguments.len()),
     List::and_ticked(arguments)
   ))]
   SubcommandArguments {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -7,11 +7,12 @@ pub(crate) enum Subcommand {
   Evaluate {
     overrides: BTreeMap<String, String>,
   },
+  Init,
+  List,
   Run {
     overrides: BTreeMap<String, String>,
     arguments: Vec<String>,
   },
-  List,
   Show {
     name: String,
   },

--- a/test-utilities/src/lib.rs
+++ b/test-utilities/src/lib.rs
@@ -134,18 +134,32 @@ macro_rules! entries {
     std::collections::HashMap::new()
   };
   {
-    $($name:ident : $contents:tt,)*
+    $($name:tt : $contents:tt,)*
   } => {
     {
       let mut entries: std::collections::HashMap<&'static str, $crate::Entry> = std::collections::HashMap::new();
 
       $(
-        entries.insert(stringify!($name), $crate::entry!($contents));
+        entries.insert($crate::name!($name), $crate::entry!($contents));
       )*
 
       entries
     }
   }
+}
+
+#[macro_export]
+macro_rules! name {
+  {
+    $name:ident
+  } => {
+    stringify!($name)
+  };
+  {
+    $name:literal
+  } => {
+    $name
+  };
 }
 
 #[macro_export]

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -1,0 +1,159 @@
+use std::{fs, process::Command};
+
+use executable_path::executable_path;
+
+use test_utilities::{tempdir, tmptree};
+
+const EXPECTED: &str = "default:\n\techo 'Hello, world!'\n";
+
+#[test]
+fn current_dir() {
+  let tmp = tempdir();
+
+  let output = Command::new(executable_path("just"))
+    .current_dir(tmp.path())
+    .arg("--init")
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
+
+  assert_eq!(
+    fs::read_to_string(tmp.path().join("justfile")).unwrap(),
+    EXPECTED
+  );
+}
+
+#[test]
+fn exists() {
+  let tmp = tempdir();
+
+  let output = Command::new(executable_path("just"))
+    .current_dir(tmp.path())
+    .arg("--init")
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
+
+  let output = Command::new(executable_path("just"))
+    .current_dir(tmp.path())
+    .arg("--init")
+    .output()
+    .unwrap();
+
+  assert!(!output.status.success());
+}
+
+#[test]
+fn invocation_directory() {
+  let tmp = tmptree! {
+    ".git": {},
+  };
+
+  let output = Command::new(executable_path("just"))
+    .current_dir(tmp.path())
+    .arg("--init")
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
+
+  assert_eq!(
+    fs::read_to_string(tmp.path().join("justfile")).unwrap(),
+    EXPECTED
+  );
+}
+
+#[test]
+fn alternate_marker() {
+  let tmp = tmptree! {
+    "_darcs": {},
+  };
+
+  let output = Command::new(executable_path("just"))
+    .current_dir(tmp.path())
+    .arg("--init")
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
+
+  assert_eq!(
+    fs::read_to_string(tmp.path().join("justfile")).unwrap(),
+    EXPECTED
+  );
+}
+
+#[test]
+fn search_directory() {
+  let tmp = tmptree! {
+    sub: {
+      ".git": {},
+    },
+  };
+
+  let output = Command::new(executable_path("just"))
+    .current_dir(tmp.path())
+    .arg("--init")
+    .arg("sub/")
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
+
+  assert_eq!(
+    fs::read_to_string(tmp.path().join("sub/justfile")).unwrap(),
+    EXPECTED
+  );
+}
+
+#[test]
+fn justfile() {
+  let tmp = tmptree! {
+    sub: {
+      ".git": {},
+    },
+  };
+
+  let output = Command::new(executable_path("just"))
+    .current_dir(tmp.path().join("sub"))
+    .arg("--init")
+    .arg("--justfile")
+    .arg(tmp.path().join("justfile"))
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
+
+  assert_eq!(
+    fs::read_to_string(tmp.path().join("justfile")).unwrap(),
+    EXPECTED
+  );
+}
+
+#[test]
+fn justfile_and_working_directory() {
+  let tmp = tmptree! {
+    sub: {
+      ".git": {},
+    },
+  };
+
+  let output = Command::new(executable_path("just"))
+    .current_dir(tmp.path().join("sub"))
+    .arg("--init")
+    .arg("--justfile")
+    .arg(tmp.path().join("justfile"))
+    .arg("--working-directory")
+    .arg("/")
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
+
+  assert_eq!(
+    fs::read_to_string(tmp.path().join("justfile")).unwrap(),
+    EXPECTED
+  );
+}


### PR DESCRIPTION
When `--init` is passed on the command line, search upward for the
project root, identified by the presence of a VCS directory like `.git`,
falling back to the current directory, and create a default justfile in
that directory.