### PR TITLE
error: reword `sh` to platform-neutral "shell command"

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -253,17 +253,17 @@ impl<'src> ColorDisplay for Error<'src> {
           match io_error.kind() {
             io::ErrorKind::NotFound => write!(
               f,
-              "Backtick could not be run because just could not find `sh`:\n{}",
+              "Backtick could not be run because just could not find the shell command:\n{}",
               io_error
             ),
             io::ErrorKind::PermissionDenied => write!(
               f,
-              "Backtick could not be run because just could not run `sh`:\n{}",
+              "Backtick could not be run because just could not run the shell command:\n{}",
               io_error
             ),
             _ => write!(
               f,
-              "Backtick could not be run because of an IO error while launching `sh`:\n{}",
+              "Backtick could not be run because of an IO error while launching the shell command:\n{}",
               io_error
             ),
           }?;
@@ -481,17 +481,17 @@ impl<'src> ColorDisplay for Error<'src> {
         match io_error.kind() {
           io::ErrorKind::NotFound => write!(
             f,
-            "Recipe `{}` could not be run because just could not find `sh`: {}",
+            "Recipe `{}` could not be run because just could not find the shell command: {}",
             recipe, io_error
           ),
           io::ErrorKind::PermissionDenied => write!(
             f,
-            "Recipe `{}` could not be run because just could not run `sh`: {}",
+            "Recipe `{}` could not be run because just could not run the shell command: {}",
             recipe, io_error
           ),
           _ => write!(
             f,
-            "Recipe `{}` could not be run because of an IO error while launching `sh`: {}",
+            "Recipe `{}` could not be run because of an IO error while launching the shell command: {}",
             recipe, io_error
           ),
         }?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -253,17 +253,17 @@ impl<'src> ColorDisplay for Error<'src> {
           match io_error.kind() {
             io::ErrorKind::NotFound => write!(
               f,
-              "Backtick could not be run because just could not find the shell command:\n{}",
+              "Backtick could not be run because just could not find the shell:\n{}",
               io_error
             ),
             io::ErrorKind::PermissionDenied => write!(
               f,
-              "Backtick could not be run because just could not run the shell command:\n{}",
+              "Backtick could not be run because just could not run the shell:\n{}",
               io_error
             ),
             _ => write!(
               f,
-              "Backtick could not be run because of an IO error while launching the shell command:\n{}",
+              "Backtick could not be run because of an IO error while launching the shell:\n{}",
               io_error
             ),
           }?;
@@ -481,17 +481,17 @@ impl<'src> ColorDisplay for Error<'src> {
         match io_error.kind() {
           io::ErrorKind::NotFound => write!(
             f,
-            "Recipe `{}` could not be run because just could not find the shell command: {}",
+            "Recipe `{}` could not be run because just could not find the shell: {}",
             recipe, io_error
           ),
           io::ErrorKind::PermissionDenied => write!(
             f,
-            "Recipe `{}` could not be run because just could not run the shell command: {}",
+            "Recipe `{}` could not be run because just could not run the shell: {}",
             recipe, io_error
           ),
           _ => write!(
             f,
-            "Recipe `{}` could not be run because of an IO error while launching the shell command: {}",
+            "Recipe `{}` could not be run because of an IO error while launching the shell: {}",
             recipe, io_error
           ),
         }?;


### PR DESCRIPTION
A simple workaround for #412, to avoid confusion on Windows without `sh`. It's a hint to look up `shell` variable, instead of trying to find a UNIX `sh` implementation.

There's no existing test with this text, and I tried making some with `not-a-command` in `shell`, `x:=\`\``, and recipe. But they are platform-specific too, and changes depending on whether I have busybox utils in PATH or not. So I have left them out for this PR.