### PR TITLE
Allow Suppressing of Failing Commands with `-` Prefix

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -31,4 +31,11 @@ impl<'src> Line<'src> {
       _ => false,
     }
   }
+
+  pub(crate) fn is_infallable(&self) -> bool {
+    match self.fragments.first() {
+      Some(Fragment::Text { token }) => token.lexeme().starts_with('-'),
+      _ => false,
+    }
+  }
 }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -211,6 +211,10 @@ impl<'src, D> Recipe<'src, D> {
         let mut evaluated = String::new();
         let mut continued = false;
         let quiet_command = lines.peek().map(|line| line.is_quiet()).unwrap_or(false);
+        let infallable_command = lines
+          .peek()
+          .map(|line| line.is_infallable())
+          .unwrap_or(false);
         loop {
           if lines.peek().is_none() {
             break;
@@ -226,7 +230,7 @@ impl<'src, D> Recipe<'src, D> {
           }
         }
         let mut command = evaluated.as_str();
-        if quiet_command {
+        if quiet_command || infallable_command {
           command = &command[1..];
         }
 
@@ -266,7 +270,7 @@ impl<'src, D> Recipe<'src, D> {
         match InterruptHandler::guard(|| cmd.status()) {
           Ok(exit_status) =>
             if let Some(code) = exit_status.code() {
-              if code != 0 {
+              if code != 0 && !infallable_command {
                 return Err(RuntimeError::Code {
                   recipe: self.name(),
                   line_number: Some(line_number),

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1286,6 +1286,30 @@ test! {
 }
 
 test! {
+  name: infallable_command,
+  justfile: r#"
+infallable:
+  -exit 101
+"#,
+  stderr: "exit 101\n",
+  status: EXIT_SUCCESS,
+}
+
+test! {
+  name: infallable_with_failing,
+  justfile: r#"
+infallable:
+  -exit 101
+  exit 202
+"#,
+  stderr: r#"exit 101
+exit 202
+error: Recipe `infallable` failed on line 4 with exit code 202
+"#,
+  status: 202,
+}
+
+test! {
   name:     quiet_recipe,
   justfile: r#"
 @quiet:


### PR DESCRIPTION
Similar to `make` if a command is prefixed with `-` then the exit
status is ignored.

Fix for  #660