### PR TITLE
Don't load `.env` file when `--no-dotenv` is passed

### DIFF
--- a/completions/just.bash
+++ b/completions/just.bash
@@ -20,7 +20,7 @@ _just() {
 
     case "${cmd}" in
         just)
-            opts=" -q -v -e -l -h -V -f -d -s  --dry-run --highlight --no-highlight --quiet --clear-shell-args --verbose --dump --edit --evaluate --init --list --summary --variables --help --version --color --justfile --set --shell --shell-arg --working-directory --completions --show  <ARGUMENTS>... "
+            opts=" -q -v -e -l -h -V -f -d -s  --dry-run --highlight --no-dotenv --no-highlight --quiet --clear-shell-args --verbose --dump --edit --evaluate --init --list --summary --variables --help --version --color --justfile --set --shell --shell-arg --working-directory --completions --show  <ARGUMENTS>... "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/just.elvish
+++ b/completions/just.elvish
@@ -27,6 +27,7 @@ edit:completion:arg-completer[just] = [@words]{
             cand --show 'Show information about <RECIPE>'
             cand --dry-run 'Print what just would do without doing it'
             cand --highlight 'Highlight echoed recipe lines in bold'
+            cand --no-dotenv 'Don''t load `.env` file'
             cand --no-highlight 'Don''t highlight echoed recipe lines in bold'
             cand -q 'Suppress all output'
             cand --quiet 'Suppress all output'

--- a/completions/just.fish
+++ b/completions/just.fish
@@ -19,6 +19,7 @@ complete -c just -n "__fish_use_subcommand" -l completions -d 'Print shell compl
 complete -c just -n "__fish_use_subcommand" -s s -l show -d 'Show information about <RECIPE>'
 complete -c just -n "__fish_use_subcommand" -l dry-run -d 'Print what just would do without doing it'
 complete -c just -n "__fish_use_subcommand" -l highlight -d 'Highlight echoed recipe lines in bold'
+complete -c just -n "__fish_use_subcommand" -l no-dotenv -d 'Don\'t load `.env` file'
 complete -c just -n "__fish_use_subcommand" -l no-highlight -d 'Don\'t highlight echoed recipe lines in bold'
 complete -c just -n "__fish_use_subcommand" -s q -l quiet -d 'Suppress all output'
 complete -c just -n "__fish_use_subcommand" -l clear-shell-args -d 'Clear shell arguments'

--- a/completions/just.powershell
+++ b/completions/just.powershell
@@ -32,6 +32,7 @@ Register-ArgumentCompleter -Native -CommandName 'just' -ScriptBlock {
             [CompletionResult]::new('--show', 'show', [CompletionResultType]::ParameterName, 'Show information about <RECIPE>')
             [CompletionResult]::new('--dry-run', 'dry-run', [CompletionResultType]::ParameterName, 'Print what just would do without doing it')
             [CompletionResult]::new('--highlight', 'highlight', [CompletionResultType]::ParameterName, 'Highlight echoed recipe lines in bold')
+            [CompletionResult]::new('--no-dotenv', 'no-dotenv', [CompletionResultType]::ParameterName, 'Don''t load `.env` file')
             [CompletionResult]::new('--no-highlight', 'no-highlight', [CompletionResultType]::ParameterName, 'Don''t highlight echoed recipe lines in bold')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress all output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress all output')

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -28,6 +28,7 @@ _just() {
 '--show=[Show information about <RECIPE>]: :_just_commands' \
 '(-q --quiet)--dry-run[Print what just would do without doing it]' \
 '--highlight[Highlight echoed recipe lines in bold]' \
+'--no-dotenv[Don'\''t load `.env` file]' \
 '--no-highlight[Don'\''t highlight echoed recipe lines in bold]' \
 '(--dry-run)-q[Suppress all output]' \
 '(--dry-run)--quiet[Suppress all output]' \

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ pub(crate) struct Config {
   pub(crate) dry_run:              bool,
   pub(crate) highlight:            bool,
   pub(crate) invocation_directory: PathBuf,
+  pub(crate) load_dotenv:          bool,
   pub(crate) quiet:                bool,
   pub(crate) search_config:        SearchConfig,
   pub(crate) shell:                String,
@@ -64,6 +65,7 @@ mod arg {
   pub(crate) const DRY_RUN: &str = "DRY-RUN";
   pub(crate) const HIGHLIGHT: &str = "HIGHLIGHT";
   pub(crate) const JUSTFILE: &str = "JUSTFILE";
+  pub(crate) const NO_DOTENV: &str = "NO-DOTENV";
   pub(crate) const NO_HIGHLIGHT: &str = "NO-HIGHLIGHT";
   pub(crate) const QUIET: &str = "QUIET";
   pub(crate) const SET: &str = "SET";
@@ -104,6 +106,11 @@ impl Config {
           .long("highlight")
           .help("Highlight echoed recipe lines in bold")
           .overrides_with(arg::NO_HIGHLIGHT),
+      )
+      .arg(
+        Arg::with_name(arg::NO_DOTENV)
+          .long("no-dotenv")
+          .help("Don't load `.env` file"),
       )
       .arg(
         Arg::with_name(arg::NO_HIGHLIGHT)
@@ -399,6 +406,7 @@ impl Config {
       highlight: !matches.is_present(arg::NO_HIGHLIGHT),
       quiet: matches.is_present(arg::QUIET),
       shell: matches.value_of(arg::SHELL).unwrap().to_owned(),
+      load_dotenv: !matches.is_present(arg::NO_DOTENV),
       color,
       invocation_directory,
       search_config,
@@ -695,6 +703,7 @@ FLAGS:
         --highlight           Highlight echoed recipe lines in bold
         --init                Initialize new justfile in project root
     -l, --list                List available recipes and their arguments
+        --no-dotenv           Don't load `.env` file
         --no-highlight        Don't highlight echoed recipe lines in bold
     -q, --quiet               Suppress all output
         --summary             List names of available recipes

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -90,7 +90,11 @@ impl<'src> Justfile<'src> {
       });
     }
 
-    let dotenv = load_dotenv()?;
+    let dotenv = if config.load_dotenv {
+      load_dotenv()?
+    } else {
+      BTreeMap::new()
+    };
 
     let scope = {
       let mut scope = Scope::new();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1972,6 +1972,19 @@ echo:
 }
 
 test! {
+   name:     no_dotenv,
+   justfile: "
+#
+X:=env_var_or_default('DOTENV_KEY', 'DEFAULT')
+echo:
+  echo {{X}}
+ ",
+   args:     ("--no-dotenv"),
+   stdout:   "DEFAULT\n",
+   stderr:   "echo DEFAULT\n",
+}
+
+test! {
    name:     invalid_escape_sequence_message,
    justfile: r#"
 X := "\'"


### PR DESCRIPTION
Add a `--no-dotenv` flag that suppresses loading `.env` files.