### PR TITLE
Note on how shebang recipes are executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1697,6 +1697,8 @@ Yo from a shell script!
 Hello from ruby!
 ```
 
+Note: Just will execute this scripts by calling the command on the shebang line and a filename containing the script as the first argument, rather than passing the script to STDIN of the command on the shebang line, as would be the case with a shell script on e.g. Linux.
+
 ### Safer Bash Shebang Recipes
 
 If you're writing a `bash` shebang recipe, consider adding `set -euxo pipefail`:


### PR DESCRIPTION
To avoid confusion due to shebang recipes not working quite like executable scripts on e.g. Linux, added a note clarifying how it is called.