### PR TITLE
github uses actions/cache@v2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
         echo /usr/local/opt/gnu-tar/libexec/gnubin > $GITHUB_PATH
 
     - name: Cache Cargo
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: |
           ~/.cargo/registry


### PR DESCRIPTION
https://github.com/actions/cache/blob/main/examples.md#rust---cargo

but the cache in windows still cannot work,  seems https://github.com/actions/toolkit/pull/670 could fix it, need to wait github to bump a new version to include this fix  