### PR TITLE
Turn `=` deprecation warning into a hard error

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -202,8 +202,8 @@ mod tests {
 
   analysis_error! {
     name: duplicate_alias,
-    input: "alias foo = bar\nalias foo = baz",
-    offset: 22,
+    input: "alias foo := bar\nalias foo := baz",
+    offset: 23,
     line: 1,
     column: 6,
     width: 3,
@@ -212,7 +212,7 @@ mod tests {
 
   analysis_error! {
     name: unknown_alias_target,
-    input: "alias foo = bar\n",
+    input: "alias foo := bar\n",
     offset: 6,
     line: 0,
     column: 6,
@@ -222,7 +222,7 @@ mod tests {
 
   analysis_error! {
     name: alias_shadows_recipe_before,
-    input: "bar: \n  echo bar\nalias foo = bar\nfoo:\n  echo foo",
+    input: "bar: \n  echo bar\nalias foo := bar\nfoo:\n  echo foo",
     offset: 23,
     line: 2,
     column: 6,
@@ -232,7 +232,7 @@ mod tests {
 
   analysis_error! {
     name: alias_shadows_recipe_after,
-    input: "foo:\n  echo foo\nalias foo = bar\nbar:\n  echo bar",
+    input: "foo:\n  echo foo\nalias foo := bar\nbar:\n  echo bar",
     offset: 22,
     line: 2,
     column: 6,
@@ -272,8 +272,8 @@ mod tests {
 
   analysis_error! {
     name:   parameter_shadows_varible,
-    input:  "foo = \"h\"\na foo:",
-    offset:  12,
+    input:  "foo := \"h\"\na foo:",
+    offset:  13,
     line:   1,
     column: 2,
     width:  3,
@@ -292,8 +292,8 @@ mod tests {
 
   analysis_error! {
     name:   duplicate_variable,
-    input:  "a = \"0\"\na = \"0\"",
-    offset:  8,
+    input:  "a := \"0\"\na := \"0\"",
+    offset: 9,
     line:   1,
     column: 0,
     width:  1,

--- a/src/assignment_resolver.rs
+++ b/src/assignment_resolver.rs
@@ -111,7 +111,7 @@ mod tests {
 
   analysis_error! {
     name:   circular_variable_dependency,
-    input:   "a = b\nb = a",
+    input:   "a := b\nb := a",
     offset:  0,
     line:   0,
     column: 0,
@@ -121,8 +121,8 @@ mod tests {
 
   analysis_error! {
     name:   self_variable_dependency,
-    input:  "a = a",
-    offset:  0,
+    input:  "a := a",
+    offset: 0,
     line:   0,
     column: 0,
     width:  1,
@@ -131,10 +131,10 @@ mod tests {
 
   analysis_error! {
     name:   unknown_expression_variable,
-    input:  "x = yy",
-    offset:  4,
+    input:  "x := yy",
+    offset: 5,
     line:   0,
-    column: 4,
+    column: 5,
     width:  2,
     kind:   UndefinedVariable{variable: "yy"},
   }

--- a/src/compilation_error.rs
+++ b/src/compilation_error.rs
@@ -62,6 +62,16 @@ impl Display for CompilationError<'_> {
         };
         writeln!(f, "`\\{}` is not a valid escape sequence", representation)?;
       },
+      DeprecatedEquals => {
+        writeln!(
+          f,
+          "`=` in assignments, exports, and aliases has been phased out on favor of `:=`"
+        )?;
+        writeln!(
+          f,
+          "Please see this issue for more details: https://github.com/casey/just/issues/379"
+        )?;
+      },
       DuplicateParameter { recipe, parameter } => {
         writeln!(
           f,

--- a/src/compilation_error_kind.rs
+++ b/src/compilation_error_kind.rs
@@ -20,6 +20,7 @@ pub(crate) enum CompilationErrorKind<'src> {
     min:        usize,
     max:        usize,
   },
+  DeprecatedEquals,
   DuplicateAlias {
     alias: &'src str,
     first: usize,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -275,8 +275,8 @@ mod tests {
   run_error! {
     name: export_assignment_backtick,
     src: r#"
-      export exported_variable = "A"
-      b = `echo $exported_variable`
+      export exported_variable := "A"
+      b := `echo $exported_variable`
 
       recipe:
         echo {{b}}

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -6,7 +6,7 @@ pub(crate) struct Justfile<'src> {
   pub(crate) assignments: Table<'src, Assignment<'src>>,
   pub(crate) aliases:     Table<'src, Alias<'src>>,
   pub(crate) settings:    Settings<'src>,
-  pub(crate) warnings:    Vec<Warning<'src>>,
+  pub(crate) warnings:    Vec<Warning>,
 }
 
 impl<'src> Justfile<'src> {
@@ -557,10 +557,10 @@ mod tests {
   run_error! {
     name: export_failure,
     src: r#"
-      export foo = "a"
-      baz = "c"
-      export bar = "b"
-      export abc = foo + bar + baz
+      export foo := "a"
+      baz := "c"
+      export bar := "b"
+      export abc := foo + bar + baz
 
       wut:
         echo $foo $bar $baz

--- a/src/module.rs
+++ b/src/module.rs
@@ -12,5 +12,5 @@ pub(crate) struct Module<'src> {
   /// Items in the justfile
   pub(crate) items:    Vec<Item<'src>>,
   /// Non-fatal warnings encountered during parsing
-  pub(crate) warnings: Vec<Warning<'src>>,
+  pub(crate) warnings: Vec<Warning>,
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -204,10 +204,8 @@ impl<'src> Node<'src> for Set<'src> {
   }
 }
 
-impl<'src> Node<'src> for Warning<'src> {
+impl<'src> Node<'src> for Warning {
   fn tree(&self) -> Tree<'src> {
-    match self {
-      Warning::DeprecatedEquals { .. } => Tree::atom("warning").push("deprecated_equals"),
-    }
+    unreachable!()
   }
 }

--- a/src/recipe_resolver.rs
+++ b/src/recipe_resolver.rs
@@ -166,8 +166,8 @@ mod tests {
 
   analysis_error! {
     name:   unknown_second_interpolation_variable,
-    input:  "wtf=\"x\"\nx:\n echo\n foo {{wtf}} {{ lol }}",
-    offset: 33,
+    input:  "wtf:=\"x\"\nx:\n echo\n foo {{wtf}} {{ lol }}",
+    offset: 34,
     line:   3,
     column: 16,
     width:  3,

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -1,39 +1,21 @@
 use crate::common::*;
 
-use Warning::*;
-
 #[derive(Debug, PartialEq)]
-pub(crate) enum Warning<'src> {
-  DeprecatedEquals { equals: Token<'src> },
-}
+pub(crate) enum Warning {}
 
-impl<'src> Warning<'src> {
-  fn context(&self) -> Option<&Token<'src>> {
-    match self {
-      DeprecatedEquals { equals } => Some(equals),
-    }
+impl Warning {
+  fn context(&self) -> Option<&Token> {
+    #![allow(clippy::unused_self)]
+    unreachable!()
   }
 }
 
-impl Display for Warning<'_> {
+impl Display for Warning {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
     let warning = Color::fmt(f).warning();
     let message = Color::fmt(f).message();
 
     write!(f, "{} {}", warning.paint("warning:"), message.prefix())?;
-
-    match self {
-      DeprecatedEquals { .. } => {
-        writeln!(
-          f,
-          "`=` in assignments, exports, and aliases is being phased out on favor of `:=`"
-        )?;
-        write!(
-          f,
-          "Please see this issue for more details: https://github.com/casey/just/issues/379"
-        )?;
-      },
-    }
 
     write!(f, "{}", message.suffix())?;
 

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -2178,15 +2178,14 @@ test! {
     default:
       echo {{foo}}
   ",
-  stdout: "bar\n",
   stderr: "
-    warning: `=` in assignments, exports, and aliases is being phased out on favor of `:=`
+    error: `=` in assignments, exports, and aliases has been phased out on favor of `:=`
     Please see this issue for more details: https://github.com/casey/just/issues/379
       |
     1 | foo = 'bar'
       |     ^
-    echo bar
   ",
+  status: EXIT_FAILURE,
 }
 
 test! {
@@ -2197,15 +2196,14 @@ test! {
     default:
       echo $FOO
     ",
-  stdout: "bar\n",
   stderr: "
-    warning: `=` in assignments, exports, and aliases is being phased out on favor of `:=`
+    error: `=` in assignments, exports, and aliases has been phased out on favor of `:=`
     Please see this issue for more details: https://github.com/casey/just/issues/379
       |
     1 | export FOO = 'bar'
       |            ^
-    echo $FOO
   ",
+  status: EXIT_FAILURE,
 }
 
 test! {
@@ -2217,15 +2215,14 @@ test! {
       echo default
   ",
   args: ("foo"),
-  stdout: "default\n",
   stderr: "
-    warning: `=` in assignments, exports, and aliases is being phased out on favor of `:=`
+    error: `=` in assignments, exports, and aliases has been phased out on favor of `:=`
     Please see this issue for more details: https://github.com/casey/just/issues/379
       |
     1 | alias foo = default
       |           ^
-    echo default
   ",
+  status: EXIT_FAILURE,
 }
 
 test! {

--- a/tests/quiet.rs
+++ b/tests/quiet.rs
@@ -66,16 +66,6 @@ default:
 }
 
 test! {
-  name: warning,
-  justfile: "
-    foo = 'bar'
-
-    baz:
-  ",
-  args: ("--quiet"),
-}
-
-test! {
   name: choose_none,
   justfile: "",
   args: ("--choose", "--quiet"),


### PR DESCRIPTION
It's been around two and a half years, and many versions, since this
warning was first introduced, so it feels reasonable to finally turn it
into a hard error. It will remain a special-cased error for a little
while.