### PR TITLE
Allow duplicate recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,14 +519,14 @@ foo:
 
 #### Table of Settings
 
-| Name                      | Value              | Description                                                    |
-| ------------------------- | ------------------ | -------------------------------------------------------------- |
+| Name                      | Value              | Description                                                                                   |
+| ------------------------- | ------------------ | --------------------------------------------------------------------------------------------- |
 | `allow-duplicate-recipes` | boolean            | Allow recipes appearing later in a `justfile` to override earlier recipes with the same name. |
-| `dotenv-load`             | boolean            | Load a `.env` file, if present.                                |
-| `export`                  | boolean            | Export all variables as environment variables.                 |
-| `positional-arguments`    | boolean            | Pass positional arguments.                                     |
-| `shell`                   | `[COMMAND, ARGS…]` | Set the command used to invoke recipes and evaluate backticks. |
-| `windows-powershell`      | boolean            | Use PowerShell on Windows as default shell.                    |
+| `dotenv-load`             | boolean            | Load a `.env` file, if present.                                                               |
+| `export`                  | boolean            | Export all variables as environment variables.                                                |
+| `positional-arguments`    | boolean            | Pass positional arguments.                                                                    |
+| `shell`                   | `[COMMAND, ARGS…]` | Set the command used to invoke recipes and evaluate backticks.                                |
+| `windows-powershell`      | boolean            | Use PowerShell on Windows as default shell.                                                   |
 
 Boolean settings can be written as:
 

--- a/README.md
+++ b/README.md
@@ -519,13 +519,14 @@ foo:
 
 #### Table of Settings
 
-| Name                   | Value              | Description                                                    |
-| ---------------------- | ------------------ | -------------------------------------------------------------- |
-| `dotenv-load`          | boolean            | Load a `.env` file, if present.                                |
-| `export`               | boolean            | Export all variables as environment variables.                 |
-| `positional-arguments` | boolean            | Pass positional arguments.                                     |
-| `shell`                | `[COMMAND, ARGS…]` | Set the command used to invoke recipes and evaluate backticks. |
-| `windows-powershell`   | boolean            | Use PowerShell on Windows as default shell.                    |
+| Name                      | Value              | Description                                                    |
+| ------------------------- | ------------------ | -------------------------------------------------------------- |
+| `allow-duplicate-recipes` | boolean            | Allow duplicate recipes (last definition is used).             |
+| `dotenv-load`             | boolean            | Load a `.env` file, if present.                                |
+| `export`                  | boolean            | Export all variables as environment variables.                 |
+| `positional-arguments`    | boolean            | Pass positional arguments.                                     |
+| `shell`                   | `[COMMAND, ARGS…]` | Set the command used to invoke recipes and evaluate backticks. |
+| `windows-powershell`      | boolean            | Use PowerShell on Windows as default shell.                    |
 
 Boolean settings can be written as:
 
@@ -537,6 +538,25 @@ Which is equivalent to:
 
 ```mf
 set NAME := true
+```
+
+#### Allow Duplicate Recipes
+
+If `allow-duplicate-recipes` is `true`, recipes can be redefined, (the last definition will be used). Defaults to `false`.
+
+```make
+set allow-duplicate-recipes
+
+@foo:
+  echo foo
+
+@foo:
+  echo bar
+```
+
+```sh
+$ just foo
+bar
 ```
 
 #### Dotenv Load

--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ set NAME := true
 
 #### Allow Duplicate Recipes
 
-If `allow-duplicate-recipes` is `true`, recipes can be redefined, (the last definition will be used). Defaults to `false`.
+If `allow-duplicate-recipes` is `true`, recipes can be redefined and the last definition of duplicate recipes will be used. Defaults to `false`.
 
 ```make
 set allow-duplicate-recipes

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ set NAME := true
 
 #### Allow Duplicate Recipes
 
-If `allow-duplicate-recipes` is `true`, defining multiple recipes with the same name is not an error, and the last definition is used. Defaults to `false`.
+If `allow-duplicate-recipes` is set to `true`, defining multiple recipes with the same name is not an error and the last definition is used. Defaults to `false`.
 
 ```make
 set allow-duplicate-recipes

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ foo:
 
 | Name                      | Value              | Description                                                    |
 | ------------------------- | ------------------ | -------------------------------------------------------------- |
-| `allow-duplicate-recipes` | boolean            | Allow duplicate recipes (last definition is used).             |
+| `allow-duplicate-recipes` | boolean            | Allow recipes appearing later in a `justfile` to override earlier recipes with the same name. |
 | `dotenv-load`             | boolean            | Load a `.env` file, if present.                                |
 | `export`                  | boolean            | Export all variables as environment variables.                 |
 | `positional-arguments`    | boolean            | Pass positional arguments.                                     |
@@ -542,7 +542,7 @@ set NAME := true
 
 #### Allow Duplicate Recipes
 
-If `allow-duplicate-recipes` is `true`, recipes can be redefined and the last definition of duplicate recipes will be used. Defaults to `false`.
+If `allow-duplicate-recipes` is `true`, defining multiple recipes with the same name is not an error, and the last definition is used. Defaults to `false`.
 
 ```make
 set allow-duplicate-recipes

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -70,7 +70,7 @@ impl<'src> Analyzer<'src> {
 
     AssignmentResolver::resolve_assignments(&assignments)?;
 
-    for recipe in recipes.into_iter() {
+    for recipe in recipes {
       if let Some(original) = self.recipes.get(recipe.name.lexeme()) {
         if settings.allow_duplicate_recipes {
             self.recipes.remove(recipe.name.lexeme());
@@ -316,7 +316,7 @@ mod tests {
     width:  1,
     kind:   DuplicateRecipe{recipe: "a", first: 0},
   }
-  
+
   analysis_error! {
     name:   duplicate_variable,
     input:  "a := \"0\"\na := \"0\"",

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -319,16 +319,6 @@ mod tests {
   }
   
   analysis_error! {
-    name:   duplicate_recipes_with_allowed_duplicates,
-    input:  "set allow-duplicates := true\na:\nb:\na:",
-    offset:  6,
-    line:   2,
-    column: 0,
-    width:  1,
-    kind:   DuplicateRecipe{recipe: "a", first: 0},
-  }
-
-  analysis_error! {
     name:   duplicate_variable,
     input:  "a := \"0\"\na := \"0\"",
     offset: 9,

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -72,9 +72,7 @@ impl<'src> Analyzer<'src> {
 
     for recipe in recipes {
       if let Some(original) = self.recipes.get(recipe.name.lexeme()) {
-        if settings.allow_duplicate_recipes {
-            self.recipes.remove(recipe.name.lexeme());
-        } else {
+        if !settings.allow_duplicate_recipes {
           return Err(recipe.name.token().error(DuplicateRecipe {
             recipe: original.name(),
             first: original.line_number(),
@@ -121,7 +119,6 @@ impl<'src> Analyzer<'src> {
   }
 
   fn analyze_recipe(&self, recipe: &UnresolvedRecipe<'src>) -> CompileResult<'src, ()> {
-
     let mut parameters = BTreeSet::new();
     let mut passed_default = false;
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -30,7 +30,7 @@ impl<'src> Analyzer<'src> {
         }
         Item::Comment(_) => (),
         Item::Recipe(recipe) => {
-          self.analyze_recipe(&recipe)?;
+          Self::analyze_recipe(&recipe)?;
           recipes.push(recipe);
         }
         Item::Set(set) => {
@@ -118,7 +118,7 @@ impl<'src> Analyzer<'src> {
     })
   }
 
-  fn analyze_recipe(&self, recipe: &UnresolvedRecipe<'src>) -> CompileResult<'src, ()> {
+  fn analyze_recipe(recipe: &UnresolvedRecipe<'src>) -> CompileResult<'src, ()> {
     let mut parameters = BTreeSet::new();
     let mut passed_default = false;
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -16,7 +16,7 @@ impl<'src> Analyzer<'src> {
   }
 
   pub(crate) fn justfile(mut self, ast: Ast<'src>) -> CompileResult<'src, Justfile<'src>> {
-    let mut recipes: Vec<UnresolvedRecipe<'src>> = Vec::new();
+    let mut recipes = Vec::new();
 
     for item in ast.items {
       match item {

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -34,7 +34,7 @@ impl<'src> Analyzer<'src> {
         Item::Recipe(recipe) => {
           let r = self.analyze_recipe(&recipe);
           match r {
-              Err(CompileError{token: _, kind: DuplicateRecipe{..}}) if settings.allow_duplicates => {
+              Err(CompileError{token: _, kind: DuplicateRecipe{..}}) if settings.allow_duplicate_recipes => {
                   self.recipes.remove(recipe.name.lexeme());
               },
               Err(e) => return Err(e),
@@ -177,8 +177,8 @@ impl<'src> Analyzer<'src> {
 
   fn resolve_set(&self, settings: &mut Settings<'src>, set: Set<'src>) -> CompileResult<'src, ()> {
     match set.value {
-      Setting::AllowDuplicates(allow_duplicates) => {
-        settings.allow_duplicates = allow_duplicates;
+      Setting::AllowDuplicateRecipes(allow_duplicate_recipes) => {
+        settings.allow_duplicate_recipes = allow_duplicate_recipes;
       }
       Setting::DotenvLoad(dotenv_load) => {
         settings.dotenv_load = Some(dotenv_load);

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -4,7 +4,7 @@ use crate::common::*;
 #[strum(serialize_all = "kebab_case")]
 pub(crate) enum Keyword {
   Alias,
-  AllowDuplicates,
+  AllowDuplicateRecipes,
   DotenvLoad,
   Else,
   Export,

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -4,6 +4,7 @@ use crate::common::*;
 #[strum(serialize_all = "kebab_case")]
 pub(crate) enum Keyword {
   Alias,
+  AllowDuplicates,
   DotenvLoad,
   Else,
   Export,

--- a/src/node.rs
+++ b/src/node.rs
@@ -221,7 +221,7 @@ impl<'src> Node<'src> for Set<'src> {
     set.push_mut(self.name.lexeme().replace('-', "_"));
 
     match &self.value {
-      DotenvLoad(value) | Export(value) | PositionalArguments(value) | WindowsPowerShell(value) => {
+      AllowDuplicates(value) | DotenvLoad(value) | Export(value) | PositionalArguments(value) | WindowsPowerShell(value) => {
         set.push_mut(value.to_string());
       }
       Shell(setting::Shell { command, arguments }) => {

--- a/src/node.rs
+++ b/src/node.rs
@@ -221,7 +221,11 @@ impl<'src> Node<'src> for Set<'src> {
     set.push_mut(self.name.lexeme().replace('-', "_"));
 
     match &self.value {
-      AllowDuplicateRecipes(value) | DotenvLoad(value) | Export(value) | PositionalArguments(value) | WindowsPowerShell(value) => {
+      AllowDuplicateRecipes(value)
+      | DotenvLoad(value)
+      | Export(value)
+      | PositionalArguments(value)
+      | WindowsPowerShell(value) => {
         set.push_mut(value.to_string());
       }
       Shell(setting::Shell { command, arguments }) => {

--- a/src/node.rs
+++ b/src/node.rs
@@ -221,7 +221,7 @@ impl<'src> Node<'src> for Set<'src> {
     set.push_mut(self.name.lexeme().replace('-', "_"));
 
     match &self.value {
-      AllowDuplicates(value) | DotenvLoad(value) | Export(value) | PositionalArguments(value) | WindowsPowerShell(value) => {
+      AllowDuplicateRecipes(value) | DotenvLoad(value) | Export(value) | PositionalArguments(value) | WindowsPowerShell(value) => {
         set.push_mut(value.to_string());
       }
       Shell(setting::Shell { command, arguments }) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -729,7 +729,13 @@ impl<'tokens, 'src> Parser<'tokens, 'src> {
     let name = Name::from_identifier(self.presume(Identifier)?);
     let lexeme = name.lexeme();
 
-    if Keyword::DotenvLoad == lexeme {
+    if Keyword::AllowDuplicates == lexeme {
+      let value = self.parse_set_bool()?;
+      return Ok(Set {
+        value: Setting::AllowDuplicates(value),
+        name,
+      });
+    } else if Keyword::DotenvLoad == lexeme {
       let value = self.parse_set_bool()?;
       return Ok(Set {
         value: Setting::DotenvLoad(value),
@@ -1712,6 +1718,12 @@ mod tests {
     name: set_dotenv_load_implicit,
     text: "set dotenv-load",
     tree: (justfile (set dotenv_load true)),
+  }
+  
+  test! {
+    name: set_allow_duplicates_implicit,
+    text: "set allow-duplicates",
+    tree: (justfile (set allow_duplicates true)),
   }
 
   test! {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -729,10 +729,10 @@ impl<'tokens, 'src> Parser<'tokens, 'src> {
     let name = Name::from_identifier(self.presume(Identifier)?);
     let lexeme = name.lexeme();
 
-    if Keyword::AllowDuplicates == lexeme {
+    if Keyword::AllowDuplicateRecipes == lexeme {
       let value = self.parse_set_bool()?;
       return Ok(Set {
-        value: Setting::AllowDuplicates(value),
+        value: Setting::AllowDuplicateRecipes(value),
         name,
       });
     } else if Keyword::DotenvLoad == lexeme {
@@ -1719,11 +1719,11 @@ mod tests {
     text: "set dotenv-load",
     tree: (justfile (set dotenv_load true)),
   }
-  
+
   test! {
-    name: set_allow_duplicates_implicit,
-    text: "set allow-duplicates",
-    tree: (justfile (set allow_duplicates true)),
+    name: set_allow_duplicate_recipes_implicit,
+    text: "set allow-duplicate-recipes",
+    tree: (justfile (set allow_duplicate_recipes true)),
   }
 
   test! {

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -2,6 +2,7 @@ use crate::common::*;
 
 #[derive(Debug, Clone)]
 pub(crate) enum Setting<'src> {
+  AllowDuplicates(bool),
   DotenvLoad(bool),
   Export(bool),
   PositionalArguments(bool),
@@ -18,7 +19,8 @@ pub(crate) struct Shell<'src> {
 impl<'src> Display for Setting<'src> {
   fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
     match self {
-      Setting::DotenvLoad(value)
+      Setting::AllowDuplicates(value)
+      | Setting::DotenvLoad(value)
       | Setting::Export(value)
       | Setting::PositionalArguments(value)
       | Setting::WindowsPowerShell(value) => write!(f, "{}", value),

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -2,7 +2,7 @@ use crate::common::*;
 
 #[derive(Debug, Clone)]
 pub(crate) enum Setting<'src> {
-  AllowDuplicates(bool),
+  AllowDuplicateRecipes(bool),
   DotenvLoad(bool),
   Export(bool),
   PositionalArguments(bool),
@@ -19,7 +19,7 @@ pub(crate) struct Shell<'src> {
 impl<'src> Display for Setting<'src> {
   fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
     match self {
-      Setting::AllowDuplicates(value)
+      Setting::AllowDuplicateRecipes(value)
       | Setting::DotenvLoad(value)
       | Setting::Export(value)
       | Setting::PositionalArguments(value)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,6 +7,7 @@ pub(crate) const WINDOWS_POWERSHELL_ARGS: &[&str] = &["-NoLogo", "-Command"];
 
 #[derive(Debug, PartialEq, Serialize)]
 pub(crate) struct Settings<'src> {
+  pub(crate) allow_duplicates: bool,
   pub(crate) dotenv_load: Option<bool>,
   pub(crate) export: bool,
   pub(crate) positional_arguments: bool,
@@ -17,6 +18,7 @@ pub(crate) struct Settings<'src> {
 impl<'src> Settings<'src> {
   pub(crate) fn new() -> Settings<'src> {
     Settings {
+      allow_duplicates: false,
       dotenv_load: None,
       export: false,
       positional_arguments: false,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,7 +7,7 @@ pub(crate) const WINDOWS_POWERSHELL_ARGS: &[&str] = &["-NoLogo", "-Command"];
 
 #[derive(Debug, PartialEq, Serialize)]
 pub(crate) struct Settings<'src> {
-  pub(crate) allow_duplicates: bool,
+  pub(crate) allow_duplicate_recipes: bool,
   pub(crate) dotenv_load: Option<bool>,
   pub(crate) export: bool,
   pub(crate) positional_arguments: bool,
@@ -18,7 +18,7 @@ pub(crate) struct Settings<'src> {
 impl<'src> Settings<'src> {
   pub(crate) fn new() -> Settings<'src> {
     Settings {
-      allow_duplicates: false,
+      allow_duplicate_recipes: false,
       dotenv_load: None,
       export: false,
       positional_arguments: false,

--- a/tests/allow_duplicate_recipes.rs
+++ b/tests/allow_duplicate_recipes.rs
@@ -1,0 +1,38 @@
+use crate::common::*;
+
+#[test]
+fn allow_duplicate_recipes() {
+  Test::new()
+    .justfile(
+      "
+      b:
+        echo foo
+      b:
+        echo bar
+
+      set allow-duplicate-recipes
+    ",
+    )
+    .stdout("bar\n")
+    .stderr("echo bar\n")
+    .run();
+}
+
+#[test]
+fn allow_duplicate_recipes_with_args() {
+  Test::new()
+    .justfile(
+      "
+      b a:
+        echo foo
+      b c d:
+        echo bar {{c}} {{d}}
+
+      set allow-duplicate-recipes
+    ",
+    )
+    .args(&["b", "one", "two"])
+    .stdout("bar one two\n")
+    .stderr("echo bar one two\n")
+    .run();
+}

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -284,7 +284,14 @@ fn duplicate_recipes() {
           "dependencies": [],
           "doc": null,
           "name": "foo",
-          "parameters": [],
+          "parameters": [
+            {
+              "name": "bar",
+              "export": false,
+              "default": null,
+              "kind": "singular",
+            },
+          ],
           "priors": 0,
           "private": false,
           "quiet": false,

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -267,7 +267,7 @@ fn duplicate_recipes() {
       alias f := foo
 
       foo:
-      foo:
+      foo bar:
     ",
     json!({
       "first": "foo",

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -39,6 +39,7 @@ fn alias() {
         }
       },
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -66,6 +67,7 @@ fn assignment() {
       "first": null,
       "recipes": {},
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -106,6 +108,7 @@ fn body() {
         }
       },
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -156,6 +159,7 @@ fn dependencies() {
         }
       },
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -243,6 +247,52 @@ fn dependency_argument() {
         }
       },
       "settings": {
+        "allow_duplicates": false,
+        "dotenv_load": null,
+        "export": false,
+        "positional_arguments": false,
+        "shell": null,
+        "windows_powershell": false,
+      },
+      "warnings": [],
+    }),
+  );
+}
+
+#[test]
+fn duplicates() {
+  test(
+    "
+      set allow-duplicates
+      alias f := foo
+
+      foo:
+      foo:
+    ",
+    json!({
+      "first": "foo",
+      "aliases": {
+        "f": {
+          "name": "f",
+          "target": "foo",
+        }
+      },
+      "assignments": {},
+      "recipes": {
+        "foo": {
+          "body": [],
+          "dependencies": [],
+          "doc": null,
+          "name": "foo",
+          "parameters": [],
+          "priors": 0,
+          "private": false,
+          "quiet": false,
+          "shebang": false,
+        }
+      },
+      "settings": {
+        "allow_duplicates": true,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -276,6 +326,7 @@ fn doc_comment() {
         }
       },
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -297,6 +348,7 @@ fn empty_justfile() {
       "first": null,
       "recipes": {},
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -427,6 +479,7 @@ fn parameters() {
         },
       },
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -496,6 +549,7 @@ fn priors() {
         },
       },
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -529,6 +583,7 @@ fn private() {
         }
       },
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -562,6 +617,7 @@ fn quiet() {
         }
       },
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -613,6 +669,7 @@ fn settings() {
         }
       },
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": true,
         "export": true,
         "positional_arguments": true,
@@ -652,6 +709,7 @@ fn shebang() {
         }
       },
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -685,6 +743,7 @@ fn simple() {
         }
       },
       "settings": {
+        "allow_duplicates": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -39,7 +39,7 @@ fn alias() {
         }
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -67,7 +67,7 @@ fn assignment() {
       "first": null,
       "recipes": {},
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -108,7 +108,7 @@ fn body() {
         }
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -159,7 +159,7 @@ fn dependencies() {
         }
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -247,7 +247,7 @@ fn dependency_argument() {
         }
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -260,10 +260,10 @@ fn dependency_argument() {
 }
 
 #[test]
-fn duplicates() {
+fn duplicate_recipes() {
   test(
     "
-      set allow-duplicates
+      set allow-duplicate-recipes
       alias f := foo
 
       foo:
@@ -292,7 +292,7 @@ fn duplicates() {
         }
       },
       "settings": {
-        "allow_duplicates": true,
+        "allow_duplicate_recipes": true,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -326,7 +326,7 @@ fn doc_comment() {
         }
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -348,7 +348,7 @@ fn empty_justfile() {
       "first": null,
       "recipes": {},
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -479,7 +479,7 @@ fn parameters() {
         },
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -549,7 +549,7 @@ fn priors() {
         },
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -583,7 +583,7 @@ fn private() {
         }
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -617,7 +617,7 @@ fn quiet() {
         }
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -669,7 +669,7 @@ fn settings() {
         }
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": true,
         "export": true,
         "positional_arguments": true,
@@ -709,7 +709,7 @@ fn shebang() {
         }
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,
@@ -743,7 +743,7 @@ fn simple() {
         }
       },
       "settings": {
-        "allow_duplicates": false,
+        "allow_duplicate_recipes": false,
         "dotenv_load": null,
         "export": false,
         "positional_arguments": false,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 mod test;
 
+mod allow_duplicate_recipes;
 mod assert_stdout;
 mod assert_success;
 mod byte_order_mark;

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1222,6 +1222,14 @@ test! {
 }
 
 test! {
+  name:     allow_duplicate_recipes,
+  justfile: "b:\n  echo foo\nb:\n  echo bar\nset allow-duplicate-recipes",
+  args:     ("b"),
+  stdout: "bar\n",
+  stderr: "echo bar\n",
+}
+
+test! {
   name:     duplicate_variable,
   justfile: "a := 'hello'\na := 'hello'\nfoo:",
   args:     ("foo"),

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1222,14 +1222,6 @@ test! {
 }
 
 test! {
-  name:     allow_duplicate_recipes,
-  justfile: "b:\n  echo foo\nb:\n  echo bar\nset allow-duplicate-recipes",
-  args:     ("b"),
-  stdout: "bar\n",
-  stderr: "echo bar\n",
-}
-
-test! {
   name:     duplicate_variable,
   justfile: "a := 'hello'\na := 'hello'\nfoo:",
   args:     ("foo"),


### PR DESCRIPTION
Hey there @casey first off just wanted to thank you for an awesome tool. I personally love using it in all my projects.

This is meant to address the allowing duplicate recipes via a setting. This should help partially resolve [the conversation in how to override recipes](https://github.com/casey/just/issues/383#issuecomment-882002853) when using `justprep`.

I know this conversation was a while ago, and your reasoning may have changed (I really want modules or recipes that can have prereqs from other files), but `justprep` is the closest we can get to having modular "dependencies" at the moment, and this is sort of the last piece that would help our workflows.

Why I chose to use a setting rather than a cli flag: if there are duplicate recipes in the justfiles, they will not parse, rather than pass around the config flags everywhere it seemed logical to have that be a setting in the file (that if used in an older version will properly barf not knowing about the `allow-duplicates` setting.

Some tradeoffs made: settings are parsed in order and duplicates are only allowed after the setting is used. I know this breaks the nice unordered property of justfiles generally, but the compromise seemed fair while I was there.

It looks like this now:

```
set allow-duplicates

# default that might come from `justprep`
foo:
  @echo "basic recipe"

foo:
  @echo "more specific overridden recipe"
```

```shell
$ just
more specific overridden recipe
```

and without the `set allow-duplicates` line will error as normal:
```
error: Recipe `foo` first defined on line 3 is redefined on line 6
  |
6 | @foo:
  |  ^^^
```


Open to any feedback (both on approach and code) -- or if you want to go a different direction entirely at this point it would be understandable too.

I can also write up the docs as needed, but didn't want to go overboard until got your general approval to refine more