### PR TITLE
Add cross-platform example

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,7 +893,7 @@ $ just system-info
 This is an x86_64 machine
 ```
 
-`os_family()` can be used to create cross-platform `justfile` if the project has contributors using various operating systems. For example see  [cross-platform.just](examples/cross-platform.just) file.
+The `os_family()` function can be used to create cross-platform `justfile`s that work on various operating systems. For an example, see [cross-platform.just](examples/cross-platform.just) file.
 
 #### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -893,6 +893,8 @@ $ just system-info
 This is an x86_64 machine
 ```
 
+`os_family()` can be used to create cross-platform `justfile` if the project has contributors using various operating systems. For example see  [cross-platform.just](examples/cross-platform.just) file.
+
 #### Environment Variables
 
 - `env_var(key)` — Retrieves the environment variable with name `key`, aborting if it is not present.

--- a/examples/cross-platform.just
+++ b/examples/cross-platform.just
@@ -1,0 +1,26 @@
+# use with https://github.com/casey/just
+#
+# Example cross-platform Python project
+#
+
+python_dir := if os_family() == "windows" { "./.venv/Scripts" } else { "./.venv/bin" }
+python := python_dir + if os_family() == "windows" { "/python.exe" } else { "/python3" }
+system_python := if os_family() == "windows" { "py.exe -3.9" } else { "python3.9" }
+
+# Set up development environment
+bootstrap:
+    if test ! -e .venv; then {{ system_python }} -m venv .venv; fi
+    {{ python }} -m pip install --upgrade pip wheel pip-tools
+    {{ python_dir }}/pip-sync
+
+# Upgrade Python dependencies
+upgrade-deps: && bootstrap
+    {{ python_dir }}/pip-compile --upgrade
+
+# Sample project script 1
+script1:
+    {{ python }} script1.py
+
+# Sample project script 2
+script2 *ARGS:
+    {{ python }} script2.py {{ ARGS }}


### PR DESCRIPTION
Sometimes the file structure and the executables are very different in Windows and Unix operating systems. With this example it is possible to have one identical `justfile`. (If the same shell setting can be used in every system.)

I tried some other alternatives, but this one seemed to be the working one. I missed this information from the documentation. Just is cross-platform, but writing cross-platform `justfile` is another thing.

PS: I really love `just`, I use it in all of my pet projects on Windows.