### PR TITLE
Update asdf-just repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ You can also set the shell using command-line arguments. For example, to use Pow
   <tr>
     <td><a href="https://github.com/casey/just/releases">Various</a></td>
     <td><a href="https://asdf-vm.com">asdf</a></td>
-    <td><a href="https://github.com/ggilmore/asdf-just">just</a></td>
+    <td><a href="https://github.com/olofvndrhr/asdf-just">just</a></td>
     <td>
       <code>asdf plugin add just</code><br>
       <code>asdf install just &lt;version&gt;</code>

--- a/README.中文.md
+++ b/README.中文.md
@@ -214,7 +214,7 @@ list:
   <tr>
     <td><a href="https://github.com/casey/just/releases">Various</a></td>
     <td><a href="https://asdf-vm.com">asdf</a></td>
-    <td><a href="https://github.com/ggilmore/asdf-just">just</a></td>
+    <td><a href="https://github.com/olofvndrhr/asdf-just">just</a></td>
     <td>
       <code>asdf plugin add just</code><br>
       <code>asdf install just &lt;version&gt;</code>


### PR DESCRIPTION
asdf-vm/asdf-plugins replaced the repository to another. So short-name installing uses new repository now.

https://github.com/asdf-vm/asdf-plugins/pull/629

This PR updates #1264