### PR TITLE
Detail environment variables usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ Available recipes:
 
 ### Dotenv Integration
 
-If `dotenv-load` is set to `true`, `just` will load environment variables from a file named `.env`. This file can be located in the same directory as your `justfile` or in a parent directory. These variables are environment variables, not `just` variables, and so must be accessed using `$VARIABLE_NAME` in recipes and backticks.
+If [`dotenv-load`](#dotenv-load) is set to `true`, `just` will load environment variables from a file named `.env`. This file can be located in the same directory as your `justfile` or in a parent directory. These variables are environment variables, not `just` variables, and so must be accessed using `$VARIABLE_NAME` in recipes and backticks.
 
 For example, if your `.env` file contains:
 
@@ -897,9 +897,17 @@ This is an x86_64 machine
 
 #### Environment Variables
 
-- `env_var(key)` — Retrieves the environment variable with name `key`, aborting if it is not present.
+- `env_var(key)` — Retrieves the environment variable with name `key`, aborting if it is not present. It will be available as environment variable to the recipes.
 
-- `env_var_or_default(key, default)` — Retrieves the environment variable with name `key`, returning `default` if it is not present.
+```make
+HELLO := env_var('HELLO')
+
+test:
+  echo "${HELLO}"
+```
+
+- `env_var_or_default(key, default)` — Retrieves the environment variable with name `key`, returning `default` if it is not present. It will be available as environment variable to the recipes.
+
 
 #### Invocation Directory
 
@@ -1142,6 +1150,8 @@ $ just --set os bsd
 
 ### Environment Variables
 
+#### Exporting `just` variables
+
 Assignments prefixed with the `export` keyword will be exported to recipes as environment variables:
 
 ```make
@@ -1173,6 +1183,27 @@ BAR := `echo hello $WORLD`
 a $A $B=`echo $A`:
   echo $A $B
 ```
+
+When [export](#export) is set, all `just` variables are exported as environment variables.
+
+```make
+export := true
+
+HELLO := "Hello"
+WORLD := "World"
+
+test:
+  echo "${HELLO} ${WORLD}"  # will display 'Hello World'
+```
+
+#### Loading Environment Variables from a `.env` File
+
+`just` will load environment variables from a `.env` file if [dotenv-load](#dotenv-load) is set. The variables in the file will be available as environment variables to the recipes. See [dotenv-integration](#dotenv-integration) for more information.
+
+#### Setting `just` Variables from Environments Variables
+
+Environment variables can be propagated to `just` variables using the functions `env_var()` and `env_var_or_default()`. These variables will be available as environment variables to the recipes.
+See [environment-variables](#environment-variables).
 
 ### Recipe Parameters
 

--- a/README.md
+++ b/README.md
@@ -897,17 +897,19 @@ This is an x86_64 machine
 
 #### Environment Variables
 
-- `env_var(key)` — Retrieves the environment variable with name `key`, aborting if it is not present. It will be available as environment variable to the recipes.
+- `env_var(key)` — Retrieves the environment variable with name `key`, aborting if it is not present.
 
 ```make
-HELLO := env_var('HELLO')
+home_dir := env_var('HOME')
 
 test:
-  echo "${HELLO}"
+  echo "{{home_dir}}"
+
+$ just
+/home/user1
 ```
 
-- `env_var_or_default(key, default)` — Retrieves the environment variable with name `key`, returning `default` if it is not present. It will be available as environment variable to the recipes.
-
+- `env_var_or_default(key, default)` — Retrieves the environment variable with name `key`, returning `default` if it is not present.
 
 #### Invocation Directory
 
@@ -1148,7 +1150,7 @@ $ just --set os bsd
 ./test --test bsd
 ```
 
-### Environment Variables
+### Getting and Setting Environment Variables
 
 #### Exporting `just` Variables
 
@@ -1186,13 +1188,24 @@ a $A $B=`echo $A`:
 
 When [export](#export) is set, all `just` variables are exported as environment variables.
 
+#### Getting Environment Variables from the environment
+
+Environment variables from the environment are passed automatically to the recipes.
+
+```make
+print_home_folder:
+  echo "HOME is: '${HOME}'"
+
+$ just
+HOME is '/home/myuser'
+```
 #### Loading Environment Variables from a `.env` File
 
 `just` will load environment variables from a `.env` file if [dotenv-load](#dotenv-load) is set. The variables in the file will be available as environment variables to the recipes. See [dotenv-integration](#dotenv-integration) for more information.
 
 #### Setting `just` Variables from Environments Variables
 
-Environment variables can be propagated to `just` variables using the functions `env_var()` and `env_var_or_default()`. These variables will be available as environment variables to the recipes.
+Environment variables can be propagated to `just` variables using the functions `env_var()` and `env_var_or_default()`.
 See [environment-variables](#environment-variables).
 
 ### Recipe Parameters

--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ Available recipes:
 
 ### Dotenv Integration
 
-If [`dotenv-load`](#dotenv-load) is set to `true`, `just` will load environment variables from a file named `.env`. This file can be located in the same directory as your `justfile` or in a parent directory. These variables are environment variables, not `just` variables, and so must be accessed using `$VARIABLE_NAME` in recipes and backticks.
+If [`dotenv-load`](#dotenv-load) is set, `just` will load environment variables from a file named `.env`. This file can be located in the same directory as your `justfile` or in a parent directory. These variables are environment variables, not `just` variables, and so must be accessed using `$VARIABLE_NAME` in recipes and backticks.
 
 For example, if your `.env` file contains:
 

--- a/README.md
+++ b/README.md
@@ -904,7 +904,9 @@ home_dir := env_var('HOME')
 
 test:
   echo "{{home_dir}}"
+```
 
+```sh
 $ just
 /home/user1
 ```
@@ -1195,7 +1197,9 @@ Environment variables from the environment are passed automatically to the recip
 ```make
 print_home_folder:
   echo "HOME is: '${HOME}'"
+```
 
+```sh
 $ just
 HOME is '/home/myuser'
 ```

--- a/README.md
+++ b/README.md
@@ -1150,7 +1150,7 @@ $ just --set os bsd
 
 ### Environment Variables
 
-#### Exporting `just` variables
+#### Exporting `just` Variables
 
 Assignments prefixed with the `export` keyword will be exported to recipes as environment variables:
 

--- a/README.md
+++ b/README.md
@@ -1186,16 +1186,6 @@ a $A $B=`echo $A`:
 
 When [export](#export) is set, all `just` variables are exported as environment variables.
 
-```make
-export := true
-
-HELLO := "Hello"
-WORLD := "World"
-
-test:
-  echo "${HELLO} ${WORLD}"  # will display 'Hello World'
-```
-
 #### Loading Environment Variables from a `.env` File
 
 `just` will load environment variables from a `.env` file if [dotenv-load](#dotenv-load) is set. The variables in the file will be available as environment variables to the recipes. See [dotenv-integration](#dotenv-integration) for more information.


### PR DESCRIPTION
# Why the change

The section [Environment Variables](https://github.com/casey/just#environment-variables-1) in the README only provides information about passing environment variables to the recipes.
Finding the information about how to create `just` variables from the shell environment variables can be difficult.

# What's the change

The "Environment Variables" section now adds 2 subsections:
- How to pass environment variables to recipes
- Loading just variables from the shell environments variables

Additionally, the subsection "How to pass environment variables to recipes"
now includes information about the `export` setting, using dotenv, and the `dotenv-load` setting.