### PR TITLE
Improve --init/--fmt compatibility (#1115)

### DIFF
--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,6 +1,6 @@
 use crate::common::*;
 
-const INIT_JUSTFILE: &str = "default:\n\techo 'Hello, world!'\n";
+const INIT_JUSTFILE: &str = "default:\n    echo 'Hello, world!'\n";
 
 #[derive(PartialEq, Clone, Debug)]
 pub(crate) enum Subcommand {

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -1,6 +1,6 @@
 use crate::common::*;
 
-const EXPECTED: &str = "default:\n\techo 'Hello, world!'\n";
+const EXPECTED: &str = "default:\n    echo 'Hello, world!'\n";
 
 #[test]
 fn current_dir() {
@@ -187,4 +187,20 @@ fn justfile_and_working_directory() {
     fs::read_to_string(tmp.path().join("justfile")).unwrap(),
     EXPECTED
   );
+}
+
+#[test]
+fn fmt_compatibility() {
+  let tempdir = Test::new()
+    .no_justfile()
+    .arg("--init")
+    .stderr_regex("Wrote justfile to `.*`\n")
+    .run();
+  Test::with_tempdir(tempdir)
+    .no_justfile()
+    .arg("--unstable")
+    .arg("--check")
+    .arg("--fmt")
+    .status(EXIT_SUCCESS)
+    .run();
 }


### PR DESCRIPTION
The justfile produced by `--init` should be formatted as expected by `--fmt`.

This fixes #1115.