### PR TITLE
Add environment variables for shell and shell-arg

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -218,6 +218,7 @@ impl Config {
           .long("shell")
           .takes_value(true)
           .default_value(DEFAULT_SHELL)
+          .env("JUST_SHELL")
           .help("Invoke <SHELL> to run recipes"),
       )
       .arg(
@@ -227,6 +228,7 @@ impl Config {
           .multiple(true)
           .number_of_values(1)
           .default_value(DEFAULT_SHELL_ARG)
+          .env("JUST_SHELL_ARG")
           .allow_hyphen_values(true)
           .overrides_with(arg::CLEAR_SHELL_ARGS)
           .help("Invoke shell with <SHELL-ARG> as an argument"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -700,10 +700,10 @@ OPTIONS:
             Override <VARIABLE> with <VALUE>
 
         --shell <SHELL>
-            Invoke <SHELL> to run recipes [default: sh]
+            Invoke <SHELL> to run recipes [env: JUST_SHELL=]  [default: sh]
 
         --shell-arg <SHELL-ARG>...
-            Invoke shell with <SHELL-ARG> as an argument [default: -cu]
+            Invoke shell with <SHELL-ARG> as an argument [env: JUST_SHELL_ARG=]  [default: -cu]
 
     -s, --show <RECIPE>
             Show information about <RECIPE>


### PR DESCRIPTION
shell and shell arguments can now be defined system-wide using env vars. Discussion in #1050