### PR TITLE
Add docs for justfile and justfile_directory functions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -508,11 +508,11 @@ build:
 
 ==== Justfile and Justfile Directory
 
-- `justfile()` - Retrieves the path to the current justfile
+- `justfile()` - Retrieves the path of the current justfile.
 
-- `justfile_directory()` - Retrieves the path to the parent directory of the current justfile
+- `justfile_directory()` - Retrieves the path of the parent directory of the current justfile.
 
-For example, if you need to run a command relative to the current justfile, you could do the following:
+For example, to run a command relative to the location of the current justfile:
 
 ```
 script:

--- a/README.adoc
+++ b/README.adoc
@@ -506,6 +506,19 @@ build:
     cd {{invocation_directory()}}; ./some_script_that_needs_to_be_run_from_here
 ```
 
+==== Justfile and Justfile Directory
+
+- `justfile()` - Retrieves the path to the current justfile
+
+- `justfile_directory()` - Retrieves the path to the parent directory of the current justfile
+
+For example, if you need to run a command relative to the current justfile, you could do the following:
+
+```
+script:
+  ./{{justfile_directory()}}/scripts/some_script
+```
+
 ==== Dotenv Integration
 
 `just` will load environment variables from a file named `.env`. This file can be located in the same directory as your justfile or in a parent directory. These variables are environment variables, not `just` variables, and so must be accessed using `$VARIABLE_NAME` in recipes and backticks.


### PR DESCRIPTION
Added some basic documentations for the `justfile()` and `justfile_directory()` that were previously undocumented. These functions were added in https://github.com/casey/just/pull/569 but the only information about them was in the source code and this issue https://github.com/casey/just/issues/387