### PR TITLE
Don't evaluate comments

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+// TODO
+// - don't evaluate comments
+
 /// A single line in a recipe body, consisting of any number of `Fragment`s.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(transparent)]
@@ -13,41 +16,39 @@ impl<'src> Line<'src> {
   }
 
   pub(crate) fn is_comment(&self) -> bool {
-    match self.fragments.first() {
-      Some(Fragment::Text { token }) => token.lexeme().starts_with('#'),
-      _ => false,
-    }
+    matches!(
+      self.fragments.first(),
+      Some(Fragment::Text { token }) if token.lexeme().starts_with('#'),
+    )
   }
 
   pub(crate) fn is_continuation(&self) -> bool {
-    match self.fragments.last() {
-      Some(Fragment::Text { token }) => token.lexeme().ends_with('\\'),
-      _ => false,
-    }
+    matches!(
+      self.fragments.last(),
+      Some(Fragment::Text { token }) if token.lexeme().ends_with('\\'),
+    )
   }
 
   pub(crate) fn is_shebang(&self) -> bool {
-    match self.fragments.first() {
-      Some(Fragment::Text { token }) => token.lexeme().starts_with("#!"),
-      _ => false,
-    }
+    matches!(
+      self.fragments.first(),
+      Some(Fragment::Text { token }) if token.lexeme().starts_with("#!"),
+    )
   }
 
   pub(crate) fn is_quiet(&self) -> bool {
-    match self.fragments.first() {
-      Some(Fragment::Text { token }) => {
-        token.lexeme().starts_with('@') || token.lexeme().starts_with("-@")
-      }
-      _ => false,
-    }
+    matches!(
+      self.fragments.first(),
+      Some(Fragment::Text { token })
+        if token.lexeme().starts_with('@') || token.lexeme().starts_with("-@"),
+    )
   }
 
   pub(crate) fn is_infallible(&self) -> bool {
-    match self.fragments.first() {
-      Some(Fragment::Text { token }) => {
-        token.lexeme().starts_with('-') || token.lexeme().starts_with("@-")
-      }
-      _ => false,
-    }
+    matches!(
+      self.fragments.first(),
+      Some(Fragment::Text { token })
+        if token.lexeme().starts_with('-') || token.lexeme().starts_with("@-"),
+    )
   }
 }

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,8 +1,5 @@
 use super::*;
 
-// TODO
-// - don't evaluate comments
-
 /// A single line in a recipe body, consisting of any number of `Fragment`s.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(transparent)]

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -124,7 +124,9 @@ impl<'src, D> Recipe<'src, D> {
         }
         let line = lines.next().unwrap();
         line_number += 1;
-        evaluated += &evaluator.evaluate_line(line, continued)?;
+        if !comment_line {
+          evaluated += &evaluator.evaluate_line(line, continued)?;
+        }
         if line.is_continuation() && !comment_line {
           continued = true;
           evaluated.pop();
@@ -132,6 +134,11 @@ impl<'src, D> Recipe<'src, D> {
           break;
         }
       }
+
+      if comment_line {
+        continue;
+      }
+
       let mut command = evaluated.as_str();
 
       if quiet_command {
@@ -140,10 +147,6 @@ impl<'src, D> Recipe<'src, D> {
 
       if infallible_command {
         command = &command[1..];
-      }
-
-      if comment_line {
-        continue;
       }
 
       if command.is_empty() {

--- a/tests/ignore_comments.rs
+++ b/tests/ignore_comments.rs
@@ -83,3 +83,17 @@ fn continuations_with_echo_comments_true() {
     .stderr("# comment lines can be continued echo something-useful\n")
     .run();
 }
+
+#[test]
+fn dont_evalute_comments() {
+  Test::new()
+    .justfile(
+      "
+      set ignore-comments
+
+      some_recipe:
+        # {{ error('foo') }}
+    ",
+    )
+    .run();
+}


### PR DESCRIPTION
This is a follow-up to #1333. In addition to not printing out comments, it doesn't evaluate the contents of interpolations inside comments. @neunenak, what do you think?