### PR TITLE
Only use `cygpath` on shebang if it contains `/`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
     branches:
     - master
     tags:
-    - v*.*.*
+    - '*'
   pull_request:
     branches:
     - master
@@ -30,9 +30,12 @@ jobs:
 
     runs-on: ${{matrix.os}}
 
+    env:
+      RUSTFLAGS: "-D warnings"
+
     steps:
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Cache cargo registry
       uses: actions/cache@v1
@@ -99,16 +102,16 @@ jobs:
 
     - name: Package
       id: package
-      if: startsWith(github.ref, 'refs/tags/v')
+      if: startsWith(github.ref, 'refs/tags/')
       run: ./bin/package ${{github.ref}} ${{matrix.os}} ${{ matrix.target }}
       shell: bash
 
     - name: Publish
       uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/v')
+      if: startsWith(github.ref, 'refs/tags/')
       with:
         draft: false
         files: ${{ steps.package.outputs.archive }}
-        prerelease: false
+        prerelease: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.adoc
+++ b/README.adoc
@@ -694,6 +694,25 @@ Yo from a shell script!
 Hello from ruby!
 ```
 
+==== Shebang Recipe Execution on Windows
+
+On Windows, shebang interpreter paths containing a `/` are translated from Unix-style
+paths to Windows-style paths using `cygpath`, a utility that ships with http://www.cygwin.com[Cygwin].
+
+For example, to execute this recipe on Windows:
+
+```make
+echo:
+  #!/bin/sh
+
+  echo "Hello!"
+```
+
+The interpreter path `/bin/sh` will be translated to a Windows-style path using
+`cygpath` before being executed.
+
+If the interpreter path does not contain a `/` it will be executed without being translated. This is useful if `cygpath` is not available, or you wish to use a Windows style path to the interpreter.
+
 === Multi-line Constructs
 
 Recipes without an initial shebang are evaluated and run line-by-line, which means that multi-line constructs probably won't do what you want.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2635,3 +2635,15 @@ test! {
   status: 127,
   shell: false,
 }
+
+#[cfg(windows)]
+test! {
+  name: windows_interpreter_path_no_base,
+  justfile: r#"
+    foo:
+      #!powershell
+
+      exit 0
+  "#,
+  args: (),
+}


### PR DESCRIPTION
On Windows, skip conversion if a shebang path does not include `/`. In
this case it is not a Unix path, and does not need to be converted to a
Windows path before running.