### PR TITLE
Clarify variadic parameters with default values in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -595,7 +595,7 @@ commit MESSAGE *FLAGS:
   git commit {{FLAGS}} -m "{{MESSAGE}}"
 ```
 
-Variadic parameters prefixed by `+` can be assigned default values. These are overridden by arguments passed on the command line:
+Variadic parameters can be assigned default values. These are overridden by arguments passed on the command line:
 
 ```make
 test +FLAGS='-q':


### PR DESCRIPTION
Both `+` and `*` variadics accept defaults! My mistake, I should have caught this in #645 cba69db.