### PR TITLE
De-emphasize cmd.exe in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -88,7 +88,18 @@ On Windows, `just` works with the `sh` provided by https://git-scm.com[Git for W
 
 If you'd rather not install `sh`, you can use the `shell` setting to use the shell of your choice.
 
-Like `cmd.exe`:
+Like Powershell:
+
+```make
+
+# use Powershell instead of sh:
+set shell := ["powershell.exe", "-c"]
+
+hello:
+  Write-Host "Hello, world!"
+```
+
+…or `cmd.exe`:
 
 ```make
 
@@ -99,16 +110,7 @@ list:
   dir
 ```
 
-…or Powershell:
-
-```make
-
-# use Powershell instead of sh:
-set shell := ["powershell.exe", "-c"]
-
-hello:
-  Write-Host "Hello, world!"
-```
+(Powershell is installed by default on Windows 7 SP1 and Windows Sever 2008 R2 S1 and later, and `cmd.exe` is quite fiddly, so Powershell is recommended for most Windows users.)
 
 === Packages
 

--- a/README.adoc
+++ b/README.adoc
@@ -110,7 +110,7 @@ list:
   dir
 ```
 
-(Powershell is installed by default on Windows 7 SP1 and Windows Sever 2008 R2 S1 and later, and `cmd.exe` is quite fiddly, so Powershell is recommended for most Windows users.)
+(Powershell is installed by default on Windows 7 SP1 and Windows Server 2008 R2 S1 and later, and `cmd.exe` is quite fiddly, so Powershell is recommended for most Windows users.)
 
 === Packages
 


### PR DESCRIPTION
cmd.exe is very fiddly, and Powershell is widely available, so recommend
Powershell over cmd.exe in the readme