### PR TITLE
Fix doc Ignoring Errors with `-` in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -445,7 +445,7 @@ continue execution after a command, even if it fails, prefix the command with
 
 ```make
 foo:
-    cat foo
+    -cat foo
     echo 'Done!'
 ```
 


### PR DESCRIPTION
Fix doc Ignoring Errors with `-` in README.
The README example forgets to use `-`
