### PR TITLE
 Document behavior of `@` on shebang recipes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -812,6 +812,35 @@ goodbye
 # all done!
 ```
 
+Shebang recipes are quiet by default:
+
+```make
+foo:
+  #!/usr/bin/env bash
+  echo 'Foo!'
+```
+
+```sh
+$ just foo
+Foo!
+```
+
+Adding `@` to a shebang recipe name makes just print the recipe before executing it:
+
+
+```make
+@bar:
+  #!/usr/bin/env bash
+  echo 'Bar!'
+```
+
+```sh
+$ just bar                                                                                    ~/src/just
+#!/usr/bin/env bash
+echo 'Bar!'
+Bar!
+```
+
 === Invoking Justfiles in Other Directories
 
 If the first argument passed to `just` contains a `/`, then the following occurs:

--- a/README.adoc
+++ b/README.adoc
@@ -825,7 +825,7 @@ $ just foo
 Foo!
 ```
 
-Adding `@` to a shebang recipe name makes just print the recipe before executing it:
+Adding `@` to a shebang recipe name makes `just` print the recipe before executing it:
 
 
 ```make


### PR DESCRIPTION
Shebang recipes have the somewhat confusing property of being quiet by
default, with `@` before a shebang recipe name causing just to print out
the recipe before executing it.

This is somewhat questionable behavior, since it's the opposite of
linewise recipes, but it should be documented, even if it might change
in the future.
