### PR TITLE
Don't hardcode homebrew prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2143,7 +2143,7 @@ $ just --completions zsh > just.zsh
 
 ```zsh
 # Init Homebrew, which adds environment variables
-eval "$(/opt/homebrew/bin/brew shellenv)"
+eval "$(brew shellenv)"
 
 fpath=($HOMEBREW_PREFIX/share/zsh/site-functions $fpath)
 


### PR DESCRIPTION
Hey @nk9, does this look better? This avoids hard-coding the homebrew prefix of `/opt/homebrew`, and just calling `brew shellenv`. I think this might be necessary on systems where brew is in `/usr/local`.