### PR TITLE
Add file_extensions to Sublime syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "test-utilities",
  "unicode-width",
  "which",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -231,6 +232,12 @@ name = "libc"
 version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
@@ -617,3 +624,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ features = ["derive"]
 executable-path   = "1.0.0"
 pretty_assertions = "0.7.0"
 which             = "4.0.0"
+yaml-rust         = "0.4.5"
 
 # Until github.com/rust-lang/cargo/pull/7333 makes it into stable,
 # this version-less dev-dependency will interfere with publishing

--- a/extras/just.sublime-syntax
+++ b/extras/just.sublime-syntax
@@ -2,6 +2,7 @@
 ---
 # http://www.sublimetext.com/docs/syntax.html
 name: Just
+file_extensions: [Justfile, just]
 scope: source.just
 contexts:
   main:

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -14,3 +14,4 @@ pub(crate) use just::unindent;
 pub(crate) use libc::{EXIT_FAILURE, EXIT_SUCCESS};
 pub(crate) use test_utilities::{assert_stdout, tempdir, tmptree};
 pub(crate) use which::which;
+pub(crate) use yaml_rust::YamlLoader;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -26,4 +26,5 @@ mod search;
 mod shebang;
 mod shell;
 mod string;
+mod sublime_syntax;
 mod working_directory;

--- a/tests/sublime_syntax.rs
+++ b/tests/sublime_syntax.rs
@@ -1,0 +1,7 @@
+use crate::common::*;
+
+#[test]
+fn parse() {
+  let yaml = fs::read_to_string("extras/just.sublime-syntax").unwrap();
+  YamlLoader::load_from_str(&yaml).unwrap();
+}


### PR DESCRIPTION
Although [1] is unclear about files without extensions, it seems the
same rule for files without basenames, i.e. using full name, also
applies in practice. For example, [2].

This also allows bat [3] to import this file [4].

In addition to `Justfile`, `just` is also added as suggested [5].

[1] http://www.sublimetext.com/docs/syntax.html
[2] https://github.com/sublimehq/Packages/blob/master/Makefile/Makefile.sublime-syntax
[3] https://github.com/sharkdp/bat
[4] https://github.com/sharkdp/bat/blob/12ecb325c911d2f059962ca71f5d90b87f92dc85/src/bin/bat/main.rs#L87
[5] https://github.com/casey/just/pull/864#issuecomment-867398424
