### PR TITLE
Move link-time optimization config into `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,6 @@ path = "test-utilities"
 # their build machines some cycles.
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[profile.release]
+lto = true

--- a/bin/package
+++ b/bin/package
@@ -17,11 +17,11 @@ echo "Building $bin..."
 
 case $os in
   ubuntu-latest | macos-latest)
-    cargo rustc --bin $bin --target $target --release -- -C lto
+    cargo rustc --bin $bin --target $target --release
     executable=target/$target/release/$bin
     ;;
   windows-latest)
-    cargo rustc --bin $bin --target $target --release -- -C lto -C target-feature="+crt-static"
+    cargo rustc --bin $bin --target $target --release -- -C target-feature="+crt-static"
     executable=target/$target/release/$bin.exe
     ;;
 esac


### PR DESCRIPTION
Passing `-C lto` is more or less unsupported and may stop working, so do
this in Cargo.toml instead.