### PR TITLE
Make completions work with an alias

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1750,6 +1750,12 @@ Tools that pair nicely with `just` include:
 
 For lightning-fast command running, put `alias j=just` in your shell's configuration file.
 
+The aliased command may not keep the shell completion functionality described in the next section. In Bash, you can use the same completion function as `just` for your aliased command.
+
+```sh
+complete -F _just -o bashdefault -o default j
+```
+
 === Shell Completion Scripts
 
 Shell completion scripts for Bash, Zsh, Fish, PowerShell, and Elvish are available in the link:completions[] directory. Please refer to your shell's documentation for how to install them.

--- a/README.adoc
+++ b/README.adoc
@@ -1750,7 +1750,7 @@ Tools that pair nicely with `just` include:
 
 For lightning-fast command running, put `alias j=just` in your shell's configuration file.
 
-The aliased command may not keep the shell completion functionality described in the next section. In Bash, you can use the same completion function as `just` for your aliased command.
+In `bash`, the aliased command may not keep the shell completion functionality described in the next section. Add the following line to your `.bashrc` to use the same completion function as `just` for your aliased command:
 
 ```sh
 complete -F _just -o bashdefault -o default j

--- a/completions/just.bash
+++ b/completions/just.bash
@@ -9,7 +9,7 @@ _just() {
     for i in ${COMP_WORDS[@]}
     do
         case "${i}" in
-            just)
+            "$1")
                 cmd="just"
                 ;;
             

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -172,8 +172,6 @@ pub(crate) const BASH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
                         return 0
                     fi
                 fi"#,
-  ), (
-    r#"            just)"#,
-    r#"            "$1")"#,
-    )
+  ),
+  (r#"            just)"#, r#"            "$1")"#),
 ];

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -156,12 +156,13 @@ pub(crate) const POWERSHELL_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[(
         Sort-Object -Property ListItemText"#,
 )];
 
-pub(crate) const BASH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[(
-  r#"            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+pub(crate) const BASH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
+  (
+    r#"            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi"#,
-  r#"                if [[ ${cur} == -* ]] ; then
+    r#"                if [[ ${cur} == -* ]] ; then
                     COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                     return 0
                 elif [[ ${COMP_CWORD} -eq 1 ]]; then
@@ -171,4 +172,8 @@ pub(crate) const BASH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[(
                         return 0
                     fi
                 fi"#,
-)];
+  ), (
+    r#"            just)"#,
+    r#"            "$1")"#,
+    )
+];


### PR DESCRIPTION
Right now if you use the README recommended alias, `alias j=just`, in bash, it stops shell completion from working.

This is a small PR to allow the bash completions script to work with an alias, and adds instructions in the README for how to use it.