### PR TITLE
Don't require justfile to print completions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -388,6 +388,10 @@ impl Config {
       return self.init();
     }
 
+    if let Completions { shell } = self.subcommand {
+      return Self::completions(&shell);
+    }
+
     let search =
       Search::find(&self.search_config, &self.invocation_directory).eprint(self.color)?;
 
@@ -414,7 +418,6 @@ impl Config {
 
     match &self.subcommand {
       Dump => Self::dump(justfile),
-      Completions { shell } => Self::completions(&shell),
       Evaluate { overrides } => self.run(justfile, &search, overrides, &Vec::new()),
       Run {
         arguments,
@@ -423,7 +426,7 @@ impl Config {
       List => self.list(justfile),
       Show { ref name } => Self::show(&name, justfile),
       Summary => Self::summary(justfile),
-      Edit | Init => unreachable!(),
+      Completions { .. } | Edit | Init => unreachable!(),
     }
   }
 

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -1,12 +1,16 @@
 use std::process::Command;
 
 use executable_path::executable_path;
+use tempfile::tempdir;
 
 #[test]
 fn output() {
+  let tempdir = tempdir().unwrap();
+
   let output = Command::new(executable_path("just"))
     .arg("--completions")
     .arg("bash")
+    .current_dir(tempdir.path())
     .output()
     .unwrap();
 


### PR DESCRIPTION
Currently, the `--completions` subcommand will fail if there is no
justfile present. A justfile isn't needed to print completions, so fix
this.