### PR TITLE
Strip leading spaces after line continuation

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -145,11 +145,20 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     })
   }
 
-  pub(crate) fn evaluate_line(&mut self, line: &Line<'src>) -> RunResult<'src, String> {
+  pub(crate) fn evaluate_line(
+    &mut self,
+    line: &Line<'src>,
+    continued: bool,
+  ) -> RunResult<'src, String> {
     let mut evaluated = String::new();
-    for fragment in &line.fragments {
+    for (i, fragment) in line.fragments.iter().enumerate() {
       match fragment {
-        Fragment::Text { token } => evaluated += token.lexeme(),
+        Fragment::Text { token } =>
+          if i == 0 && continued {
+            evaluated += token.lexeme().trim_start();
+          } else {
+            evaluated += token.lexeme();
+          },
         Fragment::Interpolation { expression } => {
           evaluated += &self.evaluate_expression(expression)?;
         },

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -89,7 +89,7 @@ impl<'src, D> Recipe<'src, D> {
     if self.shebang {
       let mut evaluated_lines = vec![];
       for line in &self.body {
-        evaluated_lines.push(evaluator.evaluate_line(line)?);
+        evaluated_lines.push(evaluator.evaluate_line(line, false)?);
       }
 
       if config.dry_run || self.quiet {
@@ -205,14 +205,16 @@ impl<'src, D> Recipe<'src, D> {
           break;
         }
         let mut evaluated = String::new();
+        let mut continued = false;
         loop {
           if lines.peek().is_none() {
             break;
           }
           let line = lines.next().unwrap();
           line_number += 1;
-          evaluated += &evaluator.evaluate_line(line)?;
+          evaluated += &evaluator.evaluate_line(line, continued)?;
           if line.is_continuation() {
+            continued = true;
             evaluated.pop();
           } else {
             break;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1292,8 +1292,8 @@ foo:
          b  \
              c
 "#,
-  stdout:   "a b c\n",
-  stderr:   "echo a       b             c\n",
+  stdout:   "ab c\n",
+  stderr:   "echo ab  c\n",
 }
 
 test! {
@@ -1304,8 +1304,8 @@ foo:
          b  \
              c'
 "#,
-  stdout:   "a       b             c\n",
-  stderr:   "echo 'a       b             c'\n",
+  stdout:   "ab  c\n",
+  stderr:   "echo 'ab  c'\n",
 }
 
 test! {


### PR DESCRIPTION
Make line continuations strip leading spaces on the next line.

This changes what is passed to the shell, so this is a breaking change.
However, I don't think that this will break any recipes.