### PR TITLE
Update zsh completion file

### DIFF
--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -13,7 +13,6 @@ _just() {
         _arguments_options=(-s -C)
     fi
 
-<<<<<<< HEAD
     local common=(
         '--color=[Print colorful output]: :(auto always never)' 
         '(-f --justfile)'{-f+,--justfile=}'[Use <JUSTFILE> as justfile.]' 
@@ -58,7 +57,7 @@ _just() {
 
             if [[ ${lastarg} = */* ]]; then
                 # Arguments contain slash would be recognised as a file
-                _arguments -s -S $common '::ARGUMENTS -- Overrides and recipe(s) to run, defaulting to the first recipe in the justfile:_files' 
+                _arguments -s -S $common '*:: :_files'
             else
                 # Show usage message
                 _message $args_str

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -75,15 +75,6 @@ _just() {
     return ret
 }
 
-(( $+functions[_just_variables] )) ||
-_just_variables() {
-    local variables; variables=(
-        ${(s: :)$(_call_program commands just --variables)}
-    )
-
-    _describe -t variables 'variables' variables
-}
-
 (( $+functions[_just_commands] )) ||
 _just_commands() {
     local commands; commands=(
@@ -91,6 +82,15 @@ _just_commands() {
     )
 
     _describe -t commands 'just commands' commands "$@"
+}
+
+(( $+functions[_just_variables] )) ||
+_just_variables() {
+    local variables; variables=(
+        ${(s: :)$(_call_program commands just --variables)}
+    )
+
+    _describe -t variables 'variables' variables
 }
 
 _just "$@"

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -5,7 +5,7 @@ autoload -U is-at-least
 _just() {
     typeset -A opt_args
     typeset -a _arguments_options
-    local context curcontext="$curcontext" state line ret=1
+    local ret=1
 
     if is-at-least 5.2; then
         _arguments_options=(-s -S -C)
@@ -13,30 +13,41 @@ _just() {
         _arguments_options=(-s -C)
     fi
 
+    local context curcontext="$curcontext" state line
     local common=(
-        '--color=[Print colorful output]: :(auto always never)' 
-        '(-f --justfile)'{-f+,--justfile=}'[Use <JUSTFILE> as justfile.]' 
-        '*--set[Override <VARIABLE> with <VALUE>]: :_just_variables' 
-        '--shell=[Invoke <SHELL> to run recipes]' 
-        '*--shell-arg=[Invoke shell with <SHELL-ARG> as an argument]' 
-        '(-d --working-directory)'{-d+,--working-directory}'[Use <WORKING-DIRECTORY> as working directory. --justfile must also be set]' 
-        '--completions=[Print shell completion script for <SHELL>]: :(zsh bash fish powershell elvish)' 
-        '(-s --show)'{-s+,--show=}'[Show information about <RECIPE>]: :_just_commands' 
-        '(-q --quiet)--dry-run[Print what just would do without doing it]' 
-        '(--dry-run)'{-q,--quiet}'[Suppress all output]' 
-        '(--no-highlight)--highlight[Highlight echoed recipe lines in bold]' 
-        '(--highlight)--no-highlight[Don'\''t highlight echoed recipe lines in bold]' 
-        '--clear-shell-args[Clear shell arguments]' 
-        '*'{-v,--verbose}'[Use verbose output]' 
-        '--dump[Print entire justfile]' 
-        '(- 1 *)'{-e,--edit}'[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' 
-        '--evaluate[Print evaluated variables]' 
-        '--init[Initialize new justfile in project root]' 
-        '(- 1 *)'{-l,--list}'[List available recipes and their arguments]' 
-        '(- 1 *)--summary[List names of available recipes]' 
-        '(- 1 *)'{-h,--help}'[Print help information]' 
-        '(- 1 *)'{-V,--version}'[Print version information]' 
-    )
+'--color=[Print colorful output]: :(auto always never)' \
+'-f+[Use <JUSTFILE> as justfile.]' \
+'--justfile=[Use <JUSTFILE> as justfile.]' \
+'*--set[Override <VARIABLE> with <VALUE>]: :_just_variables' \
+'--shell=[Invoke <SHELL> to run recipes]' \
+'*--shell-arg=[Invoke shell with <SHELL-ARG> as an argument]' \
+'-d+[Use <WORKING-DIRECTORY> as working directory. --justfile must also be set]' \
+'--working-directory=[Use <WORKING-DIRECTORY> as working directory. --justfile must also be set]' \
+'--completions=[Print shell completion script for <SHELL>]: :(zsh bash fish powershell elvish)' \
+'-s+[Show information about <RECIPE>]: :_just_commands' \
+'--show=[Show information about <RECIPE>]: :_just_commands' \
+'(-q --quiet)--dry-run[Print what just would do without doing it]' \
+'--highlight[Highlight echoed recipe lines in bold]' \
+'--no-highlight[Don'\''t highlight echoed recipe lines in bold]' \
+'(--dry-run)-q[Suppress all output]' \
+'(--dry-run)--quiet[Suppress all output]' \
+'--clear-shell-args[Clear shell arguments]' \
+'*-v[Use verbose output]' \
+'*--verbose[Use verbose output]' \
+'--dump[Print entire justfile]' \
+'-e[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' \
+'--edit[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' \
+'--evaluate[Print evaluated variables]' \
+'--init[Initialize new justfile in project root]' \
+'-l[List available recipes and their arguments]' \
+'--list[List available recipes and their arguments]' \
+'--summary[List names of available recipes]' \
+'--variables[List names of variables]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
+)
 
     _arguments "${_arguments_options[@]}" $common \
         '1: :_just_commands' \
@@ -47,20 +58,14 @@ _just() {
         args)
             curcontext="${curcontext%:*}-${words[2]}:"
 
-            # Display usage
-            local -a args_str args
-            args_str="`just --show ${words[2]}`"
-
-            echo $args_str >> /tmp/debug
-
-            lastarg=${words[${#words}]}
+            local lastarg=${words[${#words}]}
 
             if [[ ${lastarg} = */* ]]; then
                 # Arguments contain slash would be recognised as a file
                 _arguments -s -S $common '*:: :_files'
             else
                 # Show usage message
-                _message $args_str
+                _message "`just --show ${words[2]}`"
                 # Or complete with other commands
                 #_arguments -s -S $common '*:: :_just_commands'
             fi
@@ -72,17 +77,19 @@ _just() {
 
 (( $+functions[_just_variables] )) ||
 _just_variables() {
-    local -a variables
+    local variables; variables=(
+        ${(s: :)$(_call_program commands just --variables)}
+    )
 
-    variables=( ${(s: :)$(_call_program commands just --variables)} )
     _describe -t variables 'variables' variables
 }
 
 (( $+functions[_just_commands] )) ||
 _just_commands() {
-    local -a commands
+    local commands; commands=(
+        ${${${(M)"${(f)$(_call_program commands just --list)}":#    *}/ ##/}/ ##/:Args: }
+    )
 
-    commands=( ${${${(M)"${(f)$(_call_program commands just --list)}":#    *}/ ##/}/ ##/:Args: } )
     _describe -t commands 'just commands' commands "$@"
 }
 

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -5,7 +5,7 @@ autoload -U is-at-least
 _just() {
     typeset -A opt_args
     typeset -a _arguments_options
-    local ret=1
+    local context curcontext="$curcontext" state line ret=1
 
     if is-at-least 5.2; then
         _arguments_options=(-s -S -C)
@@ -13,49 +13,77 @@ _just() {
         _arguments_options=(-s -C)
     fi
 
-    local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
-'--color=[Print colorful output]: :(auto always never)' \
-'-f+[Use <JUSTFILE> as justfile.]' \
-'--justfile=[Use <JUSTFILE> as justfile.]' \
-'*--set=[Override <VARIABLE> with <VALUE>]' \
-'--shell=[Invoke <SHELL> to run recipes]' \
-'*--shell-arg=[Invoke shell with <SHELL-ARG> as an argument]' \
-'-d+[Use <WORKING-DIRECTORY> as working directory. --justfile must also be set]' \
-'--working-directory=[Use <WORKING-DIRECTORY> as working directory. --justfile must also be set]' \
-'--completions=[Print shell completion script for <SHELL>]: :(zsh bash fish powershell elvish)' \
-'-s+[Show information about <RECIPE>]' \
-'--show=[Show information about <RECIPE>]' \
-'(-q --quiet)--dry-run[Print what just would do without doing it]' \
-'--highlight[Highlight echoed recipe lines in bold]' \
-'--no-highlight[Don'\''t highlight echoed recipe lines in bold]' \
-'(--dry-run)-q[Suppress all output]' \
-'(--dry-run)--quiet[Suppress all output]' \
-'--clear-shell-args[Clear shell arguments]' \
-'*-v[Use verbose output]' \
-'*--verbose[Use verbose output]' \
-'--dump[Print entire justfile]' \
-'-e[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' \
-'--edit[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' \
-'--evaluate[Print evaluated variables]' \
-'--init[Initialize new justfile in project root]' \
-'-l[List available recipes and their arguments]' \
-'--list[List available recipes and their arguments]' \
-'--summary[List names of available recipes]' \
-'-h[Print help information]' \
-'--help[Print help information]' \
-'-V[Print version information]' \
-'--version[Print version information]' \
-'::ARGUMENTS -- Overrides and recipe(s) to run, defaulting to the first recipe in the justfile:_files' \
-&& ret=0
-    
+    local common=(
+        '--color=[Print colorful output]: :(auto always never)' 
+        '(-f --justfile)'{-f+,--justfile=}'[Use <JUSTFILE> as justfile.]' 
+        '*--set[Override <VARIABLE> with <VALUE>]: :_just_variables' 
+        '--shell=[Invoke <SHELL> to run recipes]' 
+        '*--shell-arg=[Invoke shell with <SHELL-ARG> as an argument]' 
+        '(-d --working-directory)'{-d+,--working-directory}'[Use <WORKING-DIRECTORY> as working directory. --justfile must also be set]' 
+        '--completions=[Print shell completion script for <SHELL>]: :(zsh bash fish powershell elvish)' 
+        '(-s --show)'{-s+,--show=}'[Show information about <RECIPE>]: :_just_commands' 
+        '(-q --quiet)--dry-run[Print what just would do without doing it]' 
+        '(--dry-run)'{-q,--quiet}'[Suppress all output]' 
+        '(--no-highlight)--highlight[Highlight echoed recipe lines in bold]' 
+        '(--highlight)--no-highlight[Don'\''t highlight echoed recipe lines in bold]' 
+        '--clear-shell-args[Clear shell arguments]' 
+        '*'{-v,--verbose}'[Use verbose output]' 
+        '--dump[Print entire justfile]' 
+        '(- 1 *)'{-e,--edit}'[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' 
+        '--evaluate[Print evaluated variables]' 
+        '--init[Initialize new justfile in project root]' 
+        '(- 1 *)'{-l,--list}'[List available recipes and their arguments]' 
+        '(- 1 *)--summary[List names of available recipes]' 
+        '(- 1 *)'{-h,--help}'[Print help information]' 
+        '(- 1 *)'{-V,--version}'[Print version information]' 
+    )
+
+    _arguments "${_arguments_options[@]}" $common \
+        '1: :_just_commands' \
+        '*: :->args' \
+        && ret=0
+
+    case $state in
+        args)
+            curcontext="${curcontext%:*}-${words[2]}:"
+
+            # Display usage
+            local -a args_str args
+            args_str="`just --show ${words[2]}`"
+
+            echo $args_str >> /tmp/debug
+
+            lastarg=${words[${#words}]}
+
+            if [[ ${lastarg} = */* ]]; then
+                # Arguments contain slash would be recognised as a file
+                _arguments -s -S $common '*:: :_files'
+            else
+                # Show usage message
+                _message "%BUsage%b $args_str"
+                # Or complete with other commands
+                #_arguments -s -S $common '*:: :_just_commands'
+            fi
+
+        ;;
+    esac
+
+    return ret
+}
+
+(( $+functions[_just_variables] )) ||
+_just_variables() {
+    local -a variables
+
+    variables=( ${"${(f)$(_call_program commands just --evaluate)}"/ ##:= ##/:} )
+    _describe -t variables 'variables' variables
 }
 
 (( $+functions[_just_commands] )) ||
 _just_commands() {
-    local commands; commands=(
-        
-    )
+    local -a commands
+
+    commands=( ${${${(M)"${(f)$(_call_program commands just --list)}":#    *}/ ##/}/ ##/:Args: } )
     _describe -t commands 'just commands' commands "$@"
 }
 

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -60,11 +60,10 @@ _just() {
                 _arguments -s -S $common '*:: :_files'
             else
                 # Show usage message
-                _message "%BUsage%b $args_str"
+                _message $args_str
                 # Or complete with other commands
                 #_arguments -s -S $common '*:: :_just_commands'
             fi
-
         ;;
     esac
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -417,7 +417,7 @@ impl Config {
     }
 
     if let Completions { shell } = self.subcommand {
-      return Self::completions(&shell);
+      return Subcommand::completions(&shell);
     }
 
     let search =
@@ -457,21 +457,6 @@ impl Config {
       Variables => Self::variables(justfile),
       Completions { .. } | Edit | Init => unreachable!(),
     }
-  }
-
-  fn completions(shell: &str) -> Result<(), i32> {
-    let shell = shell
-      .parse::<clap::Shell>()
-      .expect("Invalid value for clap::Shell");
-
-    let buffer = Vec::new();
-    let mut cursor = Cursor::new(buffer);
-    Self::app().gen_completions_to(env!("CARGO_PKG_NAME"), shell, &mut cursor);
-    let buffer = cursor.into_inner();
-    let text = String::from_utf8(buffer).expect("Clap completion not UTF-8");
-    println!("{}", text.trim());
-
-    Ok(())
   }
 
   fn dump(justfile: Justfile) -> Result<(), i32> {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -22,3 +22,79 @@ pub(crate) enum Subcommand {
   Summary,
   Variables,
 }
+
+// TODO: make this a lookup table
+const COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
+  (
+    r#"    _arguments "${_arguments_options[@]}" \"#,
+    r#"    local common=("#,
+  ),
+  (
+    r#"'*--set=[Override <VARIABLE> with <VALUE>]' \"#,
+    r#"'*--set[Override <VARIABLE> with <VALUE>]: :_just_variables' \"#,
+  ),
+  (
+    r#"'-s+[Show information about <RECIPE>]' \
+'--show=[Show information about <RECIPE>]' \"#,
+    r#"'-s+[Show information about <RECIPE>]: :_just_commands' \
+'--show=[Show information about <RECIPE>]: :_just_commands' \"#,
+  ),
+  (
+    "    local commands; commands=(
+\x20\x20\x20\x20\x20\x20\x20\x20
+    )",
+    r#"    local commands; commands=(
+        ${${${(M)"${(f)$(_call_program commands just --list)}":#    *}/ ##/}/ ##/:Args: }
+    )"#,
+  ),
+  (
+    r#"_just "$@""#,
+    r#"(( $+functions[_just_variables] )) ||
+_just_variables() {
+    local variables; variables=(
+        ${(s: :)$(_call_program commands just --variables)}
+    )
+
+    _describe -t variables 'variables' variables
+}
+
+_just "$@""#,
+  ),
+];
+
+impl Subcommand {
+  pub(crate) fn completions(shell: &str) -> Result<(), i32> {
+    fn replace(haystack: &mut String, needle: &str, replacement: &str) -> Result<(), i32> {
+      if let Some(index) = haystack.find(needle) {
+        haystack.replace_range(index..index + needle.len(), replacement);
+        Ok(())
+      } else {
+        eprintln!("Failed to find text:");
+        eprintln!("{}", needle);
+        eprintln!("…in completion script:");
+        eprintln!("{}", haystack);
+        Err(EXIT_FAILURE)
+      }
+    }
+
+    let shell = shell
+      .parse::<clap::Shell>()
+      .expect("Invalid value for clap::Shell");
+
+    let buffer = Vec::new();
+    let mut cursor = Cursor::new(buffer);
+    Config::app().gen_completions_to(env!("CARGO_PKG_NAME"), shell, &mut cursor);
+    let buffer = cursor.into_inner();
+    let mut script = String::from_utf8(buffer).expect("Clap completion not UTF-8");
+
+    if let clap::Shell::Zsh = shell {
+      for (needle, replacement) in COMPLETION_REPLACEMENTS {
+        replace(&mut script, needle, replacement)?;
+      }
+    }
+
+    println!("{}", script.trim());
+
+    Ok(())
+  }
+}

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -23,8 +23,7 @@ pub(crate) enum Subcommand {
   Variables,
 }
 
-// TODO: make this a lookup table
-const COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
+const ZSH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
   (
     r#"    _arguments "${_arguments_options[@]}" \"#,
     r#"    local common=("#,
@@ -123,7 +122,7 @@ impl Subcommand {
     let mut script = String::from_utf8(buffer).expect("Clap completion not UTF-8");
 
     if let clap::Shell::Zsh = shell {
-      for (needle, replacement) in COMPLETION_REPLACEMENTS {
+      for (needle, replacement) in ZSH_COMPLETION_REPLACEMENTS {
         replace(&mut script, needle, replacement)?;
       }
     }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -40,12 +40,47 @@ const COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
 '--show=[Show information about <RECIPE>]: :_just_commands' \"#,
   ),
   (
+    "'::ARGUMENTS -- Overrides and recipe(s) to run, defaulting to the first recipe in the \
+     justfile:_files' \\
+&& ret=0
+\x20\x20\x20\x20
+",
+    r#")
+
+    _arguments "${_arguments_options[@]}" $common \
+        '1: :_just_commands' \
+        '*: :->args' \
+        && ret=0
+
+    case $state in
+        args)
+            curcontext="${curcontext%:*}-${words[2]}:"
+
+            local lastarg=${words[${#words}]}
+
+            if [[ ${lastarg} = */* ]]; then
+                # Arguments contain slash would be recognised as a file
+                _arguments -s -S $common '*:: :_files'
+            else
+                # Show usage message
+                _message "`just --show ${words[2]}`"
+                # Or complete with other commands
+                #_arguments -s -S $common '*:: :_just_commands'
+            fi
+        ;;
+    esac
+
+    return ret
+"#,
+  ),
+  (
     "    local commands; commands=(
 \x20\x20\x20\x20\x20\x20\x20\x20
     )",
     r#"    local commands; commands=(
         ${${${(M)"${(f)$(_call_program commands just --list)}":#    *}/ ##/}/ ##/:Args: }
-    )"#,
+    )
+"#,
   ),
   (
     r#"_just "$@""#,


### PR DESCRIPTION
I just modified the clap-generated completion file for `zsh` to make it working.

Note that completion for `--set` calls `just --evaluate` to get the variables, so it can slow down the console a bit if you have heavy evaluation logic.