### PR TITLE
Allow fallback when search directory is provided

### DIFF
--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -92,8 +92,19 @@ impl Subcommand {
     arguments: &[String],
     overrides: &BTreeMap<String, String>,
   ) -> Result<(), Error<'src>> {
-    if config.unstable && config.search_config == SearchConfig::FromInvocationDirectory {
-      let mut path = config.invocation_directory.clone();
+    if config.unstable
+      && matches!(
+        config.search_config,
+        SearchConfig::FromInvocationDirectory | SearchConfig::FromSearchDirectory { .. }
+      )
+    {
+      let mut path = match &config.search_config {
+        SearchConfig::FromInvocationDirectory => config.invocation_directory.clone(),
+        SearchConfig::FromSearchDirectory { search_directory } => std::env::current_dir()
+          .unwrap()
+          .join(search_directory.clone()),
+        _ => unreachable!(),
+      };
 
       let mut unknown_recipes_errors = None;
 

--- a/tests/fall_back_to_parent.rs
+++ b/tests/fall_back_to_parent.rs
@@ -83,7 +83,7 @@ fn requires_unstable() {
 }
 
 #[test]
-fn doesnt_work_with_search_directory() {
+fn works_with_provided_search_directory() {
   Test::new()
     .tree(tree! {
       bar: {
@@ -100,9 +100,15 @@ fn doesnt_work_with_search_directory() {
     ",
     )
     .args(&["--unstable", "./foo"])
+    .stdout("root\n")
+    .stderr(format!(
+      "
+      Trying ..{}justfile
+      echo root
+    ",
+      MAIN_SEPARATOR
+    ))
     .current_dir("bar")
-    .status(EXIT_FAILURE)
-    .stderr("error: Justfile does not contain recipe `foo`.\n")
     .run();
 }
 


### PR DESCRIPTION
This loosens a restriction, and allows falling back to a justfile in a parent justfile when a search directory is provide, e.g. with `just ..` or `just foo/bar/`. Looking at it now, I can't really think of why I enforced that restriction in the first place 🤷‍♀️.