### PR TITLE
Expose library interface

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 fn main() {
-  if let Err(code) = just::run() {
+  if let Err(code) = just::run(std::env::args_os()) {
     std::process::exit(code);
   }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,6 +1,6 @@
 use crate::common::*;
 
-pub fn run() -> Result<(), i32> {
+pub fn run(args: impl Iterator<Item = impl Into<OsString> + Clone>) -> Result<(), i32> {
   #[cfg(windows)]
   ansi_term::enable_ansi_support().ok();
 
@@ -14,7 +14,7 @@ pub fn run() -> Result<(), i32> {
   let app = Config::app();
 
   info!("Parsing command line arguments…");
-  let matches = app.get_matches();
+  let matches = app.get_matches_from(args);
 
   let config = Config::from_matches(&matches).eprint(Color::auto())?;
 


### PR DESCRIPTION
- [x] Make `run` take arguments
- [ ] Use `get_matches_from_safe` and print help and version text ourselves
- [ ] Eliminate all uses of `std::process::exit`, to avoid terminating calling process
- [ ] Figure out how to deal with signal handler

---

Some things which are out of scope for the first MVP, but which might be nice for later:

- Don't print to stdout/stderr, or make it configurable where messages are printed to
- Pass in environment variables
- Other things which should be passed in?

---

@thomcc I decided to not go with returning an `Error` type for now, and just return an `i32`. Since this is really the first release, I think planning for a few breaking changes is reasonable.

Currently, there are many places where `just` might exit the calling process, which is clearly undesirable. For example, if the arguments are bad, or if a command fails, or if the `ctrl-c` interrupt handler gets invoked.

If this is useful to you, I could document these shortcomings, merge it as-is, and then worry about fixing those things later.

What do you think?