### PR TITLE
Un-implement Deref for Table

### DIFF
--- a/src/alias_resolver.rs
+++ b/src/alias_resolver.rs
@@ -5,14 +5,14 @@ pub(crate) struct AliasResolver<'a, 'b>
 where
   'a: 'b,
 {
-  aliases: &'b BTreeMap<&'a str, Alias<'a>>,
-  recipes: &'b BTreeMap<&'a str, Recipe<'a>>,
+  aliases: &'b Table<'a, Alias<'a>>,
+  recipes: &'b Table<'a, Recipe<'a>>,
 }
 
 impl<'a: 'b, 'b> AliasResolver<'a, 'b> {
   pub(crate) fn resolve_aliases(
-    aliases: &BTreeMap<&'a str, Alias<'a>>,
-    recipes: &BTreeMap<&'a str, Recipe<'a>>,
+    aliases: &Table<'a, Alias<'a>>,
+    recipes: &Table<'a, Recipe<'a>>,
   ) -> CompilationResult<'a, ()> {
     let resolver = AliasResolver { aliases, recipes };
 

--- a/src/assignment_evaluator.rs
+++ b/src/assignment_evaluator.rs
@@ -1,7 +1,7 @@
 use crate::common::*;
 
 pub(crate) struct AssignmentEvaluator<'a: 'b, 'b> {
-  pub(crate) assignments: &'b BTreeMap<&'a str, Assignment<'a>>,
+  pub(crate) assignments: &'b Table<'a, Assignment<'a>>,
   pub(crate) config: &'a Config,
   pub(crate) dotenv: &'b BTreeMap<String, String>,
   pub(crate) evaluated: BTreeMap<&'a str, (bool, String)>,
@@ -16,7 +16,7 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
     config: &'a Config,
     working_directory: &'b Path,
     dotenv: &'b BTreeMap<String, String>,
-    assignments: &BTreeMap<&'a str, Assignment<'a>>,
+    assignments: &Table<'a, Assignment<'a>>,
     overrides: &BTreeMap<String, String>,
     settings: &'b Settings<'b>,
   ) -> RunResult<'a, BTreeMap<&'a str, (bool, String)>> {

--- a/src/assignment_resolver.rs
+++ b/src/assignment_resolver.rs
@@ -3,7 +3,7 @@ use crate::common::*;
 use CompilationErrorKind::*;
 
 pub(crate) struct AssignmentResolver<'a: 'b, 'b> {
-  assignments: &'b BTreeMap<&'a str, Assignment<'a>>,
+  assignments: &'b Table<'a, Assignment<'a>>,
   stack: Vec<&'a str>,
   seen: BTreeSet<&'a str>,
   evaluated: BTreeSet<&'a str>,
@@ -11,7 +11,7 @@ pub(crate) struct AssignmentResolver<'a: 'b, 'b> {
 
 impl<'a: 'b, 'b> AssignmentResolver<'a, 'b> {
   pub(crate) fn resolve_assignments(
-    assignments: &BTreeMap<&'a str, Assignment<'a>>,
+    assignments: &Table<'a, Assignment<'a>>,
   ) -> CompilationResult<'a, ()> {
     let mut resolver = AssignmentResolver {
       stack: empty(),

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,7 +8,7 @@ pub(crate) use std::{
   fs,
   io::{self, Write},
   iter::{self, FromIterator},
-  ops::{Deref, Range, RangeInclusive},
+  ops::{Index, Range, RangeInclusive},
   path::{Path, PathBuf},
   process::{self, Command},
   str::{self, Chars},

--- a/src/recipe_resolver.rs
+++ b/src/recipe_resolver.rs
@@ -6,14 +6,14 @@ pub(crate) struct RecipeResolver<'a: 'b, 'b> {
   stack: Vec<&'a str>,
   seen: BTreeSet<&'a str>,
   resolved: BTreeSet<&'a str>,
-  recipes: &'b BTreeMap<&'a str, Recipe<'a>>,
-  assignments: &'b BTreeMap<&'a str, Assignment<'a>>,
+  recipes: &'b Table<'a, Recipe<'a>>,
+  assignments: &'b Table<'a, Assignment<'a>>,
 }
 
 impl<'a, 'b> RecipeResolver<'a, 'b> {
   pub(crate) fn resolve_recipes(
-    recipes: &BTreeMap<&'a str, Recipe<'a>>,
-    assignments: &BTreeMap<&'a str, Assignment<'a>>,
+    recipes: &Table<'a, Recipe<'a>>,
+    assignments: &Table<'a, Assignment<'a>>,
   ) -> CompilationResult<'a, ()> {
     let mut resolver = RecipeResolver {
       seen: empty(),

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,5 +1,7 @@
 use crate::common::*;
 
+use std::collections::btree_map;
+
 #[derive(Debug, PartialEq)]
 pub(crate) struct Table<'key, V: Keyed<'key>> {
   map: BTreeMap<&'key str, V>,
@@ -8,6 +10,30 @@ pub(crate) struct Table<'key, V: Keyed<'key>> {
 impl<'key, V: Keyed<'key>> Table<'key, V> {
   pub(crate) fn insert(&mut self, value: V) {
     self.map.insert(value.key(), value);
+  }
+
+  pub(crate) fn len(&self) -> usize {
+    self.map.len()
+  }
+
+  pub(crate) fn get(&self, key: &str) -> Option<&V> {
+    self.map.get(key)
+  }
+
+  pub(crate) fn values(&self) -> btree_map::Values<&'key str, V> {
+    self.map.values()
+  }
+
+  pub(crate) fn contains_key(&self, key: &str) -> bool {
+    self.map.contains_key(key)
+  }
+
+  pub(crate) fn keys(&self) -> btree_map::Keys<&'key str, V> {
+    self.map.keys()
+  }
+
+  pub(crate) fn iter(&self) -> btree_map::Iter<&'key str, V> {
+    self.map.iter()
   }
 }
 
@@ -19,28 +45,29 @@ impl<'key, V: Keyed<'key>> FromIterator<V> for Table<'key, V> {
   }
 }
 
-impl<'key, V: Keyed<'key>> Deref for Table<'key, V> {
-  type Target = BTreeMap<&'key str, V>;
+impl<'key, V: Keyed<'key>> Index<&'key str> for Table<'key, V> {
+  type Output = V;
 
-  fn deref(&self) -> &Self::Target {
-    &self.map
+  #[inline]
+  fn index(&self, key: &str) -> &V {
+    self.map.get(key).expect("no entry found for key")
   }
 }
 
 impl<'key, V: Keyed<'key>> IntoIterator for Table<'key, V> {
   type Item = (&'key str, V);
-  type IntoIter = std::collections::btree_map::IntoIter<&'key str, V>;
+  type IntoIter = btree_map::IntoIter<&'key str, V>;
 
-  fn into_iter(self) -> std::collections::btree_map::IntoIter<&'key str, V> {
+  fn into_iter(self) -> btree_map::IntoIter<&'key str, V> {
     self.map.into_iter()
   }
 }
 
 impl<'table, V: Keyed<'table> + 'table> IntoIterator for &'table Table<'table, V> {
   type Item = (&'table &'table str, &'table V);
-  type IntoIter = std::collections::btree_map::Iter<'table, &'table str, V>;
+  type IntoIter = btree_map::Iter<'table, &'table str, V>;
 
-  fn into_iter(self) -> std::collections::btree_map::Iter<'table, &'table str, V> {
+  fn into_iter(self) -> btree_map::Iter<'table, &'table str, V> {
     self.map.iter()
   }
 }


### PR DESCRIPTION
Remove `Deref` implementation for `Table`, to make sure we're using `Table` and not `BTreeMap`.

Fixes #516.