### PR TITLE
OS Recipe Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,7 +1218,8 @@ those configurations is active.
 
 This can be used to write `justfile`s that behave differently depending on
 which operating system they run on. The `run` recipe in this `justfile` will
-invoke `cc` on Unixes and `cl` on Windows and run the resulting binary:
+compile and run `main.c`, using a different C compiler and using the correct
+output binary name for that compiler depending on the operating system:
 
 ```make
 [unix]

--- a/README.md
+++ b/README.md
@@ -1057,9 +1057,7 @@ Done!
 #### System Information
 
 - `arch()` — Instruction set architecture. Possible values are: `"aarch64"`, `"arm"`, `"asmjs"`, `"hexagon"`, `"mips"`, `"msp430"`, `"powerpc"`, `"powerpc64"`, `"s390x"`, `"sparc"`, `"wasm32"`, `"x86"`, `"x86_64"`, and `"xcore"`.
-
 - `os()` — Operating system. Possible values are: `"android"`, `"bitrig"`, `"dragonfly"`, `"emscripten"`, `"freebsd"`, `"haiku"`, `"ios"`, `"linux"`, `"macos"`, `"netbsd"`, `"openbsd"`, `"solaris"`, and `"windows"`.
-
 - `os_family()` — Operating system family; possible values are: `"unix"` and `"windows"`.
 
 For example:
@@ -1143,67 +1141,47 @@ The executable is at: /bin/just
 
 #### String Manipulation
 
-- `capitalize(s)`<sup>1.7.0</sup> - Convert first character of `s` to uppercase and the rest to lowercase.
-
-- `kebabcase(s)`<sup>1.7.0</sup> - Convert `s` to `kebab-case`.
-
-- `lowercamelcase(s)`<sup>1.7.0</sup> - Convert `s` to `lowerCamelCase`.
-
-- `lowercase(s)` - Convert `s` to lowercase.
-
 - `quote(s)` - Replace all single quotes with `'\''` and prepend and append single quotes to `s`. This is sufficient to escape special characters for many shells, including most Bourne shell descendants.
-
 - `replace(s, from, to)` - Replace all occurrences of `from` in `s` to `to`.
-
-- `shoutykebabcase(s)`<sup>1.7.0</sup> - Convert `s` to `SHOUTY-KEBAB-CASE`.
-
-- `shoutysnakecase(s)`<sup>1.7.0</sup> - Convert `s` to `SHOUTY_SNAKE_CASE`.
-
-- `snakecase(s)`<sup>1.7.0</sup> - Convert `s` to `snake_case`.
-
-- `titlecase(s)`<sup>1.7.0</sup> - Convert `s` to `Title Case`.
-
 - `trim(s)` - Remove leading and trailing whitespace from `s`.
-
 - `trim_end(s)` - Remove trailing whitespace from `s`.
-
 - `trim_end_match(s, pat)` - Remove suffix of `s` matching `pat`.
-
 - `trim_end_matches(s, pat)` - Repeatedly remove suffixes of `s` matching `pat`.
-
 - `trim_start(s)` - Remove leading whitespace from `s`.
-
 - `trim_start_match(s, pat)` - Remove prefix of `s` matching `pat`.
-
 - `trim_start_matches(s, pat)` - Repeatedly remove prefixes of `s` matching `pat`.
 
+#### Case Conversion
+
+- `capitalize(s)`<sup>1.7.0</sup> - Convert first character of `s` to uppercase and the rest to lowercase.
+- `kebabcase(s)`<sup>1.7.0</sup> - Convert `s` to `kebab-case`.
+- `lowercamelcase(s)`<sup>1.7.0</sup> - Convert `s` to `lowerCamelCase`.
+- `lowercase(s)` - Convert `s` to lowercase.
+- `shoutykebabcase(s)`<sup>1.7.0</sup> - Convert `s` to `SHOUTY-KEBAB-CASE`.
+- `shoutysnakecase(s)`<sup>1.7.0</sup> - Convert `s` to `SHOUTY_SNAKE_CASE`.
+- `snakecase(s)`<sup>1.7.0</sup> - Convert `s` to `snake_case`.
+- `titlecase(s)`<sup>1.7.0</sup> - Convert `s` to `Title Case`.
+- `uppercamelcase(s)`<sup>1.7.0</sup> - Convert `s` to `UpperCamelCase`.
 - `uppercase(s)` - Convert `s` to uppercase.
 
-- `uppercamelcase(s)`<sup>1.7.0</sup> - Convert `s` to `UpperCamelCase`.
 
 #### Path Manipulation
 
 ##### Fallible
 
 - `absolute_path(path)` - Absolute path to relative `path` in the working directory. `absolute_path("./bar.txt")` in directory `/foo` is `/foo/bar.txt`.
-
 - `extension(path)` - Extension of `path`. `extension("/foo/bar.txt")` is `txt`.
-
 - `file_name(path)` - File name of `path` with any leading directory components removed. `file_name("/foo/bar.txt")` is `bar.txt`.
-
 - `file_stem(path)` - File name of `path` without extension. `file_stem("/foo/bar.txt")` is `bar`.
-
 - `parent_directory(path)` - Parent directory of `path`. `parent_directory("/foo/bar.txt")` is `/foo`.
-
 - `without_extension(path)` - `path` without extension. `without_extension("/foo/bar.txt")` is `/foo/bar`.
 
 These functions can fail, for example if a path does not have an extension, which will halt execution.
 
 ##### Infallible
 
-- `join(a, b…)` - *This function uses `/` on Unix and `\` on Windows, which can be lead to unwanted behavior. The `/` operator, e.g., `a / b`, which always uses `/`, should be considered as a replacement unless `\`s are specifically desired on Windows.* Join path `a` with path `b`. `join("foo/bar", "baz")` is `foo/bar/baz`. Accepts two or more arguments.
-
 - `clean(path)` - Simplify `path` by removing extra path separators, intermediate `.` components, and `..` where possible. `clean("foo//bar")` is `foo/bar`, `clean("foo/..")` is `.`, `clean("foo/./bar")` is `foo/bar`.
+- `join(a, b…)` - *This function uses `/` on Unix and `\` on Windows, which can be lead to unwanted behavior. The `/` operator, e.g., `a / b`, which always uses `/`, should be considered as a replacement unless `\`s are specifically desired on Windows.* Join path `a` with path `b`. `join("foo/bar", "baz")` is `foo/bar/baz`. Accepts two or more arguments.
 
 #### Filesystem Access
 
@@ -1218,6 +1196,41 @@ These functions can fail, for example if a path does not have an extension, whic
 - `sha256(string)` - Return the SHA-256 hash of `string` as a hexadecimal string.
 - `sha256_file(path)` - Return the SHA-256 hash of the file at `path` as a hexadecimal string.
 - `uuid()` - Return a randomly generated UUID.
+
+### Recipe Attributes
+
+Recipes may be annotated with attributes that change their behavior.
+
+| Name                | Description                                       |
+| ------------------- | ------------------------------------------------- |
+| `[no-exit-message]` | Don't print an error message when a recipe fails. |
+| `[linux]`           | Enable recipe on Linux.                           |
+| `[macos]`           | Enable recipe on MacOS.                           |
+| `[unix]`            | Enable recipe on Unixes.                          |
+| `[windows]`         | Enable recipe on Windows.                         |
+
+#### Enabling and Disabling Recipes
+
+The `[linux]`, `[macos]`, `[unix]`, and `[windows]` attributes are
+configuration attributes. By default, recipes are always enabled. A recipe with
+one or more configuration attributes will only be enabled when one or more of
+those configurations is active.
+
+This can be used to write `justfile`s that behave differently depending on
+which operating system they run on. The `run` recipe in this `justfile` will
+invoke `cc` on Unixes and `cl` on Windows and run the resulting binary:
+
+```make
+[unix]
+run:
+  cc main.c
+  ./a.out
+
+[windows]
+run:
+  cl main.c
+  main.exe
+```
 
 ### Command Evaluation Using Backticks
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -30,8 +30,10 @@ impl<'src> Analyzer<'src> {
         }
         Item::Comment(_) => (),
         Item::Recipe(recipe) => {
-          Self::analyze_recipe(&recipe)?;
-          recipes.push(recipe);
+          if recipe.enabled() {
+            Self::analyze_recipe(&recipe)?;
+            recipes.push(recipe);
+          }
         }
         Item::Set(set) => {
           self.analyze_set(&set)?;

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,7 +1,10 @@
 use super::*;
 
-#[derive(EnumString, PartialEq, Debug, Clone, Serialize)]
-#[strum(serialize_all = "kebab_case")]
+#[derive(
+  EnumString, PartialEq, Debug, Copy, Clone, Serialize, Ord, PartialOrd, Eq, IntoStaticStr,
+)]
+#[strum(serialize_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub(crate) enum Attribute {
   Linux,
   Macos,
@@ -13,5 +16,19 @@ pub(crate) enum Attribute {
 impl Attribute {
   pub(crate) fn from_name(name: Name) -> Option<Attribute> {
     name.lexeme().parse().ok()
+  }
+
+  pub(crate) fn to_str(self) -> &'static str {
+    self.into()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn to_str() {
+    assert_eq!(Attribute::NoExitMessage.to_str(), "no-exit-message");
   }
 }

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,9 +1,13 @@
 use super::*;
 
-#[derive(EnumString)]
+#[derive(EnumString, PartialEq, Debug, Clone, Serialize)]
 #[strum(serialize_all = "kebab_case")]
 pub(crate) enum Attribute {
+  Linux,
+  Macos,
   NoExitMessage,
+  Unix,
+  Windows,
 }
 
 impl Attribute {

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -96,6 +96,15 @@ impl Display for CompileError<'_> {
           self.token.line.ordinal(),
         )?;
       }
+      DuplicateAttribute { attribute, first } => {
+        write!(
+          f,
+          "Recipe attribute `{}` first used on line {} is duplicated on line {}",
+          attribute,
+          first.ordinal(),
+          self.token.line.ordinal(),
+        )?;
+      }
       DuplicateParameter { recipe, parameter } => {
         write!(
           f,

--- a/src/compile_error_kind.rs
+++ b/src/compile_error_kind.rs
@@ -25,6 +25,10 @@ pub(crate) enum CompileErrorKind<'src> {
     alias: &'src str,
     first: usize,
   },
+  DuplicateAttribute {
+    attribute: &'src str,
+    first: usize,
+  },
   DuplicateParameter {
     recipe: &'src str,
     parameter: &'src str,

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ pub(crate) enum Error<'src> {
     recipe: &'src str,
     line_number: Option<usize>,
     code: i32,
-    suppress_message: bool,
+    print_message: bool,
   },
   CommandInvoke {
     binary: OsString,
@@ -169,11 +169,11 @@ impl<'src> Error<'src> {
     }
   }
 
-  pub(crate) fn suppress_message(&self) -> bool {
-    matches!(
+  pub(crate) fn print_message(&self) -> bool {
+    !matches!(
       self,
       Error::Code {
-        suppress_message: true,
+        print_message: false,
         ..
       }
     )

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -472,13 +472,13 @@ mod tests {
       recipe,
       line_number,
       code,
-      suppress_message,
+      print_message,
     },
     check: {
       assert_eq!(recipe, "a");
       assert_eq!(code, 200);
       assert_eq!(line_number, None);
-      assert!(!suppress_message);
+      assert!(print_message);
     }
   }
 
@@ -493,13 +493,13 @@ mod tests {
       recipe,
       line_number,
       code,
-      suppress_message,
+      print_message,
     },
     check: {
       assert_eq!(recipe, "fail");
       assert_eq!(code, 100);
       assert_eq!(line_number, Some(2));
-      assert!(!suppress_message);
+      assert!(print_message);
     }
   }
 
@@ -514,13 +514,13 @@ mod tests {
       recipe,
       line_number,
       code,
-      suppress_message,
+      print_message,
     },
     check: {
       assert_eq!(recipe, "a");
       assert_eq!(code, 150);
       assert_eq!(line_number, Some(2));
-      assert!(!suppress_message);
+      assert!(print_message);
     }
   }
 
@@ -672,13 +672,13 @@ mod tests {
     error: Code {
       recipe,
       line_number,
-      suppress_message,
+      print_message,
       ..
     },
     check: {
       assert_eq!(recipe, "wut");
       assert_eq!(line_number, Some(7));
-      assert!(!suppress_message);
+      assert!(print_message);
     }
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub(crate) use {
       Serialize, Serializer,
     },
     snafu::{ResultExt, Snafu},
-    strum::{Display, EnumString, IntoStaticStr},
+    strum::{Display, EnumString, IntoStaticStr, ToString},
     typed_arena::Arena,
     unicode_width::{UnicodeWidthChar, UnicodeWidthStr},
   },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub(crate) use {
       Serialize, Serializer,
     },
     snafu::{ResultExt, Snafu},
-    strum::{Display, EnumString, IntoStaticStr, ToString},
+    strum::{Display, EnumString, IntoStaticStr},
     typed_arena::Arena,
     unicode_width::{UnicodeWidthChar, UnicodeWidthStr},
   },

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -670,7 +670,7 @@ impl<'tokens, 'src> Parser<'tokens, 'src> {
       parameters: positional.into_iter().chain(variadic).collect(),
       private: name.lexeme().starts_with('_'),
       shebang: body.first().map_or(false, Line::is_shebang),
-      attribute,
+      attributes: attribute.into_iter().collect(),
       priors,
       body,
       dependencies,

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -72,21 +72,12 @@ impl<'src, D> Recipe<'src, D> {
     let macos = self.attributes.contains(&Attribute::Macos);
     let unix = self.attributes.contains(&Attribute::Unix);
 
-    if !(windows || linux || macos || unix) {
-      true
-    } else if cfg!(target_os = "windows") {
-      windows
-    } else if cfg!(target_os = "linux") {
-      linux || unix
-    } else if cfg!(target_os = "macos") {
-      macos || unix
-    } else if cfg!(windows) {
-      windows
-    } else if cfg!(unix) {
-      unix
-    } else {
-      false
-    }
+    (!windows && !linux && !macos && !unix)
+      || (cfg!(target_os = "windows") && windows)
+      || (cfg!(target_os = "linux") && (linux || unix))
+      || (cfg!(target_os = "macos") && (macos || unix))
+      || (cfg!(windows) && windows)
+      || (cfg!(unix) && unix)
   }
 
   fn print_exit_message(&self) -> bool {

--- a/src/run.rs
+++ b/src/run.rs
@@ -29,7 +29,7 @@ pub fn run() -> Result<(), i32> {
   config
     .and_then(|config| config.run(&loader))
     .map_err(|error| {
-      if !verbosity.quiet() && !error.suppress_message() {
+      if !verbosity.quiet() && error.print_message() {
         eprintln!("{}", error.color_display(color.stderr()));
       }
       error.code().unwrap_or(EXIT_FAILURE)

--- a/src/unresolved_recipe.rs
+++ b/src/unresolved_recipe.rs
@@ -53,7 +53,7 @@ impl<'src> UnresolvedRecipe<'src> {
       quiet: self.quiet,
       shebang: self.shebang,
       priors: self.priors,
-      attribute: self.attribute,
+      attributes: self.attributes,
       dependencies,
     })
   }

--- a/src/unresolved_recipe.rs
+++ b/src/unresolved_recipe.rs
@@ -53,7 +53,7 @@ impl<'src> UnresolvedRecipe<'src> {
       quiet: self.quiet,
       shebang: self.shebang,
       priors: self.priors,
-      suppress_exit_error_messages: self.suppress_exit_error_messages,
+      attribute: self.attribute,
       dependencies,
     })
   }

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+#[test]
+fn all() {
+  Test::new()
+    .justfile(
+      "
+      [macos]
+      [windows]
+      [linux]
+      [unix]
+      [no-exit-message]
+      foo:
+        exit 1
+    ",
+    )
+    .stderr("exit 1\n")
+    .status(1)
+    .run();
+}
+
+#[test]
+fn duplicate_attributes_are_disallowed() {
+  Test::new()
+    .justfile(
+      "
+      [no-exit-message]
+      [no-exit-message]
+      foo:
+        echo bar
+    ",
+    )
+    .stderr(
+      "
+      error: Recipe attribute `no-exit-message` first used on line 1 is duplicated on line 2
+        |
+      2 | [no-exit-message]
+        |  ^^^^^^^^^^^^^^^
+      ",
+    )
+    .status(1)
+    .run();
+}

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -27,6 +27,7 @@ fn alias() {
       "assignments": {},
       "recipes": {
         "foo": {
+          "attributes": [],
           "body": [],
           "dependencies": [],
           "doc": null,
@@ -36,7 +37,6 @@ fn alias() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
         }
       },
       "settings": {
@@ -102,6 +102,7 @@ fn body() {
       "first": "foo",
       "recipes": {
         "foo": {
+          "attributes": [],
           "body": [
             ["bar"],
             ["abc", ["xyz"], "def"],
@@ -114,7 +115,6 @@ fn body() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
         }
       },
       "settings": {
@@ -147,6 +147,7 @@ fn dependencies() {
       "first": "foo",
       "recipes": {
         "bar": {
+          "attributes": [],
           "doc": null,
           "name": "bar",
           "body": [],
@@ -159,7 +160,6 @@ fn dependencies() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
         },
         "foo": {
           "body": [],
@@ -171,7 +171,7 @@ fn dependencies() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         }
       },
       "settings": {
@@ -246,7 +246,7 @@ fn dependency_argument() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         },
         "foo": {
           "body": [],
@@ -265,7 +265,7 @@ fn dependency_argument() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         }
       },
       "settings": {
@@ -322,7 +322,7 @@ fn duplicate_recipes() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         }
       },
       "settings": {
@@ -361,7 +361,7 @@ fn doc_comment() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         }
       },
       "settings": {
@@ -424,6 +424,7 @@ fn parameters() {
       "assignments": {},
       "recipes": {
         "a": {
+          "attributes": [],
           "body": [],
           "dependencies": [],
           "doc": null,
@@ -433,7 +434,6 @@ fn parameters() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
         },
         "b": {
           "body": [],
@@ -452,7 +452,7 @@ fn parameters() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         },
         "c": {
           "body": [],
@@ -471,7 +471,7 @@ fn parameters() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         },
         "d": {
           "body": [],
@@ -490,7 +490,7 @@ fn parameters() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         },
         "e": {
           "body": [],
@@ -509,7 +509,7 @@ fn parameters() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         },
         "f": {
           "body": [],
@@ -528,7 +528,7 @@ fn parameters() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         },
       },
       "settings": {
@@ -571,7 +571,7 @@ fn priors() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         },
         "b": {
           "body": [],
@@ -590,7 +590,7 @@ fn priors() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
           "parameters": [],
           "priors": 1,
         },
@@ -603,7 +603,7 @@ fn priors() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
           "parameters": [],
           "priors": 0,
         },
@@ -644,7 +644,7 @@ fn private() {
           "private": true,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         }
       },
       "settings": {
@@ -683,7 +683,7 @@ fn quiet() {
           "private": false,
           "quiet": true,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         }
       },
       "settings": {
@@ -741,7 +741,7 @@ fn settings() {
           "private": false,
           "quiet": false,
           "shebang": true,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         }
       },
       "settings": {
@@ -786,7 +786,7 @@ fn shebang() {
           "private": false,
           "quiet": false,
           "shebang": true,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         }
       },
       "settings": {
@@ -825,7 +825,7 @@ fn simple() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": false,
+          "attributes": [],
         }
       },
       "settings": {
@@ -858,6 +858,7 @@ fn attribute() {
       "first": "foo",
       "recipes": {
         "foo": {
+          "attributes": ["no-exit-message"],
           "body": [],
           "dependencies": [],
           "doc": null,
@@ -867,7 +868,6 @@ fn attribute() {
           "private": false,
           "quiet": false,
           "shebang": false,
-          "suppress_exit_error_messages": true,
         }
       },
       "settings": {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -60,6 +60,7 @@ mod line_prefixes;
 mod misc;
 mod multibyte_char;
 mod no_exit_message;
+mod os_attributes;
 mod parser;
 mod positional_arguments;
 mod quiet;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -33,6 +33,7 @@ mod test;
 mod allow_duplicate_recipes;
 mod assert_stdout;
 mod assert_success;
+mod attributes;
 mod byte_order_mark;
 mod changelog;
 mod choose;

--- a/tests/no_exit_message.rs
+++ b/tests/no_exit_message.rs
@@ -86,7 +86,7 @@ hello:
   @exit 100
 "#,
   stderr: r#"
-error: Expected '@' or identifier, but found comment
+error: Expected '@', '[', or identifier, but found comment
   |
 2 | # This is a doc comment
   | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -103,7 +103,7 @@ test! {
 hello:
   @exit 100
 "#,
-  stderr: "error: Expected '@' or identifier, but found end of line\n  |\n2 | \n  | ^\n",
+  stderr: "error: Expected '@', '[', or identifier, but found end of line\n  |\n2 | \n  | ^\n",
   status: EXIT_FAILURE,
 }
 

--- a/tests/no_exit_message.rs
+++ b/tests/no_exit_message.rs
@@ -1,4 +1,4 @@
-use libc::EXIT_FAILURE;
+use super::*;
 
 test! {
   name: recipe_exit_message_suppressed,

--- a/tests/os_attributes.rs
+++ b/tests/os_attributes.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 // TODO:
+// - test multiple attributes
 // - forbid duplicate attributes?
 
 #[test]
@@ -70,5 +71,37 @@ fn os() {
     } else {
       panic!("unexpected os family")
     })
+    .run();
+}
+
+#[test]
+fn all() {
+  Test::new()
+    .justfile(
+      "
+      [macos]
+      [windows]
+      [linux]
+      [unix]
+      foo:
+        echo bar
+    ",
+    )
+    .stdout("bar\n")
+    .stderr("echo bar\n")
+    .run();
+}
+
+#[test]
+fn none() {
+  Test::new()
+    .justfile(
+      "
+      foo:
+        echo bar
+    ",
+    )
+    .stdout("bar\n")
+    .stderr("echo bar\n")
     .run();
 }

--- a/tests/os_attributes.rs
+++ b/tests/os_attributes.rs
@@ -1,0 +1,71 @@
+use super::*;
+
+#[test]
+fn os_family() {
+  Test::new()
+    .justfile(
+      "
+      [unix]
+      foo:
+        echo bar
+
+      [windows]
+      foo:
+        echo baz
+    ",
+    )
+    .stdout(if cfg!(unix) {
+      "bar\n"
+    } else if cfg!(windows) {
+      "baz\n"
+    } else {
+      panic!("unexpected os family")
+    })
+    .stderr(if cfg!(unix) {
+      "echo bar\n"
+    } else if cfg!(windows) {
+      "echo baz\n"
+    } else {
+      panic!("unexpected os family")
+    })
+    .run();
+}
+
+#[test]
+fn os() {
+  Test::new()
+    .justfile(
+      "
+      [macos]
+      foo:
+        echo bar
+
+      [windows]
+      foo:
+        echo baz
+
+      [linux]
+      foo:
+        echo quxx
+    ",
+    )
+    .stdout(if cfg!(target_os = "macos") {
+      "bar\n"
+    } else if cfg!(windows) {
+      "baz\n"
+    } else if cfg!(linux) {
+      "quxx\n"
+    } else {
+      panic!("unexpected os family")
+    })
+    .stderr(if cfg!(unix) {
+      "echo bar\n"
+    } else if cfg!(windows) {
+      "echo baz\n"
+    } else if cfg!(linux) {
+      "echo quxx\n"
+    } else {
+      panic!("unexpected os family")
+    })
+    .run();
+}

--- a/tests/os_attributes.rs
+++ b/tests/os_attributes.rs
@@ -1,9 +1,5 @@
 use super::*;
 
-// TODO:
-// - test multiple attributes
-// - forbid duplicate attributes?
-
 #[test]
 fn os_family() {
   Test::new()

--- a/tests/os_attributes.rs
+++ b/tests/os_attributes.rs
@@ -53,7 +53,7 @@ fn os() {
       "bar\n"
     } else if cfg!(windows) {
       "baz\n"
-    } else if cfg!(linux) {
+    } else if cfg!(target_os = "linux") {
       "quxx\n"
     } else {
       panic!("unexpected os family")
@@ -62,7 +62,7 @@ fn os() {
       "echo bar\n"
     } else if cfg!(windows) {
       "echo baz\n"
-    } else if cfg!(linux) {
+    } else if cfg!(target_os = "linux") {
       "echo quxx\n"
     } else {
       panic!("unexpected os family")

--- a/tests/os_attributes.rs
+++ b/tests/os_attributes.rs
@@ -58,7 +58,7 @@ fn os() {
     } else {
       panic!("unexpected os family")
     })
-    .stderr(if cfg!(unix) {
+    .stderr(if cfg!(target_os = "macos") {
       "echo bar\n"
     } else if cfg!(windows) {
       "echo baz\n"

--- a/tests/os_attributes.rs
+++ b/tests/os_attributes.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+// TODO:
+// - forbid duplicate attributes?
+
 #[test]
 fn os_family() {
   Test::new()


### PR DESCRIPTION
This adds `[linux]`, `[macos]`, `[windows]`, and `[unix]` recipe OS attributes.

By default, without an OS attribute, a recipe is enabled on all operating systems. With an OS attribute, a recipe is only enabled when being run by a version of just build for that OS. Note that this depends on the OS the `just` binary was built for, not the OS that it's running on. So recipes with `[linux]` in a justfile run by a`just` binary built for Linux but running on the Windows Subsystem for Linux be enabled.

This allows writing cross-platform justfiles by writing multiple recipes with the same name which are enabled on different OSes. For example:

```make
[windows]
foo:
  echo bar

[unix]
foo:
  echo baz
```

On Windows, `just foo` will print `bar` and on linux `just foo` will print `baz`.

Recipes with the `[unix]` attribute are enabled on all unices, including Linux and MacOS.

Todo:

- [ ] Document in readme