### PR TITLE
fix(zsh): Fix variable completion

### DIFF
--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -15,6 +15,7 @@ _just() {
 
     local context curcontext="$curcontext" state line
     local common=(
+'--chooser=[Override binary invoked by `--choose`]' \
 '--color=[Print colorful output]: :(auto always never)' \
 '-f+[Use <JUSTFILE> as justfile.]' \
 '--justfile=[Use <JUSTFILE> as justfile.]' \
@@ -28,12 +29,16 @@ _just() {
 '--show=[Show information about <RECIPE>]: :_just_commands' \
 '(-q --quiet)--dry-run[Print what just would do without doing it]' \
 '--highlight[Highlight echoed recipe lines in bold]' \
+'--no-dotenv[Don'\''t load `.env` file]' \
 '--no-highlight[Don'\''t highlight echoed recipe lines in bold]' \
 '(--dry-run)-q[Suppress all output]' \
 '(--dry-run)--quiet[Suppress all output]' \
 '--clear-shell-args[Clear shell arguments]' \
+'-u[Return list and summary entries in source order]' \
+'--unsorted[Return list and summary entries in source order]' \
 '*-v[Use verbose output]' \
 '*--verbose[Use verbose output]' \
+'--choose[Select one or more recipes to run using a binary. If `--chooser` is not passed the chooser defaults to the value of $JUST_CHOOSER, falling back to `fzf`]' \
 '--dump[Print entire justfile]' \
 '-e[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' \
 '--edit[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' \

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -63,14 +63,11 @@ _just() {
         args)
             curcontext="${curcontext%:*}-${words[2]}:"
 
-            local lastarg=${words[${#words}]}
-
             local cmds; cmds=(
                 ${(s: :)$(_call_program commands just --summary)}
             )
 
             # Find first recipe name
-            integer skip=0
             for ((i = 2; i < $#words; i++ )) do
                 if [[ ${cmds[(I)${words[i]}]} -gt 0 ]]; then
                     recipe=${words[i]}
@@ -78,7 +75,7 @@ _just() {
                 fi
             done
 
-            if [[ ${lastarg} = */* ]]; then
+            if [[ $lastarg = */* ]]; then
                 # Arguments contain slash would be recognised as a file
                 _arguments -s -S $common '*:: :_files'
             elif [[ $lastarg = *=* ]]; then

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -63,6 +63,8 @@ _just() {
         args)
             curcontext="${curcontext%:*}-${words[2]}:"
 
+            local lastarg=${words[${#words}]}
+
             local cmds; cmds=(
                 ${(s: :)$(_call_program commands just --summary)}
             )

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -64,10 +64,34 @@ _just() {
             declare recipe
             curcontext="${curcontext%:*}-${words[2]}:"
 
+            typeset -A numargs
+            numargs[--chooser]=1
+            numargs[--color]=1
+            numargs[--completions]=1
+            numargs[-f]=1
+            numargs[--justfile]=1
+            numargs[--set]=2
+            numargs[--shell]=1
+            numargs[--shell-arg]=1
+            numargs[-s]=1
+            numargs[--show]=1
+            numargs[-d]=1
+            numargs[--working-directory]=1
             local lastarg=${words[${#words}]}
 
             # Find first recipe name
+            integer skip=0
             for ((i = 2; i < $#words; i++ )) do
+                # Skip positional arguments
+                if [[ $skip -gt 0 ]]; then
+                    skip=$skip-1
+                    continue
+                fi
+                # Skip flags
+                skip=${numargs[${words[i]}]:-0}
+                if [[ $skip -gt 0 ]]; then
+                    continue
+                fi
                 if [[ ! ${words[i]} = *=* ]]; then
                     recipe=${words[i]}
                     break

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -61,18 +61,32 @@ _just() {
 
     case $state in
         args)
+            declare recipe
             curcontext="${curcontext%:*}-${words[2]}:"
 
             local lastarg=${words[${#words}]}
 
-            if [[ ${lastarg} = */* ]]; then
+            # Find first recipe name
+            for ((i = 2; i < $#words; i++ )) do
+                if [[ ! ${words[i]} = *=* ]]; then
+                    recipe=${words[i]}
+                    break
+                fi
+            done
+
+            if [[ $lastarg = */* ]]; then
                 # Arguments contain slash would be recognised as a file
                 _arguments -s -S $common '*:: :_files'
-            else
+            elif [[ $lastarg = *=* ]]; then
+                # Arguments contain equal would be recognised as a variable
+                _message "value"
+            elif [[ $recipe ]]; then
                 # Show usage message
-                _message "`just --show ${words[2]}`"
+                _message "`just --show $recipe`"
                 # Or complete with other commands
                 #_arguments -s -S $common '*:: :_just_commands'
+            else
+                _arguments -s -S $common '*:: :_just_commands'
             fi
         ;;
     esac
@@ -82,20 +96,43 @@ _just() {
 
 (( $+functions[_just_commands] )) ||
 _just_commands() {
+    [[ $PREFIX = -* ]] && return 1
+    integer ret=1
+    local variables; variables=(
+        ${(s: :)$(_call_program commands just --variables)}
+    )
     local commands; commands=(
         ${${${(M)"${(f)$(_call_program commands just --list)}":#    *}/ ##/}/ ##/:Args: }
     )
 
-    _describe -t commands 'just commands' commands "$@"
+    if compset -P '*='; then
+        case "${${words[-1]%=*}#*=}" in
+            *) _message 'value' && ret=0 ;;
+        esac
+    else
+        _describe -t variables 'variables' variables -qS "=" && ret=0
+        _describe -t commands 'just commands' commands "$@"
+    fi
+
 }
 
 (( $+functions[_just_variables] )) ||
 _just_variables() {
+    [[ $PREFIX = -* ]] && return 1
+    integer ret=1
     local variables; variables=(
         ${(s: :)$(_call_program commands just --variables)}
     )
 
-    _describe -t variables 'variables' variables
+    if compset -P '*='; then
+        case "${${words[-1]%=*}#*=}" in
+            *) _message 'value' && ret=0 ;;
+        esac
+    else
+        _describe -t variables 'variables' variables -qS "=" && ret=0
+    fi
+
+    return ret
 }
 
 _just "$@"

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -64,6 +64,7 @@ _just() {
             curcontext="${curcontext%:*}-${words[2]}:"
 
             local lastarg=${words[${#words}]}
+            local recipe
 
             local cmds; cmds=(
                 ${(s: :)$(_call_program commands just --summary)}

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -73,6 +73,7 @@ const ZSH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
             curcontext="${curcontext%:*}-${words[2]}:"
 
             local lastarg=${words[${#words}]}
+            local recipe
 
             local cmds; cmds=(
                 ${(s: :)$(_call_program commands just --summary)}

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -72,11 +72,35 @@ const ZSH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
         args)
             declare recipe
             curcontext="${curcontext%:*}-${words[2]}:"
-
+    
+            typeset -A numargs
+            numargs[--chooser]=1
+            numargs[--color]=1
+            numargs[--completions]=1
+            numargs[-f]=1
+            numargs[--justfile]=1
+            numargs[--set]=2
+            numargs[--shell]=1
+            numargs[--shell-arg]=1
+            numargs[-s]=1
+            numargs[--show]=1
+            numargs[-d]=1
+            numargs[--working-directory]=1
             local lastarg=${words[${#words}]}
 
             # Find first recipe name
+            integer skip=0
             for ((i = 2; i < $#words; i++ )) do
+                # Skip positional arguments
+                if [[ $skip -gt 0 ]]; then
+                    skip=$skip-1
+                    continue
+                fi
+                # Skip flags
+                skip=${numargs[${words[i]}]:-0}
+                if [[ $skip -gt 0 ]]; then
+                    continue
+                fi
                 if [[ ! ${words[i]} = *=* ]]; then
                     recipe=${words[i]}
                     break

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -70,38 +70,15 @@ const ZSH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
 
     case $state in
         args)
-            declare recipe
             curcontext="${curcontext%:*}-${words[2]}:"
 
-            typeset -A numargs
-            numargs[--chooser]=1
-            numargs[--color]=1
-            numargs[--completions]=1
-            numargs[-f]=1
-            numargs[--justfile]=1
-            numargs[--set]=2
-            numargs[--shell]=1
-            numargs[--shell-arg]=1
-            numargs[-s]=1
-            numargs[--show]=1
-            numargs[-d]=1
-            numargs[--working-directory]=1
-            local lastarg=${words[${#words}]}
+            local cmds; cmds=(
+                ${(s: :)$(_call_program commands just --summary)}
+            )
 
             # Find first recipe name
-            integer skip=0
             for ((i = 2; i < $#words; i++ )) do
-                # Skip positional arguments
-                if [[ $skip -gt 0 ]]; then
-                    skip=$skip-1
-                    continue
-                fi
-                # Skip flags
-                skip=${numargs[${words[i]}]:-0}
-                if [[ $skip -gt 0 ]]; then
-                    continue
-                fi
-                if [[ ! ${words[i]} = *=* ]]; then
+                if [[ ${cmds[(I)${words[i]}]} -gt 0 ]]; then
                     recipe=${words[i]}
                     break
                 fi
@@ -168,7 +145,7 @@ _just_variables() {
             *) _message 'value' && ret=0 ;;
         esac
     else
-        _describe -t variables 'variables' variables -qS "=" && ret=0
+        _describe -t variables 'variables' variables && ret=0
     fi
 
     return ret

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -75,7 +75,7 @@ const ZSH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
 
             local lastarg=${words[${#words}]}
 
-            # Find recipe name
+            # Find first recipe name
             for ((i = 2; i < $#words; i++ )) do
                 if [[ ! ${words[i]} = *=* ]]; then
                     recipe=${words[i]}
@@ -83,17 +83,17 @@ const ZSH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
                 fi
             done
 
-            if [[ $recipe = */* ]]; then
+            if [[ $lastarg = */* ]]; then
                 # Arguments contain slash would be recognised as a file
                 _arguments -s -S $common '*:: :_files'
+            elif [[ $lastarg = *=* ]]; then
+                # Arguments contain equal would be recognised as a variable
+                _message "value"
             elif [[ $recipe ]]; then
                 # Show usage message
                 _message "`just --show $recipe`"
                 # Or complete with other commands
                 #_arguments -s -S $common '*:: :_just_commands'
-            elif [[ $lastarg = *=* ]]; then
-                # Arguments contain equal would be recognised as a variable
-                _message "value"
             else
                 _arguments -s -S $common '*:: :_just_commands'
             fi

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -72,7 +72,7 @@ const ZSH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
         args)
             declare recipe
             curcontext="${curcontext%:*}-${words[2]}:"
-    
+
             typeset -A numargs
             numargs[--chooser]=1
             numargs[--color]=1

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -72,6 +72,8 @@ const ZSH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
         args)
             curcontext="${curcontext%:*}-${words[2]}:"
 
+            local lastarg=${words[${#words}]}
+
             local cmds; cmds=(
                 ${(s: :)$(_call_program commands just --summary)}
             )

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -70,18 +70,32 @@ const ZSH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
 
     case $state in
         args)
+            declare recipe
             curcontext="${curcontext%:*}-${words[2]}:"
 
             local lastarg=${words[${#words}]}
 
-            if [[ ${lastarg} = */* ]]; then
+            # Find recipe name
+            for ((i = 2; i < $#words; i++ )) do
+                if [[ ! ${words[i]} = *=* ]]; then
+                    recipe=${words[i]}
+                    break
+                fi
+            done
+
+            if [[ $recipe = */* ]]; then
                 # Arguments contain slash would be recognised as a file
                 _arguments -s -S $common '*:: :_files'
-            else
+            elif [[ $recipe ]]; then
                 # Show usage message
-                _message "`just --show ${words[2]}`"
+                _message "`just --show $recipe`"
                 # Or complete with other commands
                 #_arguments -s -S $common '*:: :_just_commands'
+            elif [[ $lastarg = *=* ]]; then
+                # Arguments contain equal would be recognised as a variable
+                _message "value"
+            else
+                _arguments -s -S $common '*:: :_just_commands'
             fi
         ;;
     esac
@@ -93,20 +107,47 @@ const ZSH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
     "    local commands; commands=(
 \x20\x20\x20\x20\x20\x20\x20\x20
     )",
-    r#"    local commands; commands=(
+    r#"    [[ $PREFIX = -* ]] && return 1
+    integer ret=1
+    local variables; variables=(
+        ${(s: :)$(_call_program commands just --variables)}
+    )
+    local commands; commands=(
         ${${${(M)"${(f)$(_call_program commands just --list)}":#    *}/ ##/}/ ##/:Args: }
     )
+"#,
+  ),
+  (
+    r#"    _describe -t commands 'just commands' commands "$@""#,
+    r#"    if compset -P '*='; then
+        case "${${words[-1]%=*}#*=}" in
+            *) _message 'value' && ret=0 ;;
+        esac
+    else
+        _describe -t variables 'variables' variables -qS "=" && ret=0
+        _describe -t commands 'just commands' commands "$@"
+    fi
 "#,
   ),
   (
     r#"_just "$@""#,
     r#"(( $+functions[_just_variables] )) ||
 _just_variables() {
+    [[ $PREFIX = -* ]] && return 1
+    integer ret=1
     local variables; variables=(
         ${(s: :)$(_call_program commands just --variables)}
     )
 
-    _describe -t variables 'variables' variables
+    if compset -P '*='; then
+        case "${${words[-1]%=*}#*=}" in
+            *) _message 'value' && ret=0 ;;
+        esac
+    else
+        _describe -t variables 'variables' variables -qS "=" && ret=0
+    fi
+
+    return ret
 }
 
 _just "$@""#,


### PR DESCRIPTION
This PR contains the following fixes:

- Allow completion of variables in the command context
- Allow completion of variables after `--set` flag

Closes #695