### PR TITLE
Release v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[v0.8.3] - 2020-10-27
+---------------------
+
+### Added
+- Allow ignoring line endings inside delimiters (#717)
+
+
 [v0.8.2] - 2020-10-26
 ---------------------
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "just"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "just"
-version     = "0.8.2"
+version     = "0.8.3"
 description = "🤖 Just a command runner"
 authors     = ["Casey Rodarmor <casey@rodarmor.com>"]
 license     = "CC0-1.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -809,7 +809,7 @@ mod tests {
   // have proper tests for all the flags, but this will do for now.
   #[test]
   fn help() {
-    const EXPECTED_HELP: &str = "just v0.8.2
+    const EXPECTED_HELP: &str = "just v0.8.3
 Casey Rodarmor <casey@rodarmor.com>
 🤖 Just a command runner \
                                  - https://github.com/casey/just


### PR DESCRIPTION
- Bump version: 0.8.2 → 0.8.3
- Update changelog
- Update config test