### PR TITLE
allow bash completion to complete tasks in other directories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,7 @@ jobs:
       run: |
         ./bin/generate-completions
         git diff --no-ext-diff --quiet --exit-code
+        ./tests/completions/just.bash
 
     - name: Check for Forbidden Words
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/completions/just.bash
+++ b/completions/just.bash
@@ -25,7 +25,15 @@ _just() {
                     COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                     return 0
                 elif [[ ${COMP_CWORD} -eq 1 ]]; then
-                    local recipes=$(just --summary --color never 2> /dev/null)
+                    if echo "${cur}" | grep -qF '/'; then
+                        local path_prefix=$(echo "${cur}" | sed 's/[/][^/]*$/\//')
+                        # TODO: Replace tr and awk below with --list-prefix "${path_prefix}". Need to update the --summary option to respect that first.
+                        local recipes=$(just --summary --color never 2> /dev/null -- "${path_prefix}" \
+                                | tr '[:blank:]' '\n' | awk "{print \"${path_prefix}\"\$0}")
+                    else
+                        local recipes=$(just --summary --color never 2> /dev/null)
+                    fi
+
                     if [[ $? -eq 0 ]]; then
                         COMPREPLY=( $(compgen -W "${recipes}" -- "${cur}") )
                         return 0

--- a/completions/just.bash
+++ b/completions/just.bash
@@ -25,13 +25,12 @@ _just() {
                     COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                     return 0
                 elif [[ ${COMP_CWORD} -eq 1 ]]; then
+                    local recipes=$(just --summary --color never 2> /dev/null)
+
                     if echo "${cur}" | grep -qF '/'; then
                         local path_prefix=$(echo "${cur}" | sed 's/[/][^/]*$/\//')
-                        # TODO: Replace tr and awk below with --list-prefix "${path_prefix}". Need to update the --summary option to respect that first.
-                        local recipes=$(just --summary --color never 2> /dev/null -- "${path_prefix}" \
-                                | tr '[:blank:]' '\n' | awk "{print \"${path_prefix}\"\$0}")
-                    else
-                        local recipes=$(just --summary --color never 2> /dev/null)
+                        local recipes=$(just --summary --color never 2> /dev/null -- "${path_prefix}")
+                        local recipes=$(printf "${path_prefix}%s" $recipes)
                     fi
 
                     if [[ $? -eq 0 ]]; then

--- a/completions/just.bash
+++ b/completions/just.bash
@@ -30,7 +30,7 @@ _just() {
                     if echo "${cur}" | grep -qF '/'; then
                         local path_prefix=$(echo "${cur}" | sed 's/[/][^/]*$/\//')
                         local recipes=$(just --summary 2> /dev/null -- "${path_prefix}")
-                        local recipes=$(printf "${path_prefix}%s" $recipes)
+                        local recipes=$(printf "${path_prefix}%s\t" $recipes)
                     fi
 
                     if [[ $? -eq 0 ]]; then

--- a/completions/just.bash
+++ b/completions/just.bash
@@ -25,11 +25,11 @@ _just() {
                     COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                     return 0
                 elif [[ ${COMP_CWORD} -eq 1 ]]; then
-                    local recipes=$(just --summary --color never 2> /dev/null)
+                    local recipes=$(just --summary 2> /dev/null)
 
                     if echo "${cur}" | grep -qF '/'; then
                         local path_prefix=$(echo "${cur}" | sed 's/[/][^/]*$/\//')
-                        local recipes=$(just --summary --color never 2> /dev/null -- "${path_prefix}")
+                        local recipes=$(just --summary 2> /dev/null -- "${path_prefix}")
                         local recipes=$(printf "${path_prefix}%s" $recipes)
                     fi
 

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -166,11 +166,11 @@ pub(crate) const BASH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
                     COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                     return 0
                 elif [[ ${COMP_CWORD} -eq 1 ]]; then
-                    local recipes=$(just --summary --color never 2> /dev/null)
+                    local recipes=$(just --summary 2> /dev/null)
 
                     if echo "${cur}" | grep -qF '/'; then
                         local path_prefix=$(echo "${cur}" | sed 's/[/][^/]*$/\//')
-                        local recipes=$(just --summary --color never 2> /dev/null -- "${path_prefix}")
+                        local recipes=$(just --summary 2> /dev/null -- "${path_prefix}")
                         local recipes=$(printf "${path_prefix}%s" $recipes)
                     fi
 

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -166,7 +166,15 @@ pub(crate) const BASH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
                     COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                     return 0
                 elif [[ ${COMP_CWORD} -eq 1 ]]; then
-                    local recipes=$(just --summary --color never 2> /dev/null)
+                    if echo "${cur}" | grep -qF '/'; then
+                        local path_prefix=$(echo "${cur}" | sed 's/[/][^/]*$/\//')
+                        # TODO: Replace tr and awk below with --list-prefix "${path_prefix}". Need to update the --summary option to respect that first.
+                        local recipes=$(just --summary --color never 2> /dev/null -- "${path_prefix}" \
+                                | tr '[:blank:]' '\n' | awk "{print \"${path_prefix}\"\$0}")
+                    else
+                        local recipes=$(just --summary --color never 2> /dev/null)
+                    fi
+
                     if [[ $? -eq 0 ]]; then
                         COMPREPLY=( $(compgen -W "${recipes}" -- "${cur}") )
                         return 0

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -171,7 +171,7 @@ pub(crate) const BASH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
                     if echo "${cur}" | grep -qF '/'; then
                         local path_prefix=$(echo "${cur}" | sed 's/[/][^/]*$/\//')
                         local recipes=$(just --summary 2> /dev/null -- "${path_prefix}")
-                        local recipes=$(printf "${path_prefix}%s" $recipes)
+                        local recipes=$(printf "${path_prefix}%s\t" $recipes)
                     fi
 
                     if [[ $? -eq 0 ]]; then

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -166,13 +166,12 @@ pub(crate) const BASH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
                     COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                     return 0
                 elif [[ ${COMP_CWORD} -eq 1 ]]; then
+                    local recipes=$(just --summary --color never 2> /dev/null)
+
                     if echo "${cur}" | grep -qF '/'; then
                         local path_prefix=$(echo "${cur}" | sed 's/[/][^/]*$/\//')
-                        # TODO: Replace tr and awk below with --list-prefix "${path_prefix}". Need to update the --summary option to respect that first.
-                        local recipes=$(just --summary --color never 2> /dev/null -- "${path_prefix}" \
-                                | tr '[:blank:]' '\n' | awk "{print \"${path_prefix}\"\$0}")
-                    else
-                        local recipes=$(just --summary --color never 2> /dev/null)
+                        local recipes=$(just --summary --color never 2> /dev/null -- "${path_prefix}")
+                        local recipes=$(printf "${path_prefix}%s" $recipes)
                     fi
 
                     if [[ $? -eq 0 ]]; then

--- a/tests/completions/just.bash
+++ b/tests/completions/just.bash
@@ -1,13 +1,26 @@
 #!/usr/bin/env bash
 
-source ./completions/just.bash
+# --- Shared functions ---
 
-exit_code='0'
+cdroot() {
+  cd "$(git rev-parse --show-toplevel)" > /dev/null
+}
+
+setup() {
+  cdroot
+  mkdir -p ./tmp > /dev/null
+  echo 'install:' > tmp/justfile
+  echo 'test:' >> tmp/justfile
+  echo 'deploy:' >> tmp/justfile
+  echo 'push:' >> tmp/justfile
+  echo 'publish:' >> tmp/justfile
+}
 
 cleanup() {
   unset COMP_WORDS
   unset COMP_CWORD
   unset COMPREPLY
+  rm -f ./tmp/justfile
 }
 
 reply_equals() {
@@ -26,6 +39,14 @@ reply_equals() {
   fi
 }
 
+# --- Initial Setup ---
+cdroot
+source ./completions/just.bash
+PATH="$(git rev-parse --show-toplevel)/target/debug:$PATH"
+exit_code='0'
+
+# --- Tests ---
+
 test_just_is_accessible() {
   if just --version > /dev/null; then
     echo "${FUNCNAME[0]}: ok"
@@ -36,44 +57,51 @@ test_just_is_accessible() {
     exit_code='1'
   fi
 }
-PATH="./target/debug:$PATH"
+setup
 test_just_is_accessible
 
 test_complete_all_recipes() {
   COMP_WORDS=(just)
+  cd tmp > /dev/null
   COMP_CWORD=1 _just just
-  reply_equals 'declare -a COMPREPLY=([0]="build" [1]="build-book" [2]="changes" [3]="check" [4]="ci" [5]="clippy" [6]="done" [7]="filter" [8]="fmt" [9]="forbid" [10]="fuzz" [11]="generate-completions" [12]="install" [13]="install-dev-deps" [14]="install-dev-deps-homebrew" [15]="man" [16]="polyglot" [17]="pr" [18]="publish" [19]="push" [20]="pwd" [21]="quine" [22]="render-readme" [23]="replace" [24]="run" [25]="sloc" [26]="test" [27]="test-quine" [28]="view-man" [29]="watch" [30]="watch-readme")'
+  reply_equals 'declare -a COMPREPLY=([0]="deploy" [1]="install" [2]="publish" [3]="push" [4]="test")'
 }
 cleanup
+setup
 test_complete_all_recipes
 
 test_complete_recipes_starting_with_i() {
   COMP_WORDS=(just i)
+  cd tmp > /dev/null
   COMP_CWORD=1 _just just
-  reply_equals 'declare -a COMPREPLY=([0]="install" [1]="install-dev-deps" [2]="install-dev-deps-homebrew")'
+  reply_equals 'declare -a COMPREPLY=([0]="install")'
 }
 cleanup
+setup
 test_complete_recipes_starting_with_i
 
-test_complete_recipes_starting_with_r() {
-  COMP_WORDS=(just r)
+test_complete_recipes_starting_with_p() {
+  setup
+  COMP_WORDS=(just p)
+  cd tmp > /dev/null
   COMP_CWORD=1 _just just
-  reply_equals 'declare -a COMPREPLY=([0]="render-readme" [1]="replace" [2]="run")'
+  reply_equals 'declare -a COMPREPLY=([0]="publish" [1]="push")'
 }
 cleanup
-test_complete_recipes_starting_with_r
+setup
+test_complete_recipes_starting_with_p
 
 test_complete_recipes_from_subdirs() {
-  mkdir -p ./tmp
-  echo 'install:' > tmp/justfile
-  echo 'deploy:' >> tmp/justfile
   COMP_WORDS=(just tmp/)
   COMP_CWORD=1 _just just
-  reply_equals 'declare -a COMPREPLY=([0]="tmp/deploy" [1]="tmp/install")'
+  reply_equals 'declare -a COMPREPLY=([0]="tmp/deploy" [1]="tmp/install" [2]="tmp/publish" [3]="tmp/push" [4]="tmp/test")'
 }
 cleanup
+setup
 test_complete_recipes_from_subdirs
 cleanup
+
+# --- Conclusion ---
 
 if [ "$exit_code" = '0' ]; then
   echo "All tests passed."

--- a/tests/completions/just.bash
+++ b/tests/completions/just.bash
@@ -57,5 +57,9 @@ if [ "$exit_code" = '0' ]; then
   echo "All tests passed."
 else
   echo "Some test[s] failed."
+
+  set -x
+  bash --version
+  uname -a
 fi
 exit "$exit_code"

--- a/tests/completions/just.bash
+++ b/tests/completions/just.bash
@@ -36,36 +36,44 @@ test_just_is_accessible() {
     exit_code='1'
   fi
 }
+PATH="./target/debug:$PATH"
+test_just_is_accessible
 
 test_complete_all_recipes() {
   COMP_WORDS=(just)
   COMP_CWORD=1 _just just
   reply_equals 'declare -a COMPREPLY=([0]="build" [1]="build-book" [2]="changes" [3]="check" [4]="ci" [5]="clippy" [6]="done" [7]="filter" [8]="fmt" [9]="forbid" [10]="fuzz" [11]="generate-completions" [12]="install" [13]="install-dev-deps" [14]="install-dev-deps-homebrew" [15]="man" [16]="polyglot" [17]="pr" [18]="publish" [19]="push" [20]="pwd" [21]="quine" [22]="render-readme" [23]="replace" [24]="run" [25]="sloc" [26]="test" [27]="test-quine" [28]="view-man" [29]="watch" [30]="watch-readme")'
 }
+cleanup
+test_complete_all_recipes
 
 test_complete_recipes_starting_with_i() {
   COMP_WORDS=(just i)
   COMP_CWORD=1 _just just
   reply_equals 'declare -a COMPREPLY=([0]="install" [1]="install-dev-deps" [2]="install-dev-deps-homebrew")'
 }
+cleanup
+test_complete_recipes_starting_with_i
 
 test_complete_recipes_starting_with_r() {
   COMP_WORDS=(just r)
   COMP_CWORD=1 _just just
   reply_equals 'declare -a COMPREPLY=([0]="render-readme" [1]="replace" [2]="run")'
 }
-
-PATH="./target/debug:$PATH"
-test_just_is_accessible
-
-cleanup
-test_complete_all_recipes
-
-cleanup
-test_complete_recipes_starting_with_i
-
 cleanup
 test_complete_recipes_starting_with_r
+
+test_complete_recipes_from_subdirs() {
+  mkdir -p ./tmp
+  echo 'install:' > tmp/justfile
+  echo 'deploy:' >> tmp/justfile
+  COMP_WORDS=(just tmp/)
+  COMP_CWORD=1 _just just
+  reply_equals 'declare -a COMPREPLY=([0]="tmp/deploy" [1]="tmp/install")'
+}
+cleanup
+test_complete_recipes_from_subdirs
+cleanup
 
 if [ "$exit_code" = '0' ]; then
   echo "All tests passed."

--- a/tests/completions/just.bash
+++ b/tests/completions/just.bash
@@ -26,6 +26,17 @@ reply_equals() {
   fi
 }
 
+test_just_is_accessible() {
+  if just --version > /dev/null; then
+    echo "${FUNCNAME[0]}: ok"
+  else
+    echo "${FUNCNAME[0]}: failed! Can't find just binary."
+    echo "  PATH=$PATH"
+    echo
+    exit_code='1'
+  fi
+}
+
 test_complete_all_recipes() {
   COMP_WORDS=(just)
   COMP_CWORD=1 _just just
@@ -44,6 +55,9 @@ test_complete_recipes_starting_with_r() {
   reply_equals 'declare -a COMPREPLY=([0]="render-readme" [1]="replace" [2]="run")'
 }
 
+PATH="./target/debug:$PATH"
+test_just_is_accessible
+
 cleanup
 test_complete_all_recipes
 
@@ -57,9 +71,5 @@ if [ "$exit_code" = '0' ]; then
   echo "All tests passed."
 else
   echo "Some test[s] failed."
-
-  set -x
-  bash --version
-  uname -a
 fi
 exit "$exit_code"

--- a/tests/completions/just.bash
+++ b/tests/completions/just.bash
@@ -8,19 +8,13 @@ cdroot() {
 
 setup() {
   cdroot
-  mkdir -p ./tmp > /dev/null
-  echo 'install:' > tmp/justfile
-  echo 'test:' >> tmp/justfile
-  echo 'deploy:' >> tmp/justfile
-  echo 'push:' >> tmp/justfile
-  echo 'publish:' >> tmp/justfile
+  cd tests/completions > /dev/null
 }
 
 cleanup() {
   unset COMP_WORDS
   unset COMP_CWORD
   unset COMPREPLY
-  rm -f ./tmp/justfile
 }
 
 reply_equals() {
@@ -62,7 +56,6 @@ test_just_is_accessible
 
 test_complete_all_recipes() {
   COMP_WORDS=(just)
-  cd tmp > /dev/null
   COMP_CWORD=1 _just just
   reply_equals 'declare -a COMPREPLY=([0]="deploy" [1]="install" [2]="publish" [3]="push" [4]="test")'
 }
@@ -72,7 +65,6 @@ test_complete_all_recipes
 
 test_complete_recipes_starting_with_i() {
   COMP_WORDS=(just i)
-  cd tmp > /dev/null
   COMP_CWORD=1 _just just
   reply_equals 'declare -a COMPREPLY=([0]="install")'
 }
@@ -83,7 +75,6 @@ test_complete_recipes_starting_with_i
 test_complete_recipes_starting_with_p() {
   setup
   COMP_WORDS=(just p)
-  cd tmp > /dev/null
   COMP_CWORD=1 _just just
   reply_equals 'declare -a COMPREPLY=([0]="publish" [1]="push")'
 }
@@ -92,9 +83,9 @@ setup
 test_complete_recipes_starting_with_p
 
 test_complete_recipes_from_subdirs() {
-  COMP_WORDS=(just tmp/)
+  COMP_WORDS=(just subdir/)
   COMP_CWORD=1 _just just
-  reply_equals 'declare -a COMPREPLY=([0]="tmp/deploy" [1]="tmp/install" [2]="tmp/publish" [3]="tmp/push" [4]="tmp/test")'
+  reply_equals 'declare -a COMPREPLY=([0]="subdir/special" [1]="subdir/surprise")'
 }
 cleanup
 setup

--- a/tests/completions/just.bash
+++ b/tests/completions/just.bash
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+source ./completions/just.bash
+
+exit_code='0'
+
+cleanup() {
+  unset COMP_WORDS
+  unset COMP_CWORD
+  unset COMPREPLY
+}
+
+reply_equals() {
+  local reply=$(declare -p COMPREPLY)
+  local expected="$1"
+
+  if [ "$reply" = "$expected" ]; then
+    echo "${FUNCNAME[1]}: ok"
+  else
+    exit_code='1'
+    echo >&2 "${FUNCNAME[1]}: failed! Completion for \`${COMP_WORDS[*]}\` does not match."
+
+    echo
+    diff -U3 --label expected <(echo "$expected") --label actual <(echo "$reply") >&2
+    echo
+  fi
+}
+
+test_complete_all_recipes() {
+  COMP_WORDS=(just)
+  COMP_CWORD=1 _just just
+  reply_equals 'declare -a COMPREPLY=([0]="build" [1]="build-book" [2]="changes" [3]="check" [4]="ci" [5]="clippy" [6]="done" [7]="filter" [8]="fmt" [9]="forbid" [10]="fuzz" [11]="generate-completions" [12]="install" [13]="install-dev-deps" [14]="install-dev-deps-homebrew" [15]="man" [16]="polyglot" [17]="pr" [18]="publish" [19]="push" [20]="pwd" [21]="quine" [22]="render-readme" [23]="replace" [24]="run" [25]="sloc" [26]="test" [27]="test-quine" [28]="view-man" [29]="watch" [30]="watch-readme")'
+}
+
+test_complete_recipes_starting_with_i() {
+  COMP_WORDS=(just i)
+  COMP_CWORD=1 _just just
+  reply_equals 'declare -a COMPREPLY=([0]="install" [1]="install-dev-deps" [2]="install-dev-deps-homebrew")'
+}
+
+test_complete_recipes_starting_with_r() {
+  COMP_WORDS=(just r)
+  COMP_CWORD=1 _just just
+  reply_equals 'declare -a COMPREPLY=([0]="render-readme" [1]="replace" [2]="run")'
+}
+
+cleanup
+test_complete_all_recipes
+
+cleanup
+test_complete_recipes_starting_with_i
+
+cleanup
+test_complete_recipes_starting_with_r
+
+if [ "$exit_code" = '0' ]; then
+  echo "All tests passed."
+else
+  echo "Some test[s] failed."
+fi
+exit "$exit_code"

--- a/tests/completions/justfile
+++ b/tests/completions/justfile
@@ -1,0 +1,5 @@
+install:
+test:
+deploy:
+push:
+publish:

--- a/tests/completions/subdir/justfile
+++ b/tests/completions/subdir/justfile
@@ -1,0 +1,2 @@
+special:
+surprise:


### PR DESCRIPTION
Today, I learned about just's ability to [invoke justfiles in other directories](https://just.systems/man/en/chapter_50.html#invoking-justfiles-in-other-directories).

I moved part of my tasks into `./ci/justfile`. Then, with bash completion on, typed `just ci/` + _tab_. It completed with files, not with `just` tasks.

This change here solves that problem.

If the current text being completed has a `/` char, we'll run a different `just --summary` command.