### PR TITLE
update suggested default recipe to include a justfile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,11 +576,10 @@ If you'd like `just` to default to listing the recipes in the `justfile`, you ca
 
 ```make
 default:
-  @# list recipes from the current justfile
-  @just --justfile {{justfile()}} --list
+  @just --list
 ```
 
-Note that the `--justfile {{justfile()}}` above is needed to make sure the listed recipes are from the current `justfile`. Without it, if you executed `just -f /some/distant/justfile` or `just -f ./non-standard-justfile`, the plain `just --list` call in the `default` recipe would not use the file you provided. It would try to find a justfile in your current path, maybe even resulting in a `No justfile found` error.
+Note that you may need to add `--justfile {{justfile()}}` to the line above above. Without it, if you executed `just -f /some/distant/justfile` or `just -f ./non-standard-justfile`, the plain `just --list` inside the recipe would not necessarily use the file you provided. It would try to find a justfile in your current path, maybe even resulting in a `No justfile found` error.
 
 The heading text can be customized with `--list-heading`:
 

--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ If you'd like `just` to default to listing the recipes in the `justfile`, you ca
 
 ```make
 default:
+  @# list recipes from the current justfile
   @just --justfile {{justfile()}} --list
 ```
 

--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ default:
   @just --justfile {{justfile()}} --list
 ```
 
-Note that the `-f {{justfile()}}` above is needed to make sure the listed are from the current `justfile`. If you executed `just -f /path/to/justfile`, you could list recipes from somewhere else or get a `No justfile found` error.
+Note that the `--justfile {{justfile()}}` above is needed to make sure the listed recipes are from the current `justfile`. Without it, if you executed `just -f /some/distant/justfile` or `just -f ./non-standard-justfile`, the plain `just --list` call in the `default` recipe would not use the file you provided. It would try to find a justfile in your current path, maybe even resulting in a `No justfile found` error.
 
 The heading text can be customized with `--list-heading`:
 

--- a/README.md
+++ b/README.md
@@ -576,8 +576,10 @@ If you'd like `just` to default to listing the recipes in the `justfile`, you ca
 
 ```make
 default:
-  @just --list
+  @just -f {{justfile()}} --list
 ```
+
+Note that the `-f {{justfile()}}` above is needed to make sure the listed are from the current `justfile`. If you executed `just -f /path/to/justfile`, you could list recipes from somewhere else or get a `No justfile found` error.
 
 The heading text can be customized with `--list-heading`:
 

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ default:
   @just --list
 ```
 
-Note that you may need to add `--justfile {{justfile()}}` to the line above above. Without it, if you executed `just -f /some/distant/justfile` or `just -f ./non-standard-justfile`, the plain `just --list` inside the recipe would not necessarily use the file you provided. It would try to find a justfile in your current path, maybe even resulting in a `No justfile found` error.
+Note that you may need to add `--justfile {{justfile()}}` to the line above above. Without it, if you executed `just -f /some/distant/justfile -d .` or `just -f ./non-standard-justfile`, the plain `just --list` inside the recipe would not necessarily use the file you provided. It would try to find a justfile in your current path, maybe even resulting in a `No justfile found` error.
 
 The heading text can be customized with `--list-heading`:
 

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ If you'd like `just` to default to listing the recipes in the `justfile`, you ca
 
 ```make
 default:
-  @just -f {{justfile()}} --list
+  @just --justfile {{justfile()}} --list
 ```
 
 Note that the `-f {{justfile()}}` above is needed to make sure the listed are from the current `justfile`. If you executed `just -f /path/to/justfile`, you could list recipes from somewhere else or get a `No justfile found` error.


### PR DESCRIPTION
This is an update to documentation, with a better recipe suggestion.

---

I had a `justfile` with the following content:

```
# as suggested at [Listing Available Recipes](https://just.systems/man/en/chapter_22.html)
default:
  @just --list

pwd:
  pwd
```

Then, I tried to run `.j` (aliased to `just -f ~/.justfile -d .` as suggested at [User justfiles](https://just.systems/man/en/chapter_63.html)), and got the following error:

```
$ .j
error: No justfile found
error: Recipe `default` failed on line 4 with exit code 1
```

Running `.j pwd` worked. The issue if that `.j` would run the `default` recipe, which executes `just --list` without passing the `--justfile` option again.