### PR TITLE
makes slash operator default lhs value to an empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,6 +924,17 @@ $ just --evaluate bar
 a//b
 ```
 
+Absolute paths can also be constructed:
+
+```make
+foo := / "b"
+```
+
+```
+$ just --evaluate foo
+/b
+```
+
 The `/` operator uses the `/` character, even on Windows. Thus, using the `/` operator should be avoided with paths that use universal naming convention (UNC), i.e., those that start with `\?`, since forward slashes are not supported with UNC paths.
 
 #### Escaping `{{`

--- a/src/assignment_resolver.rs
+++ b/src/assignment_resolver.rs
@@ -101,8 +101,14 @@ impl<'src: 'run, 'run> AssignmentResolver<'src, 'run> {
           self.resolve_expression(c)
         }
       },
-      Expression::Concatenation { lhs, rhs } | Expression::Join { lhs, rhs } => {
+      Expression::Concatenation { lhs, rhs } => {
         self.resolve_expression(lhs)?;
+        self.resolve_expression(rhs)
+      }
+      Expression::Join { lhs, rhs } => {
+        let empty = Box::new(Expression::empty_string_literal());
+        let lhs = lhs.as_ref().unwrap_or(&empty);
+        self.resolve_expression(&lhs)?;
         self.resolve_expression(rhs)
       }
       Expression::Conditional {

--- a/src/assignment_resolver.rs
+++ b/src/assignment_resolver.rs
@@ -106,9 +106,9 @@ impl<'src: 'run, 'run> AssignmentResolver<'src, 'run> {
         self.resolve_expression(rhs)
       }
       Expression::Join { lhs, rhs } => {
-        let empty = Box::new(Expression::empty_string_literal());
-        let lhs = lhs.as_ref().unwrap_or(&empty);
-        self.resolve_expression(&lhs)?;
+        if let Some(lhs) = lhs {
+          self.resolve_expression(lhs)?;
+        }
         self.resolve_expression(rhs)
       }
       Expression::Conditional {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -176,13 +176,11 @@ impl<'src, 'run> Evaluator<'src, 'run> {
         }
       }
       Expression::Group { contents } => self.evaluate_expression(contents),
-      Expression::Join { lhs, rhs } => {
-        let lhs = match lhs {
-          Some(lhs) => self.evaluate_expression(lhs)?,
-          None => String::new(),
-        };
-        Ok(lhs + "/" + &self.evaluate_expression(rhs)?)
-      }
+      Expression::Join { lhs: None, rhs } => Ok("/".to_string() + &self.evaluate_expression(rhs)?),
+      Expression::Join {
+        lhs: Some(lhs),
+        rhs,
+      } => Ok(self.evaluate_expression(lhs)? + "/" + &self.evaluate_expression(rhs)?),
     }
   }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -177,10 +177,10 @@ impl<'src, 'run> Evaluator<'src, 'run> {
       }
       Expression::Group { contents } => self.evaluate_expression(contents),
       Expression::Join { lhs, rhs } => {
-        let lhs = if lhs.is_some() {
-          self.evaluate_expression(lhs.as_ref().unwrap())?
+        let lhs = if let Some(lhs) = lhs {
+          self.evaluate_expression(lhs)?
         } else {
-          "".to_string()
+          String::new()
         };
         Ok(lhs + "/" + &self.evaluate_expression(rhs)?)
       }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -177,10 +177,9 @@ impl<'src, 'run> Evaluator<'src, 'run> {
       }
       Expression::Group { contents } => self.evaluate_expression(contents),
       Expression::Join { lhs, rhs } => {
-        let lhs = if let Some(lhs) = lhs {
-          self.evaluate_expression(lhs)?
-        } else {
-          String::new()
+        let lhs = match lhs {
+          Some(lhs) => self.evaluate_expression(lhs)?,
+          None => String::new(),
         };
         Ok(lhs + "/" + &self.evaluate_expression(rhs)?)
       }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -177,7 +177,12 @@ impl<'src, 'run> Evaluator<'src, 'run> {
       }
       Expression::Group { contents } => self.evaluate_expression(contents),
       Expression::Join { lhs, rhs } => {
-        Ok(self.evaluate_expression(lhs)? + "/" + &self.evaluate_expression(rhs)?)
+        let lhs = if lhs.is_some() {
+          self.evaluate_expression(lhs.as_ref().unwrap())?
+        } else {
+          "".to_string()
+        };
+        Ok(lhs + "/" + &self.evaluate_expression(rhs)?)
       }
     }
   }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -45,30 +45,17 @@ impl<'src> Expression<'src> {
   pub(crate) fn variables<'expression>(&'expression self) -> Variables<'expression, 'src> {
     Variables::new(self)
   }
-
-  pub(crate) fn empty_string_literal() -> Self {
-    Expression::StringLiteral {
-      string_literal: StringLiteral {
-        kind: StringKind::new(string_kind::StringDelimiter::QuoteDouble, false),
-        raw: "",
-        cooked: "".to_string(),
-      },
-    }
-  }
 }
 
 impl<'src> Display for Expression<'src> {
   fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
     match self {
       Expression::Backtick { token, .. } => write!(f, "{}", token.lexeme()),
-      Expression::Join { lhs, rhs } => write!(
-        f,
-        "{} / {}",
-        lhs
-          .as_ref()
-          .unwrap_or(&Box::new(Expression::empty_string_literal())),
-        rhs
-      ),
+      Expression::Join { lhs: None, rhs } => write!(f, "/ {}", rhs),
+      Expression::Join {
+        lhs: Some(lhs),
+        rhs,
+      } => write!(f, "{} / {}", lhs, rhs),
       Expression::Concatenation { lhs, rhs } => write!(f, "{} + {}", lhs, rhs),
       Expression::Conditional {
         lhs,

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -45,6 +45,16 @@ impl<'src> Expression<'src> {
   pub(crate) fn variables<'expression>(&'expression self) -> Variables<'expression, 'src> {
     Variables::new(self)
   }
+
+  pub(crate) fn empty_string_literal() -> Self {
+    Expression::StringLiteral {
+      string_literal: StringLiteral {
+        kind: StringKind::new(string_kind::StringDelimiter::QuoteDouble, false),
+        raw: "",
+        cooked: "".to_string(),
+      },
+    }
+  }
 }
 
 impl<'src> Display for Expression<'src> {

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -32,7 +32,7 @@ pub(crate) enum Expression<'src> {
   Group { contents: Box<Expression<'src>> },
   /// `lhs / rhs`
   Join {
-    lhs: Box<Expression<'src>>,
+    lhs: Option<Box<Expression<'src>>>,
     rhs: Box<Expression<'src>>,
   },
   /// `"string_literal"` or `'string_literal'`
@@ -61,7 +61,14 @@ impl<'src> Display for Expression<'src> {
   fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
     match self {
       Expression::Backtick { token, .. } => write!(f, "{}", token.lexeme()),
-      Expression::Join { lhs, rhs } => write!(f, "{} / {}", lhs, rhs),
+      Expression::Join { lhs, rhs } => write!(
+        f,
+        "{} / {}",
+        lhs
+          .as_ref()
+          .unwrap_or(&Box::new(Expression::empty_string_literal())),
+        rhs
+      ),
       Expression::Concatenation { lhs, rhs } => write!(f, "{} + {}", lhs, rhs),
       Expression::Conditional {
         lhs,

--- a/src/node.rs
+++ b/src/node.rs
@@ -118,14 +118,11 @@ impl<'src> Node<'src> for Expression<'src> {
       } => Tree::string(cooked),
       Expression::Backtick { contents, .. } => Tree::atom("backtick").push(Tree::string(contents)),
       Expression::Group { contents } => Tree::List(vec![contents.tree()]),
-      Expression::Join { lhs, rhs } => Tree::atom("/")
-        .push(
-          lhs
-            .as_ref()
-            .unwrap_or(&Box::new(Expression::empty_string_literal()))
-            .tree(),
-        )
-        .push(rhs.tree()),
+      Expression::Join { lhs: None, rhs } => Tree::atom("/").push(rhs.tree()),
+      Expression::Join {
+        lhs: Some(lhs),
+        rhs,
+      } => Tree::atom("/").push(lhs.tree()).push(rhs.tree()),
     }
   }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -118,7 +118,14 @@ impl<'src> Node<'src> for Expression<'src> {
       } => Tree::string(cooked),
       Expression::Backtick { contents, .. } => Tree::atom("backtick").push(Tree::string(contents)),
       Expression::Group { contents } => Tree::List(vec![contents.tree()]),
-      Expression::Join { lhs, rhs } => Tree::atom("/").push(lhs.tree()).push(rhs.tree()),
+      Expression::Join { lhs, rhs } => Tree::atom("/")
+        .push(
+          lhs
+            .as_ref()
+            .unwrap_or(&Box::new(Expression::empty_string_literal()))
+            .tree(),
+        )
+        .push(rhs.tree()),
     }
   }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -404,6 +404,10 @@ impl<'tokens, 'src> Parser<'tokens, 'src> {
 
     let expression = if self.accepted_keyword(Keyword::If)? {
       self.parse_conditional()?
+    } else if self.accepted(Slash)? {
+      let lhs = Box::new(Expression::empty_string_literal());
+      let rhs = Box::new(self.parse_expression()?);
+      Expression::Join { lhs, rhs }
     } else {
       let value = self.parse_value()?;
 
@@ -1989,6 +1993,7 @@ mod tests {
         Identifier,
         ParenL,
         ParenR,
+        Slash,
         StringToken,
       ],
       found: Eof,
@@ -2008,6 +2013,7 @@ mod tests {
         Identifier,
         ParenL,
         ParenR,
+        Slash,
         StringToken,
       ],
       found: InterpolationEnd,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -405,27 +405,18 @@ impl<'tokens, 'src> Parser<'tokens, 'src> {
     let expression = if self.accepted_keyword(Keyword::If)? {
       self.parse_conditional()?
     } else {
-      let value = self.parse_value();
+      let value = self.parse_value()?;
+
       if self.accepted(Slash)? {
-        // Enables Slash operator to build absolute paths, like `/ "Users"`, by
-        // setting a default empty string on the lhs if the resulting expression
-        // is not Ok.
-        let value = value.unwrap_or(Expression::StringLiteral {
-          string_literal: StringLiteral {
-            kind: StringKind::new(string_kind::StringDelimiter::QuoteDouble, false),
-            raw: "",
-            cooked: "".to_string(),
-          },
-        });
         let lhs = Box::new(value);
         let rhs = Box::new(self.parse_expression()?);
         Expression::Join { lhs, rhs }
       } else if self.accepted(Plus)? {
-        let lhs = Box::new(value?);
+        let lhs = Box::new(value);
         let rhs = Box::new(self.parse_expression()?);
         Expression::Concatenation { lhs, rhs }
       } else {
-        value?
+        value
       }
     };
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -405,14 +405,14 @@ impl<'tokens, 'src> Parser<'tokens, 'src> {
     let expression = if self.accepted_keyword(Keyword::If)? {
       self.parse_conditional()?
     } else if self.accepted(Slash)? {
-      let lhs = Box::new(Expression::empty_string_literal());
+      let lhs = None;
       let rhs = Box::new(self.parse_expression()?);
       Expression::Join { lhs, rhs }
     } else {
       let value = self.parse_value()?;
 
       if self.accepted(Slash)? {
-        let lhs = Box::new(value);
+        let lhs = Some(Box::new(value));
         let rhs = Box::new(self.parse_expression()?);
         Expression::Join { lhs, rhs }
       } else if self.accepted(Plus)? {

--- a/src/string_kind.rs
+++ b/src/string_kind.rs
@@ -7,7 +7,7 @@ pub(crate) struct StringKind {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Ord, PartialOrd, Eq)]
-pub(crate) enum StringDelimiter {
+enum StringDelimiter {
   Backtick,
   QuoteDouble,
   QuoteSingle,
@@ -26,7 +26,7 @@ impl StringKind {
     Self::new(StringDelimiter::QuoteSingle, false),
   ];
 
-  pub(crate) const fn new(delimiter: StringDelimiter, indented: bool) -> Self {
+  const fn new(delimiter: StringDelimiter, indented: bool) -> Self {
     Self {
       delimiter,
       indented,

--- a/src/string_kind.rs
+++ b/src/string_kind.rs
@@ -7,7 +7,7 @@ pub(crate) struct StringKind {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Ord, PartialOrd, Eq)]
-enum StringDelimiter {
+pub(crate) enum StringDelimiter {
   Backtick,
   QuoteDouble,
   QuoteSingle,
@@ -26,7 +26,7 @@ impl StringKind {
     Self::new(StringDelimiter::QuoteSingle, false),
   ];
 
-  const fn new(delimiter: StringDelimiter, indented: bool) -> Self {
+  pub(crate) const fn new(delimiter: StringDelimiter, indented: bool) -> Self {
     Self {
       delimiter,
       indented,

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -197,7 +197,7 @@ pub enum Expression {
     operator: ConditionalOperator,
   },
   Join {
-    lhs: Box<Expression>,
+    lhs: Option<Box<Expression>>,
     rhs: Box<Expression>,
   },
   String {
@@ -258,7 +258,11 @@ impl Expression {
         rhs: Box::new(Expression::new(rhs)),
       },
       Join { lhs, rhs } => Expression::Join {
-        lhs: Box::new(Expression::new(lhs)),
+        lhs: if lhs.is_some() {
+          Some(Box::new(Expression::new(lhs.as_ref().unwrap())))
+        } else {
+          None
+        },
         rhs: Box::new(Expression::new(rhs)),
       },
       Conditional {

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -258,11 +258,7 @@ impl Expression {
         rhs: Box::new(Expression::new(rhs)),
       },
       Join { lhs, rhs } => Expression::Join {
-        lhs: if lhs.is_some() {
-          Some(Box::new(Expression::new(lhs.as_ref().unwrap())))
-        } else {
-          None
-        },
+        lhs: lhs.as_ref().map(|lhs| Box::new(Expression::new(lhs))),
         rhs: Box::new(Expression::new(rhs)),
       },
       Conditional {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -1,16 +1,12 @@
 use super::*;
 
 pub(crate) struct Variables<'expression, 'src> {
-  empty_string: &'expression Box<Expression<'expression>>,
   stack: Vec<&'expression Expression<'src>>,
 }
 
 impl<'expression, 'src> Variables<'expression, 'src> {
   pub(crate) fn new(root: &'expression Expression<'src>) -> Variables<'expression, 'src> {
-    Variables {
-      stack: vec![root],
-      empty_string: &Box::new(Expression::empty_string_literal()),
-    }
+    Variables { stack: vec![root] }
   }
 }
 
@@ -62,9 +58,10 @@ impl<'expression, 'src> Iterator for Variables<'expression, 'src> {
           self.stack.push(lhs);
         }
         Expression::Join { lhs, rhs } => {
-          let lhs = lhs.as_ref().unwrap_or(self.empty_string);
           self.stack.push(rhs);
-          self.stack.push(lhs);
+          if let Some(lhs) = lhs {
+            self.stack.push(lhs);
+          }
         }
         Expression::Group { contents } => {
           self.stack.push(contents);

--- a/tests/slash_operator.rs
+++ b/tests/slash_operator.rs
@@ -19,6 +19,15 @@ fn twice() {
 }
 
 #[test]
+fn no_lhs() {
+  Test::new()
+    .justfile("x := / 'a'")
+    .args(&["--evaluate", "x"])
+    .stdout("/a")
+    .run();
+}
+
+#[test]
 fn default_un_parenthesized() {
   Test::new()
     .justfile(

--- a/tests/slash_operator.rs
+++ b/tests/slash_operator.rs
@@ -19,15 +19,6 @@ fn twice() {
 }
 
 #[test]
-fn no_lhs() {
-  Test::new()
-    .justfile("x := / 'a'")
-    .args(&["--evaluate", "x"])
-    .stdout("/a")
-    .run();
-}
-
-#[test]
 fn default_un_parenthesized() {
   Test::new()
     .justfile(

--- a/tests/slash_operator.rs
+++ b/tests/slash_operator.rs
@@ -19,11 +19,41 @@ fn twice() {
 }
 
 #[test]
-fn no_lhs() {
+fn no_lhs_once() {
   Test::new()
     .justfile("x := / 'a'")
     .args(&["--evaluate", "x"])
     .stdout("/a")
+    .run();
+}
+
+#[test]
+fn no_lhs_twice() {
+  Test::new()
+    .justfile("x := / 'a' / 'b'")
+    .args(&["--evaluate", "x"])
+    .stdout("/a/b")
+    .run();
+  Test::new()
+    .justfile("x := // 'a'")
+    .args(&["--evaluate", "x"])
+    .stdout("//a")
+    .run();
+}
+
+#[test]
+fn no_rhs_once() {
+  Test::new()
+    .justfile("x := 'a' /")
+    .stderr(
+      "
+      error: Expected backtick, identifier, '(', '/', or string, but found end of file
+        |
+      1 | x := 'a' /
+        |           ^
+    ",
+    )
+    .status(EXIT_FAILURE)
     .run();
 }
 
@@ -49,6 +79,27 @@ fn default_un_parenthesized() {
 }
 
 #[test]
+fn no_lhs_un_parenthesized() {
+  Test::new()
+    .justfile(
+      "
+      foo x=/ 'a' / 'b':
+        echo {{x}}
+    ",
+    )
+    .stderr(
+      "
+      error: Expected backtick, identifier, '(', or string, but found '/'
+        |
+      1 | foo x=/ 'a' / 'b':
+        |       ^
+    ",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
 fn default_parenthesized() {
   Test::new()
     .justfile(
@@ -59,5 +110,19 @@ fn default_parenthesized() {
     )
     .stderr("echo a/b\n")
     .stdout("a/b\n")
+    .run();
+}
+
+#[test]
+fn no_lhs_parenthesized() {
+  Test::new()
+    .justfile(
+      "
+      foo x=(/ 'a' / 'b'):
+        echo {{x}}
+    ",
+    )
+    .stderr("echo /a/b\n")
+    .stdout("/a/b\n")
     .run();
 }


### PR DESCRIPTION
I was looking for a _good first issue_ and came across https://github.com/casey/just/issues/1298

~The change is that the parser will now default an empty string literal on the left hand side of the `/` operator if it fails unwrapping a value for the lhs. This makes it possible to create a path with an expression like: `/ "Users" / user`.~

~Lemme know if there is anything that should be changed!~

Edit:
The approach was changed to wrapping the left-hand side (lhs) value of a join expression (using the `/` operator) to an `Option`.