### PR TITLE
Add a replace function that supports regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,7 @@ The executable is at: /bin/just
 
 - `quote(s)` - Replace all single quotes with `'\''` and prepend and append single quotes to `s`. This is sufficient to escape special characters for many shells, including most Bourne shell descendants.
 - `replace(s, from, to)` - Replace all occurrences of `from` in `s` to `to`.
+- `replace_regex(s, regex, replacement)` - Replace all occurrences of `regec` in `s` to `replacement`.
 - `trim(s)` - Remove leading and trailing whitespace from `s`.
 - `trim_end(s)` - Remove trailing whitespace from `s`.
 - `trim_end_match(s, pat)` - Remove suffix of `s` matching `pat`.

--- a/src/function.rs
+++ b/src/function.rs
@@ -292,7 +292,7 @@ fn replace_regex(
 ) -> Result<String, String> {
   Ok(
     Regex::new(regex)
-      .map_err(|err| format!("Failed to compile regular expression: {}", err))?
+      .map_err(|err| err.to_string())?
       .replace_all(s, replacement)
       .to_string(),
   )

--- a/src/function.rs
+++ b/src/function.rs
@@ -43,6 +43,7 @@ lazy_static! {
     ("path_exists", Unary(path_exists)),
     ("quote", Unary(quote)),
     ("replace", Ternary(replace)),
+    ("replace_regex", Ternary(replace_regex)),
     ("sha256", Unary(sha256)),
     ("sha256_file", Unary(sha256_file)),
     ("shoutykebabcase", Unary(shoutykebabcase)),
@@ -281,6 +282,18 @@ fn quote(_context: &FunctionContext, s: &str) -> Result<String, String> {
 
 fn replace(_context: &FunctionContext, s: &str, from: &str, to: &str) -> Result<String, String> {
   Ok(s.replace(from, to))
+}
+
+fn replace_regex(
+  _context: &FunctionContext,
+  s: &str,
+  from: &str,
+  to: &str,
+) -> Result<String, String> {
+  let re =
+    Regex::new(from).map_err(|err| format!("Failed to compile regular expression: {}", err))?;
+
+  Ok(re.replace_all(s, to).to_string())
 }
 
 fn sha256(_context: &FunctionContext, s: &str) -> Result<String, String> {

--- a/src/function.rs
+++ b/src/function.rs
@@ -287,13 +287,15 @@ fn replace(_context: &FunctionContext, s: &str, from: &str, to: &str) -> Result<
 fn replace_regex(
   _context: &FunctionContext,
   s: &str,
-  from: &str,
-  to: &str,
+  regex: &str,
+  replacement: &str,
 ) -> Result<String, String> {
-  let re =
-    Regex::new(from).map_err(|err| format!("Failed to compile regular expression: {}", err))?;
-
-  Ok(re.replace_all(s, to).to_string())
+  Ok(
+    Regex::new(regex)
+      .map_err(|err| format!("Failed to compile regular expression: {}", err))?
+      .replace_all(s, replacement)
+      .to_string(),
+  )
 }
 
 fn sha256(_context: &FunctionContext, s: &str) -> Result<String, String> {

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -390,7 +390,7 @@ test! {
       echo {{ replace_regex('barbarbar', 'foo\\', 'foo') }}
   ",
   stderr:
-"error: Call to function `replace_regex` failed: Failed to compile regular expression: regex parse error:
+"error: Call to function `replace_regex` failed: regex parse error:
     foo\\
        ^
 error: incomplete escape sequence, reached end of pattern prematurely

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -374,6 +374,34 @@ test! {
 }
 
 test! {
+  name: replace_regex,
+  justfile: "
+    foo:
+      echo {{ replace_regex('123bar123bar123bar', '\\d+bar', 'foo') }}
+  ",
+  stdout: "foofoofoo\n",
+  stderr: "echo foofoofoo\n",
+}
+
+test! {
+  name: invalid_replace_regex,
+  justfile: "
+    foo:
+      echo {{ replace_regex('barbarbar', 'foo\\', 'foo') }}
+  ",
+  stderr:
+"error: Call to function `replace_regex` failed: Failed to compile regular expression: regex parse error:
+    foo\\
+       ^
+error: incomplete escape sequence, reached end of pattern prematurely
+  |
+2 |   echo {{ replace_regex('barbarbar', 'foo\\', 'foo') }}
+  |           ^^^^^^^^^^^^^
+",
+  status: EXIT_FAILURE,
+}
+
+test! {
     name: capitalize,
     justfile: "
       foo:


### PR DESCRIPTION
Add `replace_regex(s, from, to)` that supports replacing text using regular expressions.

Closes #1389.