### PR TITLE
Add `quote` function for escaping strings

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -888,6 +888,7 @@ The executable is at: /bin/just
 ==== String Manipulation
 
 - `lowercase(s)` - Convert `s` to lowercase.
+- `quote(s)` - Replace all single quotes with `'\''` and prepend and append single quotes to `s`. This is sufficient to escape special characters for many shells, including most Bourne shell descendants.
 - `replace(s, from, to)` - Replace all occurrences of `from` in `s` to `to`.
 - `trim(s)` - Remove leading and trailing whitespace from `s`.
 - `trim_end(s)` - Remove trailing whitespace from `s`.

--- a/src/function.rs
+++ b/src/function.rs
@@ -27,6 +27,7 @@ lazy_static! {
     ("os", Nullary(os)),
     ("os_family", Nullary(os_family)),
     ("parent_directory", Unary(parent_directory)),
+    ("quote", Unary(quote)),
     ("replace", Ternary(replace)),
     ("trim", Unary(trim)),
     ("trim_end", Unary(trim_end)),
@@ -204,6 +205,10 @@ fn parent_directory(_context: &FunctionContext, path: &str) -> Result<String, St
     .parent()
     .map(Utf8Path::to_string)
     .ok_or_else(|| format!("Could not extract parent directory from `{}`", path))
+}
+
+fn quote(_context: &FunctionContext, s: &str) -> Result<String, String> {
+  Ok(format!("'{}'", s.replace('\'', "'\\''")))
 }
 
 fn replace(_context: &FunctionContext, s: &str, from: &str, to: &str) -> Result<String, String> {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -26,6 +26,7 @@ mod invocation_directory;
 mod misc;
 mod positional_arguments;
 mod quiet;
+mod quote;
 mod readme;
 mod regexes;
 mod search;

--- a/tests/quote.rs
+++ b/tests/quote.rs
@@ -1,0 +1,43 @@
+use crate::common::*;
+
+#[test]
+fn single_quotes_are_prepended_and_appended() {
+  Test::new()
+    .justfile(
+      "
+      x := quote('abc')
+    ",
+    )
+    .args(&["--evaluate", "x"])
+    .stdout("'abc'")
+    .run();
+}
+
+#[test]
+fn quotes_are_escaped() {
+  Test::new()
+    .justfile(
+      r#"
+      x := quote("'")
+    "#,
+    )
+    .args(&["--evaluate", "x"])
+    .stdout(r"''\'''")
+    .run();
+}
+
+#[test]
+fn quoted_strings_can_be_used_as_arguments() {
+  Test::new()
+    .justfile(
+      r#"
+      file := quote("foo ' bar")
+
+      @foo:
+        touch {{ file }}
+        ls -1
+    "#,
+    )
+    .stdout("foo ' bar\njustfile\n")
+    .run();
+}


### PR DESCRIPTION
`quote(s)` surrounds `s` with single quotes and replaces all single
quotes in `s` with `'\''`, serving to escape special characters for most
shells, including Bourne shell descendants.