### PR TITLE
Removed yaourt aur helper from readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -108,7 +108,7 @@ scoop install just
 
 === Arch Linux
 
-On Arch Linux, `just` is packaged as https://aur.archlinux.org/packages/just/[just] in AUR, the https://aur.archlinux.org[Arch User Repository]. Several tools are available to install packages from AUR, including https://github.com/Jguer/yay[yay] and https://github.com/archlinuxfr/yaourt[yaourt].
+On Arch Linux, `just` is packaged as https://aur.archlinux.org/packages/just/[just] in AUR, the https://aur.archlinux.org[Arch User Repository]. Several tools are available to install packages from AUR, including https://github.com/Jguer/yay[yay].
 
 === Void Linux
 


### PR DESCRIPTION
Yaourt is not recommended anymore, because it isn't maintained for almost 2 years. 
See this article: https://itsfoss.com/best-aur-helpers/
Yaourt is also removed from the aur itself.