### PR TITLE
Move separate quiet config value to verbosity

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -131,7 +131,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
 
     cmd.stdin(process::Stdio::inherit());
 
-    cmd.stderr(if self.config.quiet {
+    cmd.stderr(if self.config.verbosity.quiet() {
       process::Stdio::null()
     } else {
       process::Stdio::inherit()

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -236,7 +236,7 @@ impl<'src, D> Recipe<'src, D> {
 
         if config.dry_run
           || config.verbosity.loquacious()
-          || !((quiet_command ^ self.quiet) || config.quiet)
+          || !((quiet_command ^ self.quiet) || config.verbosity.quiet())
         {
           let color = if config.highlight {
             config.color.command()
@@ -256,7 +256,7 @@ impl<'src, D> Recipe<'src, D> {
 
         cmd.arg(command);
 
-        if config.quiet {
+        if config.verbosity.quiet() {
           cmd.stderr(Stdio::null());
           cmd.stdout(Stdio::null());
         }

--- a/src/verbosity.rs
+++ b/src/verbosity.rs
@@ -2,6 +2,7 @@ use Verbosity::*;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum Verbosity {
+  Quiet,
   Taciturn,
   Loquacious,
   Grandiloquent,
@@ -16,16 +17,23 @@ impl Verbosity {
     }
   }
 
+  pub(crate) fn quiet(self) -> bool {
+    match self {
+      Quiet => true,
+      _ => false,
+    }
+  }
+
   pub(crate) fn loquacious(self) -> bool {
     match self {
-      Taciturn => false,
+      Quiet | Taciturn => false,
       Loquacious | Grandiloquent => true,
     }
   }
 
   pub(crate) fn grandiloquent(self) -> bool {
     match self {
-      Taciturn | Loquacious => false,
+      Quiet | Taciturn | Loquacious => false,
       Grandiloquent => true,
     }
   }


### PR DESCRIPTION
Fixes #520

Moves the separate `quiet` variable in the `Config` struct into the existing `verbosity` field; the `Verbosity` enum now has a `Quiet` value. When running, the presence of the quiet flag will set the verbosity to quiet, overriding any number of verbosity flags also in the CLI args.