### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,7 @@ Yay, all your tests passed!
 `just` has a ton of useful features, and many improvements over `make`:
 
 - `just` is a command runner, not a build system, so it avoids much of
-  link:https://github.com/casey/just#what-are-the-idiosyncrasies-of-make-that-just-avoids[`make`'s
+  link:https://github.com/casey/just#what-are-the-idiosyncrasies-of-make-that-just-avoids[``make``'s
   complexity and idiosyncrasies]. No need for `.PHONY` recipes!
 
 - Linux, MacOS, and Windows are supported with no additional dependencies. (Although if your system doesn't have an `sh`, you'll need to link:https://github.com/casey/just#shell[choose a different shell].)


### PR DESCRIPTION
Before this PR the monospace formatting would extend until `.PHONY`. I'm not sure exactly why, [this](https://docs.asciidoctor.org/asciidoc/latest/text/monospace/) documentation sounds like the version on master should work. In any case, switching to [unconstrained](https://docs.asciidoctor.org/asciidoc/latest/text/monospace/#unconstrained) monospace seems to fix it on github.