### PR TITLE
Add MPR/Prebuilt-MPR installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ You can also set the shell using command-line arguments. For example, to use Pow
     <td><a href="https://mpr.makedeb.org/packages/just">just</a></td>
     <td>
       <code>git clone 'https://mpr.makedeb.org/just'</code><br>
-      <code>cd just/</code>
+      <code>cd just</code><br>
       <code>makedeb -si</code>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -222,6 +222,25 @@ You can also set the shell using command-line arguments. For example, to use Pow
       <code>asdf install just &lt;version&gt;</code>
     </td>
   </tr>
+  <tr>
+    <td><a href="https://debian.org">Debian derivatives</td>
+    <td><a href="https://mpr.makedeb.org">MPR</a></td>
+    <td><a href="https://mpr.makedeb.org/packages/just">just</a></td>
+    <td>
+      <code>git clone 'https://mpr.makedeb.org/just'</code><br>
+      <code>cd just/</code>
+      <code>makedeb -si</code>
+    </td>
+  </tr>
+  <tr>
+    <td><a href="https://debian.org">Debian derivatives</a></td>
+    <td><a href="https://docs.makedeb.org/prebuilt-mpr">Prebuilt-MPR</a></td>
+    <td><a href="https://mpr.makedeb.org/packages/just">just</a></td>
+    <td>
+      <sup><b>You must have the <a href="https://docs.makedeb.org/prebuilt-mpr/getting-started/#setting-up-the-repository">Prebuilt-MPR set up</a> on your system in order to run this command.</b></sup><br>
+      <code>sudo apt install just</code>
+    </td>
+  </tr>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ You can also set the shell using command-line arguments. For example, to use Pow
     </td>
   </tr>
   <tr>
-    <td><a href="https://debian.org">Debian derivatives</td>
+    <td><a href="https://debian.org">Debian</a> and <a href="https://ubuntu.com">Ubuntu</a> derivatives</td>
     <td><a href="https://mpr.makedeb.org">MPR</a></td>
     <td><a href="https://mpr.makedeb.org/packages/just">just</a></td>
     <td>
@@ -233,7 +233,7 @@ You can also set the shell using command-line arguments. For example, to use Pow
     </td>
   </tr>
   <tr>
-    <td><a href="https://debian.org">Debian derivatives</a></td>
+    <td><a href="https://debian.org">Debian</a> and <a href="https://ubuntu.com">Ubuntu</a> derivatives</td>
     <td><a href="https://docs.makedeb.org/prebuilt-mpr">Prebuilt-MPR</a></td>
     <td><a href="https://mpr.makedeb.org/packages/just">just</a></td>
     <td>


### PR DESCRIPTION
This adds installation instructions for both the MPR and Prebuilt-MPR to the README. Both of these function as installation methods for Debian/Ubuntu system though, and I was thinking users might not know what to choose if they see both at once, so I was thinking if there was only one listed it would probably be the Prebuilt-MPR simply because it uses an APT repository instead of requiring additional tools to be installed.

The Prebuilt-MPR method is awaiting the completion of https://drone.hunterwittenborn.com/makedeb/prebuilt-mpr/324.

Partial solution for https://github.com/casey/just/issues/429.