### PR TITLE
Change dotenv-load default to false

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unknown_clippy_lints)]
+#![allow(unknown_lints)]
 #![allow(clippy::unnecessary_wraps)]
 
 use crate::common::*;

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints)]
+#![allow(clippy::unknown_clippy_lints)]
 #![allow(clippy::unnecessary_wraps)]
 
 use crate::common::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(
   clippy::doc_markdown,
+  clippy::empty_enum,
   clippy::enum_glob_use,
   clippy::if_not_else,
   clippy::missing_errors_doc,

--- a/src/load_dotenv.rs
+++ b/src/load_dotenv.rs
@@ -7,7 +7,7 @@ pub(crate) fn load_dotenv(
   settings: &Settings,
   working_directory: &Path,
 ) -> RunResult<'static, BTreeMap<String, String>> {
-  if !settings.dotenv_load.unwrap_or(true)
+  if !settings.dotenv_load.unwrap_or(false)
     && config.dotenv_filename.is_none()
     && config.dotenv_path.is_none()
   {
@@ -42,19 +42,6 @@ fn load_from_file(
   // `dotenv::from_path_iter` should eventually be un-deprecated, see:
   // https://github.com/dotenv-rs/dotenv/issues/13
   #![allow(deprecated)]
-
-  if config.verbosity.loud()
-    && settings.dotenv_load.is_none()
-    && config.dotenv_filename.is_none()
-    && config.dotenv_path.is_none()
-    && !std::env::var_os("JUST_SUPPRESS_DOTENV_LOAD_WARNING")
-      .map_or(false, |val| val.as_os_str().to_str() == Some("1"))
-  {
-    eprintln!(
-      "{}",
-      Warning::DotenvLoad.color_display(config.color.stderr())
-    );
-  }
 
   let iter = dotenv::from_path_iter(&path)?;
   let mut dotenv = BTreeMap::new();

--- a/src/load_dotenv.rs
+++ b/src/load_dotenv.rs
@@ -15,7 +15,7 @@ pub(crate) fn load_dotenv(
   }
 
   if let Some(path) = &config.dotenv_path {
-    return load_from_file(config, settings, path);
+    return load_from_file(path);
   }
 
   let filename = config
@@ -27,18 +27,14 @@ pub(crate) fn load_dotenv(
   for directory in working_directory.ancestors() {
     let path = directory.join(&filename);
     if path.is_file() {
-      return load_from_file(config, settings, &path);
+      return load_from_file(&path);
     }
   }
 
   Ok(BTreeMap::new())
 }
 
-fn load_from_file(
-  config: &Config,
-  settings: &Settings,
-  path: &Path,
-) -> RunResult<'static, BTreeMap<String, String>> {
+fn load_from_file(path: &Path) -> RunResult<'static, BTreeMap<String, String>> {
   // `dotenv::from_path_iter` should eventually be un-deprecated, see:
   // https://github.com/dotenv-rs/dotenv/issues/13
   #![allow(deprecated)]

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -4,6 +4,7 @@ use crate::common::*;
 pub(crate) enum Warning {}
 
 impl Warning {
+  #[allow(clippy::unused_self)]
   fn context(&self) -> Option<&Token> {
     None
   }
@@ -15,10 +16,6 @@ impl ColorDisplay for Warning {
     let message = color.message();
 
     write!(f, "{} {}", warning.paint("warning:"), message.prefix())?;
-
-    match self {
-      _ => {}
-    }
 
     write!(f, "{}", message.suffix())?;
 

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -1,15 +1,11 @@
 use crate::common::*;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum Warning {
-  DotenvLoad,
-}
+pub(crate) enum Warning {}
 
 impl Warning {
   fn context(&self) -> Option<&Token> {
-    match self {
-      Self::DotenvLoad => None,
-    }
+    None
   }
 }
 
@@ -21,27 +17,7 @@ impl ColorDisplay for Warning {
     write!(f, "{} {}", warning.paint("warning:"), message.prefix())?;
 
     match self {
-      Self::DotenvLoad => {
-        #[rustfmt::skip]
-        write!(f, "\
-A `.env` file was found and loaded, but this behavior will change in the future.
-
-To silence this warning and continue loading `.env` files, add:
-
-    set dotenv-load := true
-
-To silence this warning and stop loading `.env` files, add:
-
-    set dotenv-load := false
-
-This warning may also be silenced by setting the `JUST_SUPPRESS_DOTENV_LOAD_WARNING`
-environment variable to `1`. This can be used to silence the warning globally by
-adding the following line to your shell rc file:
-
-  export JUST_SUPPRESS_DOTENV_LOAD_WARNING=1
-
-See https://github.com/casey/just/issues/469 for more details.")?;
-      }
+      _ => {}
     }
 
     write!(f, "{}", message.suffix())?;

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -43,6 +43,8 @@ test! {
 test! {
   name: env_is_loaded,
   justfile: "
+    set dotenv-load
+
     x:
       echo XYZ
   ",

--- a/tests/dotenv.rs
+++ b/tests/dotenv.rs
@@ -6,7 +6,7 @@ fn dotenv() {
     ".env": "KEY=ROOT",
     sub: {
       ".env": "KEY=SUB",
-      justfile: "default:\n\techo KEY=$KEY",
+      justfile: "default:\n\techo KEY=${KEY:-unset}",
     },
   };
 
@@ -21,7 +21,7 @@ fn dotenv() {
   assert_eq!(output.status.code().unwrap(), 0);
 
   let stdout = str::from_utf8(&output.stdout).unwrap();
-  assert_eq!(stdout, "KEY=SUB\n");
+  assert_eq!(stdout, "KEY=unset\n");
 }
 
 test! {
@@ -61,43 +61,16 @@ test! {
 }
 
 #[test]
-fn warning() {
+fn no_warning() {
   Test::new()
     .justfile(
       "
       foo:
-        echo $DOTENV_KEY
+        echo ${DOTENV_KEY:-unset}
     ",
     )
-    .stdout("dotenv-value\n")
-    .stderr(
-      "
-warning: A `.env` file was found and loaded, but this behavior will change in the future.
-
-To \
-       silence this warning and continue loading `.env` files, add:
-
-    set dotenv-load := true
-
-To silence \
-       this warning and stop loading `.env` files, add:
-
-    set dotenv-load := false
-
-This warning may \
-       also be silenced by setting the `JUST_SUPPRESS_DOTENV_LOAD_WARNING`
-environment variable to `1`. \
-       This can be used to silence the warning globally by
-adding the following line to your shell rc \
-       file:
-
-  export JUST_SUPPRESS_DOTENV_LOAD_WARNING=1
-
-See https://github.com/casey/just/issues/469 \
-       for more details.
-echo $DOTENV_KEY
-   ",
-    )
+    .stdout("unset\n")
+    .stderr("echo ${DOTENV_KEY:-unset}\n")
     .suppress_dotenv_load_warning(false)
     .run();
 }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1553,6 +1553,8 @@ test! {
    name:     dotenv_variable_in_recipe,
    justfile: "
 #
+set dotenv-load
+
 echo:
   echo $DOTENV_KEY
  ",
@@ -1564,6 +1566,7 @@ test! {
    name:     dotenv_variable_in_backtick,
    justfile: "
 #
+set dotenv-load
 X:=`echo $DOTENV_KEY`
 echo:
   echo {{X}}
@@ -1575,6 +1578,7 @@ test! {
    name:     dotenv_variable_in_function_in_recipe,
    justfile: "
 #
+set dotenv-load
 echo:
   echo {{env_var_or_default('DOTENV_KEY', 'foo')}}
   echo {{env_var('DOTENV_KEY')}}
@@ -1587,6 +1591,7 @@ test! {
    name:     dotenv_variable_in_function_in_backtick,
    justfile: "
 #
+set dotenv-load
 X:=env_var_or_default('DOTENV_KEY', 'foo')
 Y:=env_var('DOTENV_KEY')
 echo:


### PR DESCRIPTION
This changes the default value of `dotenv-load` from `true` to `false`. This is a backwards incompatible change, and will require a minor version bump. After this change, there is nothing stopping a 1.0 release. I was thinking about still including the warning after this change, if a dotenv file was found but not loaded, but decided to skip it. The warning has been around for a long time, so hopefully everyone relying on the old behavior has migrated.