### PR TITLE
Ignores '@' returned from interpolation evaluation

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -24,4 +24,11 @@ impl<'src> Line<'src> {
       _ => false,
     }
   }
+
+  pub(crate) fn is_quiet(&self) -> bool {
+    match self.fragments.first() {
+      Some(Fragment::Text { token }) => token.lexeme().starts_with('@'),
+      _ => false,
+    }
+  }
 }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -206,6 +206,7 @@ impl<'src, D> Recipe<'src, D> {
         }
         let mut evaluated = String::new();
         let mut continued = false;
+        let quiet_command = lines.peek().map(|line| line.is_quiet()).unwrap_or(false);
         loop {
           if lines.peek().is_none() {
             break;
@@ -221,7 +222,6 @@ impl<'src, D> Recipe<'src, D> {
           }
         }
         let mut command = evaluated.as_str();
-        let quiet_command = command.starts_with('@');
         if quiet_command {
           command = &command[1..];
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2516,3 +2516,36 @@ test! {
   stderr: "",
   shell: false,
 }
+
+test! {
+  name: interpolation_evaluation_ignore_quiet,
+  justfile: r#"
+    foo:
+      {{"@echo foo 2>/dev/null"}}
+  "#,
+  args: (),
+  stdout: "",
+  stderr: "
+    @echo foo 2>/dev/null
+    error: Recipe `foo` failed on line 2 with exit code 127
+  ",
+  status: 127,
+  shell: false,
+}
+
+test! {
+  name: interpolation_evaluation_ignore_quiet_continuation,
+  justfile: r#"
+    foo:
+      {{""}}\
+      @echo foo 2>/dev/null
+  "#,
+  args: (),
+  stdout: "",
+  stderr: "
+    @echo foo 2>/dev/null
+    error: Recipe `foo` failed on line 3 with exit code 127
+  ",
+  status: 127,
+  shell: false,
+}


### PR DESCRIPTION
Just now interprets this literally rather than propagating it to make the line run quietly.