### PR TITLE
Test that example justfiles successfully parse

### DIFF
--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,0 +1,23 @@
+use std::{fs, process::Command};
+
+use executable_path::executable_path;
+use test_utilities::assert_success;
+
+#[test]
+fn examples() {
+  for result in fs::read_dir("examples").unwrap() {
+    let entry = result.unwrap();
+    let path = entry.path();
+
+    println!("Parsing `{}`…", path.display());
+
+    let output = Command::new(executable_path("just"))
+      .arg("--justfile")
+      .arg(&path)
+      .arg("--dump")
+      .output()
+      .unwrap();
+
+    assert_success(&output);
+  }
+}


### PR DESCRIPTION
Parse all entries in `examples` as justfiles, to make sure that example
justfiles parse successfully.