### PR TITLE
Add just-install to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ Example usage:
 
 An [RSS feed](https://en.wikipedia.org/wiki/RSS) of `just` releases is available [here](https://github.com/casey/just/releases.atom).
 
+### Node.js Installation
+
+[just-install](https://npmjs.com/packages/just-install) can be used to automate installation of `just` in Node.js applications.
+
+`just` is a great, more robust alternative to npm scripts. If you want to include `just` in the dependencies of a Node.js application, `just-install` will install a local, platform-specific binary as part of the `npm install` command. This removes the need for every developer to install `just` independently using one of the processes mentioned above. After installation, the `just` command will work in npm scripts or with npx. It's great for teams who want to make the set up process for their project as easy as possible.
+
+For more information, see the [just-install README file](https://github.com/brombal/just-install#readme).
+
 Backwards Compatibility
 -----------------------
 


### PR DESCRIPTION
Adding information about `just-install` to the README file, re: https://github.com/casey/just/discussions/1238.