### PR TITLE
Fix justfile env shebang on Linux

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-#!/usr/bin/env just --justfile
+#!/usr/bin/env -S just --justfile
 # ^ A shebang isn't required, but allows a justfile to be executed
 #   like a script, with `./justfile test`, for example.
 


### PR DESCRIPTION
Add `-S` to the env invocation in the main justfile's shebang, which is
required on Linux.