### PR TITLE
Add flags to set and clear shell arguments

### DIFF
--- a/src/assignment_evaluator.rs
+++ b/src/assignment_evaluator.rs
@@ -164,7 +164,7 @@ impl<'a, 'b> AssignmentEvaluator<'a, 'b> {
     raw: &str,
     token: &Token<'a>,
   ) -> RunResult<'a, String> {
-    let mut cmd = self.settings.shell_command(&self.config.shell);
+    let mut cmd = self.settings.shell_command(self.config);
 
     cmd.arg(raw);
 

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -275,7 +275,7 @@ impl<'a, D> Recipe<'a, D> {
           continue;
         }
 
-        let mut cmd = context.settings.shell_command(&config.shell);
+        let mut cmd = context.settings.shell_command(config);
 
         cmd.current_dir(context.working_directory);
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -10,8 +10,8 @@ impl<'src> Settings<'src> {
     Settings { shell: None }
   }
 
-  pub(crate) fn shell_command(&self, default_shell: &str) -> Command {
-    if let Some(shell) = &self.shell {
+  pub(crate) fn shell_command(&self, config: &Config) -> Command {
+    if let (Some(shell), false) = (&self.shell, config.shell_present) {
       let mut cmd = Command::new(shell.command.cooked.as_ref());
 
       for argument in &shell.arguments {
@@ -20,9 +20,9 @@ impl<'src> Settings<'src> {
 
       cmd
     } else {
-      let mut cmd = Command::new(default_shell);
+      let mut cmd = Command::new(&config.shell);
 
-      cmd.arg("-cu");
+      cmd.args(&config.shell_args);
 
       cmd
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -76,7 +76,6 @@ impl<'a> Test<'a> {
 
     let mut child = Command::new(&executable_path("just"))
       .current_dir(tmp.path())
-      .args(&["--shell", "bash"])
       .args(self.args)
       .stdin(Stdio::piped())
       .stdout(Stdio::piped())
@@ -2210,4 +2209,41 @@ test! {
       |           ^
     echo default
   ",
+}
+
+test! {
+  name: shell_args,
+  justfile: "
+    default:
+      echo A${foo}A
+  ",
+  args: ("--shell-arg", "-c"),
+  stdout: "AA\n",
+  stderr: "echo A${foo}A\n",
+}
+
+test! {
+  name: shell_override,
+  justfile: "
+    set shell := ['foo-bar-baz']
+
+    default:
+      echo hello
+  ",
+  args: ("--shell", "bash"),
+  stdout: "hello\n",
+  stderr: "echo hello\n",
+}
+
+test! {
+  name: shell_arg_override,
+  justfile: "
+    set shell := ['foo-bar-baz']
+
+    default:
+      echo hello
+  ",
+  args: ("--shell-arg", "-cu"),
+  stdout: "hello\n",
+  stderr: "echo hello\n",
 }


### PR DESCRIPTION
Add the `--shell-arg` and `--clear-shell-args` flags, which allow
setting and clearing arguments to the shell fromt the command line.

Additionally, any shell-related arguments to `just` on the command line
will override a `set shell := [...]` setting, which I think will be the behavior
that most people expect.

Fixes #529.