### PR TITLE
Add mdbook deps for build-book recipe (#1258)

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,8 +97,9 @@ install-dev-deps:
   rustup install nightly
   rustup update nightly
   cargo +nightly install cargo-fuzz
-  cargo install cargo-check
+  cargo install cargo-check 
   cargo install cargo-watch
+  cargo install mdbook mdbook-linkcheck
 
 # install system development dependencies with homebrew
 install-dev-deps-homebrew:

--- a/justfile
+++ b/justfile
@@ -97,7 +97,7 @@ install-dev-deps:
   rustup install nightly
   rustup update nightly
   cargo +nightly install cargo-fuzz
-  cargo install cargo-check 
+  cargo install cargo-check
   cargo install cargo-watch
   cargo install mdbook mdbook-linkcheck
 


### PR DESCRIPTION
added mdbook dependencies needed to run recipe `build-book`. Tested in the alpine-based `docker.io/library/rust` container that running the `install-dev-deps` recipe and then the `build-book` recipe results in no errors. 

github issue #1258 