### PR TITLE
Warn if `.env` file is loaded in and `dotenv-load` isn't explicitly set

### DIFF
--- a/src/load_dotenv.rs
+++ b/src/load_dotenv.rs
@@ -1,7 +1,5 @@
 use crate::common::*;
 
-// Remove this on 2021-07-01.
-#[allow(unused)]
 pub(crate) fn load_dotenv(
   config: &Config,
   settings: &Settings,
@@ -19,15 +17,16 @@ pub(crate) fn load_dotenv(
     let path = directory.join(".env");
 
     if path.is_file() {
-      // Un-comment this on 2021-07-01.
-      //
-      // if settings.dotenv_load.is_none() && config.verbosity.loud() {
-      //   if config.color.stderr().active() {
-      //     eprintln!("{:#}", Warning::DotenvLoad);
-      //   } else {
-      //     eprintln!("{}", Warning::DotenvLoad);
-      //   }
-      // }
+      if settings.dotenv_load.is_none()
+        && config.verbosity.loud()
+        && !std::env::var_os("JUST_SUPPRESS_DOTENV_LOAD_WARNING")
+          .map(|val| val.as_os_str().to_str() == Some("1"))
+          .unwrap_or(false)
+      {
+        Warning::DotenvLoad
+          .write(&mut io::stderr(), config.color.stderr())
+          .ok();
+      }
 
       let iter = dotenv::from_path_iter(&path)?;
       let mut dotenv = BTreeMap::new();

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -34,6 +34,12 @@ To silence this warning and stop loading `.env` files, add:
 
     set dotenv-load := false
 
+This warning may also be silenced by setting the `JUST_SUPPRESS_DOTENV_LOAD_WARNING`
+environment variable to `1`. This can be used to silence the warning globally by
+adding the following line to your shell rc file:
+
+  export JUST_SUPPRESS_DOTENV_LOAD_WARNING=1
+
 See https://github.com/casey/just/issues/469 for more details.")?;
       },
     }

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -25,6 +25,7 @@ impl Warning {
         #[rustfmt::skip]
         write!(w, "\
 A `.env` file was found and loaded, but this behavior will change in the future.
+
 To silence this warning and continue loading `.env` files, add:
 
     set dotenv-load := true

--- a/tests/dotenv.rs
+++ b/tests/dotenv.rs
@@ -60,27 +60,35 @@ test! {
   stderr:   "echo $DOTENV_KEY\n",
 }
 
-// Un-comment this on 2021-07-01.
-//
-// test! {
-//   name:     warning,
-//   justfile: r#"
-//     foo:
-//       echo $DOTENV_KEY
-//   "#,
-//   stdout:   "dotenv-value\n",
-//   stderr:   "
-//     warning: A `.env` file was found and loaded, but this behavior will
-// change in the future.     To silence this warning and continue loading `.env`
-// files, add:
+#[test]
+fn warning() {
+  Test::new()
+    .justfile(
+      "
+      foo:
+        echo $DOTENV_KEY
+    ",
+    )
+    .stdout("dotenv-value\n")
+    .stderr(
+      "
+warning: A `.env` file was found and loaded, but this behavior will change in the future.
 
-//         set dotenv-load := true
+To \
+       silence this warning and continue loading `.env` files, add:
 
-//     To silence this warning and stop loading `.env` files, add:
+    set dotenv-load := true
 
-//         set dotenv-load := false
+To silence \
+       this warning and stop loading `.env` files, add:
 
-//     See https://github.com/casey/just/issues/469 for more details.
-//     echo $DOTENV_KEY
-//   ",
-// }
+    set dotenv-load := false
+
+See https://github.com/casey/just/issues/469 \
+       for more details.
+echo $DOTENV_KEY
+   ",
+    )
+    .suppress_dotenv_load_warning(false)
+    .run();
+}

--- a/tests/dotenv.rs
+++ b/tests/dotenv.rs
@@ -84,6 +84,15 @@ To silence \
 
     set dotenv-load := false
 
+This warning may \
+       also be silenced by setting the `JUST_SUPPRESS_DOTENV_LOAD_WARNING`
+environment variable to `1`. \
+       This can be used to silence the warning globally by
+adding the following line to your shell rc \
+       file:
+
+  export JUST_SUPPRESS_DOTENV_LOAD_WARNING=1
+
 See https://github.com/casey/just/issues/469 \
        for more details.
 echo $DOTENV_KEY

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -33,16 +33,17 @@ macro_rules! test {
 }
 
 pub(crate) struct Test {
-  pub(crate) tempdir:      TempDir,
-  pub(crate) justfile:     Option<String>,
-  pub(crate) args:         Vec<String>,
-  pub(crate) env:          BTreeMap<String, String>,
-  pub(crate) stdin:        String,
-  pub(crate) stdout:       String,
-  pub(crate) stderr:       String,
+  pub(crate) tempdir: TempDir,
+  pub(crate) justfile: Option<String>,
+  pub(crate) args: Vec<String>,
+  pub(crate) env: BTreeMap<String, String>,
+  pub(crate) stdin: String,
+  pub(crate) stdout: String,
+  pub(crate) stderr: String,
   pub(crate) stderr_regex: Option<Regex>,
-  pub(crate) status:       i32,
-  pub(crate) shell:        bool,
+  pub(crate) status: i32,
+  pub(crate) shell: bool,
+  pub(crate) suppress_dotenv_load_warning: bool,
 }
 
 impl Test {
@@ -55,12 +56,13 @@ impl Test {
       args: Vec::new(),
       env: BTreeMap::new(),
       justfile: Some(String::new()),
-      stderr_regex: None,
       shell: true,
       status: EXIT_SUCCESS,
       stderr: String::new(),
+      stderr_regex: None,
       stdin: String::new(),
       stdout: String::new(),
+      suppress_dotenv_load_warning: true,
       tempdir,
     }
   }
@@ -125,6 +127,11 @@ impl Test {
     self.stdout = stdout.into();
     self
   }
+
+  pub(crate) fn suppress_dotenv_load_warning(mut self, suppress_dotenv_load_warning: bool) -> Self {
+    self.suppress_dotenv_load_warning = suppress_dotenv_load_warning;
+    self
+  }
 }
 
 impl Test {
@@ -150,6 +157,14 @@ impl Test {
     let mut child = command
       .args(self.args)
       .envs(&self.env)
+      .env(
+        "JUST_SUPPRESS_DOTENV_LOAD_WARNING",
+        if self.suppress_dotenv_load_warning {
+          "1"
+        } else {
+          "0"
+        },
+      )
       .current_dir(self.tempdir.path())
       .stdin(Stdio::piped())
       .stdout(Stdio::piped())


### PR DESCRIPTION
If a `.env` file is found and loaded, but the `dotenv-load` setting hasn't been explicitly
set to true, print a warning to stderr. In approximately six months, `dotenv-load` will
change from defaulting to true to defaulting to false, which will be a potentially breaking
change in behavior for justfiles which elicit this warning.

See this issue for more details:

    https://github.com/casey/just/issues/469