### PR TITLE
Add github pages site with improved install script

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -97,20 +97,11 @@ hello:
 
 Pre-built binaries for Linux, MacOS, and Windows can be found on https://github.com/casey/just/releases[the releases page].
 
-You can use the following command to download the latest binary for MacOS or Windows, just replace `DESTINATION_DIRECTORY` with the directory where you'd like to put `just`:
+You can use the following command on Linux, MacOS, or Windows to download the latest release, just replace `DEST` with the directory where you'd like to put `just`:
 
 ```sh
-curl -LSfs https://japaric.github.io/trust/install.sh | \
-  sh -s -- --git casey/just --to DESTINATION_DIRECTORY
+curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to DEST
 ```
-
-On Linux, use:
-
-```sh
-curl -LSfs https://japaric.github.io/trust/install.sh | \
-  sh -s -- --git casey/just --target x86_64-unknown-linux-musl --to DESTINATION_DIRECTORY
-```
-
 
 == Quick Start
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+just.systems

--- a/docs/index.css
+++ b/docs/index.css
@@ -1,0 +1,55 @@
+:root {
+  --width-target:      calc(100vw / 6);
+  --height-target:     calc(100vh / 3);
+  --size:              min(var(--width-target), var(--height-target));
+  --margin-vertical:   calc((100vh - var(--size) * 2) / 2);
+  --margin-horizontal: calc((100vw - var(--size) * 5) / 2);
+}
+
+* {
+  margin:  0;
+  padding: 0;
+}
+
+html {
+  background-color: black;
+  color:            white;
+  overflow:         hidden;
+  text-align:       center;
+}
+
+a {
+  color:           white;
+  text-decoration: none;
+}
+
+#just {
+  font-family:      sans-serif;
+  font-size:        var(--size);
+  line-height:      var(--size);
+  display:               grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin-bottom:         var(--margin-vertical);
+  margin-left:           var(--margin-horizontal);
+  margin-right:          var(--margin-horizontal);
+  margin-top:            var(--margin-vertical);
+}
+
+#just > * {
+  height:       var(--size);
+  width:        var(--size);
+}
+
+#subtitle {
+  font-style: italic;
+}
+
+/* just is an isogram */
+#j:after        { content: 'j'; }
+#j:hover:after  { content: 'J'; }
+#u:after        { content: 'u'; }
+#u:hover:after  { content: 'U'; }
+#s:after        { content: 's'; }
+#s:hover:after  { content: 'S'; }
+#t:after        { content: 't'; }
+#t:hover:after  { content: 'T'; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Just: A Command Runner</title>
+    <link href="index.css" rel="stylesheet" type="text/css">
+  </head>
+  <body>
+    <a href="https://github.com/casey/just">
+      <div id="just">
+        <div id="j"></div>
+        <div id="u"></div>
+        <div id="s"></div>
+        <div id="t"></div>
+      </div>
+      <div id="subtitle">a command runner</div>
+    </a>
+  </body>
+</html>
+<!-- Love, Casey -->

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -eu
+
+help() {
+  cat <<'EOF'
+Install a binary release of a just hosted on GitHub
+
+Usage:
+    install [options]
+
+Options:
+    -h, --help      Display this message
+    -f, --force     Force overwriting an existing binary
+    --tag TAG       Tag (version) of the crate to install (default <latest release>)
+    --to LOCATION   Where to install the binary (default ~/.cargo/bin)
+EOF
+}
+
+git=casey/just
+crate=just
+url=https://github.com/casey/just
+releases=$url/releases
+
+case `uname -s` in
+  Darwin) target=x86_64-apple-darwin;;
+  Linux)  target=x86_64-unknown-linux-musl;;
+  *)      target=x86_64-pc-windows-msvc;;
+esac
+
+say() {
+  echo "install: $1"
+}
+
+say_err() {
+  say "$1" >&2
+}
+
+err() {
+  if [ ! -z ${td-} ]; then
+    rm -rf $td
+  fi
+
+  say_err "ERROR $1"
+  exit 1
+}
+
+need() {
+  if ! command -v $1 > /dev/null 2>&1; then
+    err "need $1 (command not found)"
+  fi
+}
+
+force=false
+while test $# -gt 0; do
+  case $1 in
+    --force | -f)
+      force=true
+      ;;
+    --help | -h)
+      help
+      exit 0
+      ;;
+    --tag)
+      tag=$2
+      shift
+      ;;
+    --to)
+      dest=$2
+      shift
+      ;;
+    *)
+      ;;
+  esac
+  shift
+done
+
+# Dependencies
+need basename
+need curl
+need install
+need mkdir
+need mktemp
+need tar
+
+# Optional dependencies
+if [ -z ${tag-} ]; then
+  need cut
+  need rev
+fi
+
+if [ -z ${dest-} ]; then
+  dest="$HOME/.cargo/bin"
+fi
+
+if [ -z ${tag-} ]; then
+  tag=$(curl -s "$releases/latest" | cut -d'"' -f2 | rev | cut -d'/' -f1 | rev)
+fi
+
+archive="$releases/download/$tag/$crate-$tag-$target.tar.gz"
+
+say_err "Repository:  $url"
+say_err "Crate:       $crate"
+say_err "Tag:         $tag"
+say_err "Target:      $target"
+say_err "Destination: $dest"
+say_err "Archive:     $archive"
+
+td=$(mktemp -d || mktemp -d -t tmp)
+curl -sL $archive | tar -C $td -xz
+
+for f in $(ls $td); do
+  test -x $td/$f || continue
+
+  if [ -e "$dest/$f" ] && [ $force = false ]; then
+    err "$f already exists in $dest"
+  else
+    mkdir -p $dest
+    install -m 755 $td/$f $dest
+  fi
+done
+
+rm -rf $td


### PR DESCRIPTION
- Add a very basic github pages site that links to the github repo.
- Add new install script in the root of the site
- Document the new script in the readme

Fixes #589