### PR TITLE
Add link to GitHub Action

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1181,6 +1181,18 @@ Tools that pair nicely with `just` include:
 
 - https://github.com/mattgreen/watchexec[`watchexec`] — a simple tool that watches a path and runs a command whenever it detects modifications.
 
+=== GitHub Actions
+
+link:https://github.com/extractions/setup-just[extractions/setup-just] can be used to install `just` in a GitHub Actions workflow.
+
+Example usage:
+
+```yaml
+- uses: extractions/setup-just@v1
+  with:
+    just-version: 0.8  # optional semver specification, otherwise latest
+```
+
 === Shell Alias
 
 For lightning-fast command running, put `alias j=just` in your shell's configuration file.


### PR DESCRIPTION
Just wanted to share the GitHub Action I wrote to install `just`. I use `just` regularly as a command runner in my projects and often want to run it in CI. See [extractions/setup-just](https://github.com/extractions/setup-just).