### PR TITLE
Remove `summary` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,10 +53,6 @@ default = []
 # The `help4help2man` feature modifies the message produced by `--help`
 # so that `help2man` produces a reasonable man page.
 help4help2man = []
-# The `summary` feature includes the `summary` module, which is used
-# by Janus, https://github.com/casey/janus, a tool that analyses all
-# public justfiles on GitHub to avoid breaking changes.
-summary = []
 
 # The public documentation is minimal and doesn't change between
 # platforms, so we only build them for linux on docs.rs to save

--- a/justfile
+++ b/justfile
@@ -64,7 +64,6 @@ changes:
 check: lint clippy test
 	git diff --no-ext-diff --quiet --exit-code
 	grep {{version}} CHANGELOG.md
-	cargo build --features summary
 	cargo +nightly generate-lockfile -Z minimal-versions
 	cargo test
 	git checkout Cargo.lock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,5 +143,8 @@ pub use crate::run::run;
 #[doc(hidden)]
 pub use unindent::unindent;
 
-#[cfg(feature = "summary")]
+// Used by Janus, https://github.com/casey/janus, a tool
+// that analyses all public justfiles on GitHub to avoid
+// breaking changes.
+#[doc(hidden)]
 pub mod summary;


### PR DESCRIPTION
Remove the `summary` feature and make the `summary` module always build.
It's a small module, so it shouldn't hurt compile times, and it should
prevent accidental breakages that are only caught on CI.