### PR TITLE
Reform indentation handling

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -60,7 +60,7 @@ pub(crate) use crate::{
   position::Position, positional::Positional, recipe::Recipe, recipe_context::RecipeContext,
   recipe_resolver::RecipeResolver, runtime_error::RuntimeError, scope::Scope, search::Search,
   search_config::SearchConfig, search_error::SearchError, set::Set, setting::Setting,
-  settings::Settings, shebang::Shebang, show_whitespace::ShowWhitespace, state::State,
+  settings::Settings, shebang::Shebang, show_whitespace::ShowWhitespace,
   string_literal::StringLiteral, subcommand::Subcommand, table::Table, thunk::Thunk, token::Token,
   token_kind::TokenKind, unresolved_dependency::UnresolvedDependency,
   unresolved_recipe::UnresolvedRecipe, use_color::UseColor, variables::Variables,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,6 @@ mod setting;
 mod settings;
 mod shebang;
 mod show_whitespace;
-mod state;
 mod string_literal;
 mod subcommand;
 mod table;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,9 +1,0 @@
-use crate::common::*;
-
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub(crate) enum State<'src> {
-  Normal,
-  Indented { indentation: &'src str },
-  Text,
-  Interpolation { interpolation_start: Token<'src> },
-}


### PR DESCRIPTION
Improve indentation handling in preparation for implementing inline
submodules. This changes the lexer to only parse freeform text inside
the first indent after a ':', so that Just can be extended with new
indented constructs which are not recipe bodies. In addition, the lexer
should now handle multiple levels of indentation correctly.