### PR TITLE
powershell recipe autocomplete implementation

### DIFF
--- a/completions/just.powershell
+++ b/completions/just.powershell
@@ -73,9 +73,8 @@ Register-ArgumentCompleter -Native -CommandName 'just' -ScriptBlock {
             $justArgs += @("--justfile", $justFileLocation)
         }
 
-        $recipesRaw = $(just @justArgs) | Select-Object -Skip 1
-        $recipes = $recipesRaw | ForEach-Object { (($_.Trim()) -split ' ')[0] }
-        return  $recipes | ForEach-Object { [CompletionResult]::new($_) }
+        $recipes = $(just @justArgs) -split ' '
+        return $recipes | ForEach-Object { [CompletionResult]::new($_) }
     }
 
     $elementValues = $commandElements | Select-Object -ExpandProperty Value

--- a/completions/just.powershell
+++ b/completions/just.powershell
@@ -67,7 +67,7 @@ Register-ArgumentCompleter -Native -CommandName 'just' -ScriptBlock {
             $justFileLocation = $commandElements[$justFileIndex + 1]
         }
 
-        $justArgs = @("--list")
+        $justArgs = @("--summary")
 
         if (Test-Path $justFileLocation) {
             $justArgs += @("--justfile", $justFileLocation)

--- a/completions/just.powershell
+++ b/completions/just.powershell
@@ -60,6 +60,27 @@ Register-ArgumentCompleter -Native -CommandName 'just' -ScriptBlock {
         }
     })
 
+    function Get-JustFileRecipes([string[]]$CommandElements) {
+        $justFileIndex = $commandElements.IndexOf("--justfile");
+
+        if ($justFileIndex -ne -1 && $justFileIndex + 1 -le $commandElements.Length) {
+            $justFileLocation = $commandElements[$justFileIndex + 1]
+        }
+
+        $justArgs = @("--list")
+
+        if (Test-Path $justFileLocation) {
+            $justArgs += @("--justfile", $justFileLocation)
+        }
+
+        $recipesRaw = $(just @justArgs) | Select-Object -Skip 1
+        $recipes = $recipesRaw | ForEach-Object { (($_.Trim()) -split ' ')[0] }
+        return  $recipes | ForEach-Object { [CompletionResult]::new($_) }
+    }
+
+    $elementValues = $commandElements | Select-Object -ExpandProperty Value
+    $recipes = Get-JustFileRecipes -CommandElements $elementValues
+    $completions += $recipes
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -202,7 +202,7 @@ impl Subcommand {
         for (needle, replacement) in ZSH_COMPLETION_REPLACEMENTS {
           replace(&mut script, needle, replacement)?;
         },
-      _ => {},
+      Shell::Elvish => {},
     }
 
     println!("{}", script.trim());

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -129,9 +129,8 @@ const POWERSHELL_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[(
             $justArgs += @("--justfile", $justFileLocation)
         }
 
-        $recipesRaw = $(just @justArgs) | Select-Object -Skip 1
-        $recipes = $recipesRaw | ForEach-Object { (($_.Trim()) -split ' ')[0] }
-        return  $recipes | ForEach-Object { [CompletionResult]::new($_) }
+        $recipes = $(just @justArgs) -split ' '
+        return $recipes | ForEach-Object { [CompletionResult]::new($_) }
     }
 
     $elementValues = $commandElements | Select-Object -ExpandProperty Value

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -123,7 +123,7 @@ const POWERSHELL_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[(
             $justFileLocation = $commandElements[$justFileIndex + 1]
         }
 
-        $justArgs = @("--list")
+        $justArgs = @("--summary")
 
         if (Test-Path $justFileLocation) {
             $justArgs += @("--justfile", $justFileLocation)


### PR DESCRIPTION
Adds powershell recipe autocomplete as mentioned in: #573

Because it's executing in a scriptblock I have to include the function doing it as a local function. I've also set it up so that if you specify a justfile with --justfile it will use that for the completions. 

```
ex. 
justfile
	recipes:
		- A
		- B
		- C

justfileB:
	recipes:
		- X
		- Y
		- Z
```

`just <tab>` would get you the results of just --list in order.
`just --justfile ".\justfileB" <tab>`
will complete X, Y, Z. You can test it out from outside of the just repo. I've exercised this a bunch locally but not with any exceptional cases. As well the default vscode powershell extension formatter took over and formatted the file. I'm definitely fine with reverting it but you'll likely run into it again.
