### PR TITLE
'else' is a keyword

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -65,7 +65,7 @@ setting       : 'set' 'dotenv-load' boolean?
 
 boolean       : ':=' ('true' | 'false')
 
-expression    : 'if' condition '{' expression '}' else '{' expression '}'
+expression    : 'if' condition '{' expression '}' 'else' '{' expression '}'
               | value '+' expression
               | value
 


### PR DESCRIPTION
It seems that `else` was incorrect typed as a rule instead of a keyword here.