### PR TITLE
Fix regression in error message color printing

### DIFF
--- a/src/error_result_ext.rs
+++ b/src/error_result_ext.rs
@@ -10,7 +10,7 @@ impl<T, E: Error> ErrorResultExt<T> for Result<T, E> {
       Ok(ok) => Ok(ok),
       Err(error) => {
         if color.stderr().active() {
-          eprintln!("{} {:#}", color.error().paint("error:"), error);
+          eprintln!("{}: {:#}", color.stderr().error().paint("error"), error);
         } else {
           eprintln!("error: {}", error);
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -970,7 +970,7 @@ test! {
   justfile: "b := a\na := `exit 100`\nbar:\n echo '{{`exit 200`}}'",
   args:     ("--color", "always"),
   stdout:   "",
-  stderr:   "\u{1b}[1;31merror:\u{1b}[0m \u{1b}[1mBacktick failed with exit code 100
+  stderr:   "\u{1b}[1;31merror\u{1b}[0m: \u{1b}[1mBacktick failed with exit code 100
 \u{1b}[0m  |\n2 | a := `exit 100`\n  |      \u{1b}[1;31m^^^^^^^^^^\u{1b}[0m\n",
   status:   100,
 }
@@ -1008,7 +1008,7 @@ recipe:
   @exit 100",
   args:     ("--color=always"),
   stdout:   "",
-  stderr:   "\u{1b}[1;31merror:\u{1b}[0m \u{1b}[1m\
+  stderr:   "\u{1b}[1;31merror\u{1b}[0m: \u{1b}[1m\
 Recipe `recipe` failed on line 3 with exit code 100\u{1b}[0m\n",
   status:   100,
 }


### PR DESCRIPTION
Make the word "error" print in red instead of plain text.