### PR TITLE
Allow filtering varaibles to evaluate

### DIFF
--- a/completions/just.elvish
+++ b/completions/just.elvish
@@ -43,7 +43,7 @@ edit:completion:arg-completer[just] = [@words]{
             cand --dump 'Print entire justfile'
             cand -e 'Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`'
             cand --edit 'Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`'
-            cand --evaluate 'Print evaluated variables'
+            cand --evaluate 'Evaluate and print all variables. If positional arguments are present, only print the variables whose names are given as arguments.'
             cand --init 'Initialize new justfile in project root'
             cand -l 'List available recipes and their arguments'
             cand --list 'List available recipes and their arguments'

--- a/completions/just.fish
+++ b/completions/just.fish
@@ -31,7 +31,7 @@ complete -c just -n "__fish_use_subcommand" -s v -l verbose -d 'Use verbose outp
 complete -c just -n "__fish_use_subcommand" -l choose -d 'Select one or more recipes to run using a binary. If `--chooser` is not passed the chooser defaults to the value of $JUST_CHOOSER, falling back to `fzf`'
 complete -c just -n "__fish_use_subcommand" -l dump -d 'Print entire justfile'
 complete -c just -n "__fish_use_subcommand" -s e -l edit -d 'Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`'
-complete -c just -n "__fish_use_subcommand" -l evaluate -d 'Print evaluated variables'
+complete -c just -n "__fish_use_subcommand" -l evaluate -d 'Evaluate and print all variables. If positional arguments are present, only print the variables whose names are given as arguments.'
 complete -c just -n "__fish_use_subcommand" -l init -d 'Initialize new justfile in project root'
 complete -c just -n "__fish_use_subcommand" -s l -l list -d 'List available recipes and their arguments'
 complete -c just -n "__fish_use_subcommand" -l summary -d 'List names of available recipes'

--- a/completions/just.powershell
+++ b/completions/just.powershell
@@ -48,7 +48,7 @@ Register-ArgumentCompleter -Native -CommandName 'just' -ScriptBlock {
             [CompletionResult]::new('--dump', 'dump', [CompletionResultType]::ParameterName, 'Print entire justfile')
             [CompletionResult]::new('-e', 'e', [CompletionResultType]::ParameterName, 'Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`')
             [CompletionResult]::new('--edit', 'edit', [CompletionResultType]::ParameterName, 'Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`')
-            [CompletionResult]::new('--evaluate', 'evaluate', [CompletionResultType]::ParameterName, 'Print evaluated variables')
+            [CompletionResult]::new('--evaluate', 'evaluate', [CompletionResultType]::ParameterName, 'Evaluate and print all variables. If positional arguments are present, only print the variables whose names are given as arguments.')
             [CompletionResult]::new('--init', 'init', [CompletionResultType]::ParameterName, 'Initialize new justfile in project root')
             [CompletionResult]::new('-l', 'l', [CompletionResultType]::ParameterName, 'List available recipes and their arguments')
             [CompletionResult]::new('--list', 'list', [CompletionResultType]::ParameterName, 'List available recipes and their arguments')

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -44,7 +44,7 @@ _just() {
 '--dump[Print entire justfile]' \
 '-e[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' \
 '--edit[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' \
-'--evaluate[Print evaluated variables]' \
+'--evaluate[Evaluate and print all variables. If positional arguments are present, only print the variables whose names are given as arguments.]' \
 '--init[Initialize new justfile in project root]' \
 '-l[List available recipes and their arguments]' \
 '--list[List available recipes and their arguments]' \

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -107,14 +107,26 @@ impl<'src> Justfile<'src> {
       )?
     };
 
-    if let Subcommand::Evaluate { .. } = config.subcommand {
+    if let Subcommand::Evaluate { variables, .. } = &config.subcommand {
       let mut width = 0;
 
       for name in scope.names() {
+        if !variables.is_empty() && !variables.iter().any(|variable| variable == name) {
+          continue;
+        }
+
         width = cmp::max(name.len(), width);
       }
 
       for binding in scope.bindings() {
+        if !variables.is_empty()
+          && !variables
+            .iter()
+            .any(|variable| variable == binding.name.lexeme())
+        {
+          continue;
+        }
+
         println!(
           "{0:1$} := \"{2}\"",
           binding.name.lexeme(),
@@ -122,6 +134,7 @@ impl<'src> Justfile<'src> {
           binding.value
         );
       }
+
       return Ok(());
     }
 

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -13,6 +13,7 @@ pub(crate) enum Subcommand {
   Edit,
   Evaluate {
     overrides: BTreeMap<String, String>,
+    variables: Vec<String>,
   },
   Init,
   List,

--- a/tests/evaluate.rs
+++ b/tests/evaluate.rs
@@ -27,3 +27,17 @@ test! {
     a := "foo"
   "#,
 }
+
+test! {
+  name:     evaluate_arguments,
+  justfile: "
+    a := 'x'
+    b := 'y'
+    c := 'z'
+  ",
+  args:     ("--evaluate", "a", "c"),
+  stdout:   r#"
+    a := "x"
+    c := "z"
+  "#,
+}


### PR DESCRIPTION
If variable names are passed to `--evaluate`, only print those
variables.