### PR TITLE
Document how to run recipes after a recipe is done

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -615,9 +615,9 @@ search QUERY:
 
 === Running recipes at the end of a recipe
 
-Dependencies always run of a recipes always run a recipe starts. That is to say, the dependee always runs before the depender.
+Dependencies of a recipes always run before a recipe starts. That is to say, the dependee always runs before the depender.
 
-To run a recipe at the end of a recipe, you can call just recursively. Running `b` from the following justfile:
+You can call Just recursively to run a recipe after a recipe ends. Given the following justfile:
 
 ```make
 a:
@@ -631,7 +631,7 @@ c:
   echo 'C!'
 ```
 
-…prints:
+…running 'b' prints:
 
 ```sh
 $ just b
@@ -643,7 +643,7 @@ echo 'C!'
 C!
 ```
 
-This has some limitations, since it's an entirely new invocation of Just: Assignments will be recalculated, dependencies might run twice, and command line arguments will not be propagated to the child Just process.
+This has some limitations, since recipe `c` is run with an entirely new invocation of Just: Assignments will be recalculated, dependencies might run twice, and command line arguments will not be propagated to the child Just process.
 
 === Writing Recipes in Other Languages
 

--- a/README.adoc
+++ b/README.adoc
@@ -613,6 +613,38 @@ search QUERY:
     lynx 'https://www.google.com/?q={{QUERY}}'
 ```
 
+=== Running recipes at the end of a recipe
+
+Dependencies always run of a recipes always run a recipe starts. That is to say, the dependee always runs before the depender.
+
+To run a recipe at the end of a recipe, you can call just recursively. Running `b` from the following justfile:
+
+```make
+a:
+  echo 'A!'
+
+b: a
+  echo 'B!'
+  just c
+
+c:
+  echo 'C!'
+```
+
+…prints:
+
+```sh
+$ just b
+echo 'A!'
+A!
+echo 'B!'
+B!
+echo 'C!'
+C!
+```
+
+This has some limitations, since it's an entirely new invocation of Just: Assignments will be recalculated, dependencies might run twice, and command line arguments will not be propagated to the child Just process.
+
 === Writing Recipes in Other Languages
 
 Recipes that start with a `#!` are executed as scripts, so you can write recipes in other languages:


### PR DESCRIPTION
Add a section to the readme documenting how to shell out to Just at the
end of a recipe, to simulate dependencies that run after a recipe,
instead of before.

This is certainly not as good as having an explicit syntax for this, but
it's a common question so it would be good to document the current best
workaround.