### PR TITLE
See how hard it is for recipe names to be strings

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -17,7 +17,7 @@ impl<'src> Alias<'src, Name<'src>> {
   }
 
   pub(crate) fn resolve(self, target: Rc<Recipe<'src>>) -> Alias<'src> {
-    assert_eq!(self.target.lexeme(), target.name.lexeme());
+    assert_eq!(self.target.lexeme(), target.name());
 
     Alias {
       name: self.name,
@@ -51,11 +51,6 @@ impl<'src> Display for Alias<'src, Name<'src>> {
 
 impl<'src> Display for Alias<'src> {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-    write!(
-      f,
-      "alias {} := {}",
-      self.name.lexeme(),
-      self.target.name.lexeme()
-    )
+    write!(f, "alias {} := {}", self.name.lexeme(), self.target.name())
   }
 }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -79,9 +79,9 @@ impl<'src> Analyzer<'src> {
     AssignmentResolver::resolve_assignments(&assignments)?;
 
     for recipe in recipes {
-      if let Some(original) = self.recipes.get(recipe.name.lexeme()) {
+      if let Some(original) = self.recipes.get(recipe.name()) {
         if !settings.allow_duplicate_recipes {
-          return Err(recipe.name.token().error(DuplicateRecipe {
+          return Err(recipe.token().error(DuplicateRecipe {
             recipe: original.name(),
             first: original.line_number(),
           }));
@@ -133,7 +133,7 @@ impl<'src> Analyzer<'src> {
     for parameter in &recipe.parameters {
       if parameters.contains(parameter.name.lexeme()) {
         return Err(parameter.name.token().error(DuplicateParameter {
-          recipe: recipe.name.lexeme(),
+          recipe: recipe.name(),
           parameter: parameter.name.lexeme(),
         }));
       }

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,9 +1,8 @@
 #![allow(unknown_lints)]
 #![allow(clippy::unnecessary_wraps)]
 
-use super::*;
+use {super::*, ::target, Function::*};
 
-use Function::*;
 pub(crate) enum Function {
   Nullary(fn(&FunctionContext) -> Result<String, String>),
   Unary(fn(&FunctionContext, &str) -> Result<String, String>),

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -33,7 +33,7 @@ impl<'src> Justfile<'src> {
           edit_distance(name, input),
           Suggestion {
             name,
-            target: Some(alias.target.name.lexeme()),
+            target: Some(alias.target.name()),
           },
         )
       }))
@@ -196,7 +196,7 @@ impl<'src> Justfile<'src> {
       let min_arguments = recipe.min_arguments();
       if min_arguments > 0 {
         return Err(Error::DefaultRecipeRequiresArguments {
-          recipe: recipe.name.lexeme(),
+          recipe: recipe.name(),
           min_arguments,
         });
       }
@@ -370,7 +370,7 @@ impl<'src> Justfile<'src> {
       .collect::<Vec<&Recipe<Dependency>>>();
 
     if source_order {
-      recipes.sort_by_key(|recipe| recipe.name.offset);
+      recipes.sort_by_key(|recipe| recipe.token().offset);
     }
 
     recipes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,9 @@ pub(crate) use {
     search_error::SearchError, set::Set, setting::Setting, settings::Settings, shebang::Shebang,
     shell::Shell, show_whitespace::ShowWhitespace, string_kind::StringKind,
     string_literal::StringLiteral, subcommand::Subcommand, suggestion::Suggestion, table::Table,
-    thunk::Thunk, token::Token, token_kind::TokenKind, unresolved_dependency::UnresolvedDependency,
-    unresolved_recipe::UnresolvedRecipe, use_color::UseColor, variables::Variables,
-    verbosity::Verbosity, warning::Warning,
+    target::Target, thunk::Thunk, token::Token, token_kind::TokenKind,
+    unresolved_dependency::UnresolvedDependency, unresolved_recipe::UnresolvedRecipe,
+    use_color::UseColor, variables::Variables, verbosity::Verbosity, warning::Warning,
   },
   std::{
     cmp,
@@ -180,6 +180,7 @@ mod string_literal;
 mod subcommand;
 mod suggestion;
 mod table;
+mod target;
 mod thunk;
 mod token;
 mod token_kind;

--- a/src/node.rs
+++ b/src/node.rs
@@ -140,7 +140,7 @@ impl<'src> Node<'src> for UnresolvedRecipe<'src> {
       t.push_mut(Tree::string(doc));
     }
 
-    t.push_mut(self.name.lexeme());
+    t.push_mut(self.name());
 
     if !self.parameters.is_empty() {
       let mut params = Tree::atom("params");

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -247,7 +247,7 @@ impl Subcommand {
         .stdin
         .as_mut()
         .expect("Child was created with piped stdio")
-        .write_all(format!("{}\n", recipe.name).as_bytes())
+        .write_all(format!("{}\n", recipe.name()).as_bytes())
       {
         return Err(Error::ChooserWrite { io_error, chooser });
       }
@@ -436,11 +436,11 @@ impl Subcommand {
         continue;
       }
 
-      if recipe_aliases.contains_key(alias.target.name.lexeme()) {
-        let aliases = recipe_aliases.get_mut(alias.target.name.lexeme()).unwrap();
+      if recipe_aliases.contains_key(alias.target.name()) {
+        let aliases = recipe_aliases.get_mut(alias.target.name()).unwrap();
         aliases.push(alias.name.lexeme());
       } else {
-        recipe_aliases.insert(alias.target.name.lexeme(), vec![alias.name.lexeme()]);
+        recipe_aliases.insert(alias.target.name(), vec![alias.name.lexeme()]);
       }
     }
 
@@ -501,7 +501,7 @@ impl Subcommand {
           (0, Some(doc)) => print_doc(doc),
           (0, None) => (),
           _ => {
-            let alias_doc = format!("alias for `{}`", recipe.name);
+            let alias_doc = format!("alias for `{}`", recipe.name());
             print_doc(&alias_doc);
           }
         }
@@ -512,7 +512,7 @@ impl Subcommand {
 
   fn show<'src>(config: &Config, name: &str, justfile: Justfile<'src>) -> Result<(), Error<'src>> {
     if let Some(alias) = justfile.get_alias(name) {
-      let recipe = justfile.get_recipe(alias.target.name.lexeme()).unwrap();
+      let recipe = justfile.get_recipe(alias.target.name()).unwrap();
       println!("{}", alias);
       println!("{}", recipe.color_display(config.color.stdout()));
       Ok(())

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+pub(crate) enum Target<'src> {
+  Name(Name<'src>),
+  Path { path: String, token: Token<'src> },
+}
+
+impl<'src> Target<'src> {
+  pub(crate) fn token(&self) -> Token<'src> {
+    match self {
+      Self::Name(name) => name.token(),
+      Self::Path { path, token } => *token,
+    }
+  }
+}
+
+impl<'src> Serialize for Target<'src> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    match self {
+      Self::Name(name) => name.serialize(serializer),
+      Self::Path { path, token } => *token,
+    }
+  }
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -20,6 +20,12 @@ impl<'src> Token<'src> {
   }
 }
 
+impl Display for Token<'_> {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    write!(f, "{}", self.lexeme())
+  }
+}
+
 impl<'src> ColorDisplay for Token<'src> {
   fn fmt(&self, f: &mut Formatter, color: Color) -> fmt::Result {
     let width = if self.length == 0 { 1 } else { self.length };
@@ -78,5 +84,14 @@ impl<'src> ColorDisplay for Token<'src> {
     }
 
     Ok(())
+  }
+}
+
+impl<'src> Serialize for Token<'src> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    serializer.serialize_str(self.lexeme())
   }
 }

--- a/src/unresolved_recipe.rs
+++ b/src/unresolved_recipe.rs
@@ -16,7 +16,7 @@ impl<'src> UnresolvedRecipe<'src> {
     );
 
     for (unresolved, resolved) in self.dependencies.iter().zip(&resolved) {
-      assert_eq!(unresolved.recipe.lexeme(), resolved.name.lexeme());
+      assert_eq!(unresolved.recipe.lexeme(), resolved.name());
       if !resolved
         .argument_range()
         .contains(&unresolved.arguments.len())
@@ -46,14 +46,14 @@ impl<'src> UnresolvedRecipe<'src> {
 
     Ok(Recipe {
       body: self.body,
+      dependencies,
       doc: self.doc,
-      name: self.name,
       parameters: self.parameters,
+      priors: self.priors,
       private: self.private,
       quiet: self.quiet,
       shebang: self.shebang,
-      priors: self.priors,
-      dependencies,
+      target: self.target,
     })
   }
 }


### PR DESCRIPTION
This is totally broken. Just experimenting to see what it's like for recipe targets to optionally be strings, like so:

```
"foo.bar":
```

This is so we can eventually have make-like recipe.