### PR TITLE
Search for `.env` file from working directory

### DIFF
--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -91,7 +91,7 @@ impl<'src> Justfile<'src> {
     }
 
     let dotenv = if config.load_dotenv {
-      load_dotenv()?
+      load_dotenv(&search.working_directory)?
     } else {
       BTreeMap::new()
     };

--- a/src/load_dotenv.rs
+++ b/src/load_dotenv.rs
@@ -1,25 +1,26 @@
 use crate::common::*;
 
-pub(crate) fn load_dotenv() -> RunResult<'static, BTreeMap<String, String>> {
-  // `dotenv::dotenv_iter` should eventually be un-deprecated, see:
+pub(crate) fn load_dotenv(
+  working_directory: &Path,
+) -> RunResult<'static, BTreeMap<String, String>> {
+  // `dotenv::from_path_iter` should eventually be un-deprecated, see:
   // https://github.com/dotenv-rs/dotenv/issues/13
   #![allow(deprecated)]
-  match dotenv::dotenv_iter() {
-    Ok(iter) => {
+  for directory in working_directory.ancestors() {
+    let path = directory.join(".env");
+
+    if path.is_file() {
+      let iter = dotenv::from_path_iter(&path)?;
       let mut dotenv = BTreeMap::new();
       for result in iter {
-        let (key, value) = result.map_err(|dotenv_error| RuntimeError::Dotenv { dotenv_error })?;
+        let (key, value) = result?;
         if env::var_os(&key).is_none() {
           dotenv.insert(key, value);
         }
       }
-      Ok(dotenv)
-    },
-    Err(dotenv_error) =>
-      if dotenv_error.not_found() {
-        Ok(BTreeMap::new())
-      } else {
-        Err(RuntimeError::Dotenv { dotenv_error })
-      },
+      return Ok(dotenv);
+    }
   }
+
+  Ok(BTreeMap::new())
 }

--- a/src/runtime_error.rs
+++ b/src/runtime_error.rs
@@ -395,3 +395,9 @@ impl<'src> Display for RuntimeError<'src> {
     Ok(())
   }
 }
+
+impl<'src> From<dotenv::Error> for RuntimeError<'src> {
+  fn from(dotenv_error: dotenv::Error) -> RuntimeError<'src> {
+    RuntimeError::Dotenv { dotenv_error }
+  }
+}

--- a/tests/dotenv.rs
+++ b/tests/dotenv.rs
@@ -1,0 +1,28 @@
+use executable_path::executable_path;
+use std::{process, str};
+
+use test_utilities::tmptree;
+
+#[test]
+fn dotenv() {
+  let tmp = tmptree! {
+    ".env": "KEY=ROOT",
+    sub: {
+      ".env": "KEY=SUB",
+      justfile: "default:\n\techo KEY=$KEY",
+    },
+  };
+
+  let binary = executable_path("just");
+
+  let output = process::Command::new(binary)
+    .current_dir(tmp.path())
+    .arg("sub/default")
+    .output()
+    .expect("just invocation failed");
+
+  assert_eq!(output.status.code().unwrap(), 0);
+
+  let stdout = str::from_utf8(&output.stdout).unwrap();
+  assert_eq!(stdout, "KEY=SUB\n");
+}


### PR DESCRIPTION
Search for a `.env` file starting in the  working directory, instead of
the invocation directory.