### PR TITLE
Allow passing `--evaluate` alongside `--list` to evaluate parameter default expressions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -159,7 +159,7 @@ impl Config {
       .arg(
         Arg::with_name(arg::EVAL)
           .long("eval")
-          .help("Evaluate parameter default expressions.")
+          .help("Evaluate parameter defaults.")
           .requires(cmd::LIST)
       )
       .arg(

--- a/src/config.rs
+++ b/src/config.rs
@@ -992,11 +992,6 @@ mod tests {
   }
 
   error! {
-    name: subcommand_conflict_evaluate,
-    args: ["--list", "--evaluate"],
-  }
-
-  error! {
     name: subcommand_conflict_show,
     args: ["--list", "--show"],
   }

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,6 +125,7 @@ mod arg_or_cmd {
     cmd::EDIT,
     cmd::FORMAT,
     cmd::INIT,
+    cmd::SHOW,
     cmd::SUMMARY,
     cmd::VARIABLES,
   ];
@@ -545,7 +546,6 @@ impl Config {
     } else if let Some(name) = matches.value_of(cmd::SHOW) {
       Subcommand::Show {
         name: name.to_owned(),
-        evaluate: matches.is_present(arg_or_cmd::EVALUATE),
       }
     } else if matches.is_present(cmd::VARIABLES) {
       Subcommand::Variables
@@ -1125,25 +1125,19 @@ mod tests {
   test! {
     name: subcommand_show_long,
     args: ["--show", "build"],
-    subcommand: Subcommand::Show { name: String::from("build"),
-      evaluate: false,
-    },
+    subcommand: Subcommand::Show { name: String::from("build") },
   }
 
   test! {
     name: subcommand_show_short,
     args: ["-s", "build"],
-    subcommand: Subcommand::Show { name: String::from("build"),
-      evaluate: false,
-    },
+    subcommand: Subcommand::Show { name: String::from("build") },
   }
 
   test! {
     name: subcommand_show_evaluate,
-    args: ["--show", "build", "--evaluate"],
-    subcommand: Subcommand::Show { name: String::from("build"),
-      evaluate: true,
-    },
+    args: ["--show", "build"],
+    subcommand: Subcommand::Show { name: String::from("build") },
   }
 
   error! {

--- a/src/config.rs
+++ b/src/config.rs
@@ -522,11 +522,16 @@ impl Config {
     } else if matches.is_present(cmd::INIT) {
       Subcommand::Init
     } else if matches.is_present(cmd::LIST) {
-      Subcommand::List
+      Subcommand::List {
+        evaluate: matches.is_present(cmd::EVALUATE),
+      }
     } else if let Some(name) = matches.value_of(cmd::SHOW) {
       Subcommand::Show {
         name: name.to_owned(),
+        evaluate: matches.is_present(cmd::EVALUATE),
       }
+    } else if matches.is_present(cmd::VARIABLES) {
+      Subcommand::Variables
     } else if matches.is_present(cmd::EVALUATE) {
       if positional.arguments.len() > 1 {
         return Err(ConfigError::SubcommandArguments {
@@ -543,8 +548,6 @@ impl Config {
         variable: positional.arguments.into_iter().next(),
         overrides,
       }
-    } else if matches.is_present(cmd::VARIABLES) {
-      Subcommand::Variables
     } else {
       Subcommand::Run {
         arguments: positional.arguments,
@@ -1076,25 +1079,33 @@ mod tests {
   test! {
     name: subcommand_list_long,
     args: ["--list"],
-    subcommand: Subcommand::List,
+    subcommand: Subcommand::List {
+      evaluate: false,
+    },
   }
 
   test! {
     name: subcommand_list_short,
     args: ["-l"],
-    subcommand: Subcommand::List,
+    subcommand: Subcommand::List {
+      evaluate: false,
+    },
   }
 
   test! {
     name: subcommand_show_long,
     args: ["--show", "build"],
-    subcommand: Subcommand::Show { name: String::from("build") },
+    subcommand: Subcommand::Show { name: String::from("build"),
+      evaluate: false,
+    },
   }
 
   test! {
     name: subcommand_show_short,
     args: ["-s", "build"],
-    subcommand: Subcommand::Show { name: String::from("build") },
+    subcommand: Subcommand::Show { name: String::from("build"),
+      evaluate: false,
+    },
   }
 
   error! {

--- a/src/config.rs
+++ b/src/config.rs
@@ -536,8 +536,6 @@ impl Config {
       Subcommand::Show {
         name: name.to_owned(),
       }
-    } else if matches.is_present(cmd::VARIABLES) {
-      Subcommand::Variables
     } else if matches.is_present(cmd::EVALUATE) {
       if positional.arguments.len() > 1 {
         return Err(ConfigError::SubcommandArguments {
@@ -554,6 +552,8 @@ impl Config {
         variable: positional.arguments.into_iter().next(),
         overrides,
       }
+    } else if matches.is_present(cmd::VARIABLES) {
+      Subcommand::Variables
     } else {
       Subcommand::Run {
         arguments: positional.arguments,

--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -13,6 +13,43 @@ pub(crate) struct Parameter<'src> {
   pub(crate) name: Name<'src>,
 }
 
+impl<'src> Parameter<'src> {
+  pub(crate) fn format_eval<'this, 'eval, 'run>(
+    &'this self,
+    evaluator: &'eval std::cell::RefCell<Evaluator<'src, 'run>>,
+  ) -> FmtEval<'this, 'eval, 'src, 'run> {
+    FmtEval(self, evaluator)
+  }
+}
+
+pub struct FmtEval<'param, 'eval, 'src, 'run>(
+  &'param Parameter<'src>,
+  &'eval std::cell::RefCell<Evaluator<'src, 'run>>,
+);
+
+impl<'this, 'eval, 'src, 'run> ColorDisplay for FmtEval<'this, 'eval, 'src, 'run> {
+  fn fmt(&self, f: &mut Formatter, color: Color) -> fmt::Result {
+    if self.0.export {
+      write!(f, "$")?;
+    }
+    if let Some(prefix) = self.0.kind.prefix() {
+      write!(f, "{}", color.annotation().paint(prefix))?;
+    }
+    write!(f, "{}", color.parameter().paint(self.0.name.lexeme()))?;
+    if let Some(ref default) = self.0.default {
+      write!(
+        f,
+        "={}",
+        color.string().paint(&format!(
+          "'{}'",
+          self.1.borrow_mut().evaluate_expression(default).unwrap()
+        ))
+      )?;
+    }
+    Ok(())
+  }
+}
+
 impl<'src> ColorDisplay for Parameter<'src> {
   fn fmt(&self, f: &mut Formatter, color: Color) -> Result<(), fmt::Error> {
     if self.export {

--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -20,7 +20,7 @@ impl<'src> Parameter<'src> {
   ) -> RunResult<'src, Option<Parameter<'src, String>>> {
     if let Some(ref default) = self.default {
       Ok(Some(Parameter {
-        default: Some(evaluator.evaluate_expression(default)?),
+        default: Some(format!("'{}'", evaluator.evaluate_expression(default)?)),
         export: self.export,
         kind: self.kind,
         name: self.name,

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -438,7 +438,7 @@ impl Subcommand {
     search: &Search,
     justfile: Justfile<'src>,
   ) -> Result<(), Error<'src>> {
-    let dotenv = if config.load_dotenv {
+    let dotenv = if evaluate && config.load_dotenv {
       load_dotenv(config, &justfile.settings, &search.working_directory)?
     } else {
       BTreeMap::new()

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -470,8 +470,7 @@ impl Subcommand {
       let mut evaluator =
         Evaluator::recipe_evaluator(config, &dotenv, &scope, &justfile.settings, search);
 
-      let mut evaluated_parameters: BTreeMap<&str, BTreeMap<&str, Parameter<String>>> =
-        BTreeMap::new();
+      let mut evaluated_parameters: BTreeMap<&str, BTreeMap<_, _>> = BTreeMap::new();
 
       for (name, recipe) in justfile.recipes.iter() {
         if recipe.private {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -452,7 +452,7 @@ impl Subcommand {
     }
 
     if evaluate {
-      let dotenv = if evaluate && config.load_dotenv {
+      let dotenv = if config.load_dotenv {
         load_dotenv(config, &justfile.settings, &search.working_directory)?
       } else {
         BTreeMap::new()

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -34,7 +34,6 @@ pub(crate) enum Subcommand {
   },
   Show {
     name: String,
-    evaluate: bool,
   },
   Summary,
   Variables,
@@ -80,7 +79,7 @@ impl Subcommand {
       Dump => Self::dump(config, ast, justfile)?,
       Format => Self::format(config, &search, src, ast)?,
       List { evaluate } => Self::list(config, *evaluate, &search, justfile)?,
-      Show { ref name, .. } => Self::show(config, name, justfile)?,
+      Show { ref name } => Self::show(config, name, justfile)?,
       Summary => Self::summary(config, justfile),
       Variables => Self::variables(justfile),
       Changelog | Completions { .. } | Edit | Init | Run { .. } => unreachable!(),

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -499,18 +499,10 @@ impl Subcommand {
               format!(" {}", evaluated.color_display(Color::never())).as_str(),
             );
 
-            match evaluated_parameters.entry(name) {
-              Entry::Vacant(vacant) => {
-                let mut parameters = BTreeMap::new();
-                parameters.insert(evaluated.name.lexeme(), evaluated);
-                vacant.insert(parameters);
-              }
-              Entry::Occupied(mut occopied) => {
-                occopied
-                  .get_mut()
-                  .insert(evaluated.name.lexeme(), evaluated);
-              }
-            }
+            evaluated_parameters
+              .entry(name)
+              .or_default()
+              .insert(evaluated.name.lexeme(), evaluated);
           } else {
             line_width += UnicodeWidthStr::width(
               format!(" {}", parameter.color_display(Color::never())).as_str(),

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -25,13 +25,16 @@ pub(crate) enum Subcommand {
   },
   Format,
   Init,
-  List,
+  List {
+    evaluate: bool,
+  },
   Run {
     arguments: Vec<String>,
     overrides: BTreeMap<String, String>,
   },
   Show {
     name: String,
+    evaluate: bool,
   },
   Summary,
   Variables,
@@ -76,8 +79,8 @@ impl Subcommand {
       }
       Dump => Self::dump(config, ast, justfile)?,
       Format => Self::format(config, &search, src, ast)?,
-      List => Self::list(config, justfile),
-      Show { ref name } => Self::show(config, name, justfile)?,
+      List { .. } => Self::list(config, justfile),
+      Show { ref name, .. } => Self::show(config, name, justfile)?,
       Summary => Self::summary(config, justfile),
       Variables => Self::variables(justfile),
       Changelog | Completions { .. } | Edit | Init | Run { .. } => unreachable!(),

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-use std::collections::btree_map::Entry;
-
 const INIT_JUSTFILE: &str = "default:\n    echo 'Hello, world!'\n";
 
 #[derive(PartialEq, Clone, Debug)]

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use std::collections::btree_map::Entry;
+
 const INIT_JUSTFILE: &str = "default:\n    echo 'Hello, world!'\n";
 
 #[derive(PartialEq, Clone, Debug)]
@@ -495,8 +497,6 @@ impl Subcommand {
             .unwrap()
             .flatten()
           {
-            use std::collections::btree_map::Entry;
-
             line_width += UnicodeWidthStr::width(
               format!(" {}", evaluated.color_display(Color::never())).as_str(),
             );

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -480,7 +480,7 @@ impl Subcommand {
     let mut evaluated_parameters: BTreeMap<&str, BTreeMap<&str, Parameter<String>>> =
       BTreeMap::new();
 
-    for (name, recipe) in &justfile.recipes {
+    for (name, recipe) in justfile.recipes.iter() {
       if recipe.private {
         continue;
       }
@@ -489,12 +489,10 @@ impl Subcommand {
         let mut line_width = UnicodeWidthStr::width(*name);
 
         for parameter in &recipe.parameters {
-          // FIXME: unwrap -> ?
           if let Some(evaluated) = evaluator
             .as_mut()
             .map(|evaluator| parameter.evaluate_default(evaluator))
-            .transpose()
-            .unwrap()
+            .transpose()?
             .flatten()
           {
             line_width += UnicodeWidthStr::width(

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -20,27 +20,25 @@ test! {
   stdout: "foo",
 }
 
-// TODO: it remains to be decided how to easily include --evaluate as a subcommand in the usage
-//       while also allowing it to be used with --show and --list, but not others
-// test! {
-//   name: no_binary,
-//   justfile: "
-//     x:
-//       echo XYZ
-//   ",
-//   args: ("--command"),
-//   stderr: &format!("
-//     error: The argument '--command <COMMAND>' requires a value but none was supplied
+test! {
+  name: no_binary,
+  justfile: "
+    x:
+      echo XYZ
+  ",
+  args: ("--command"),
+  stderr: &format!("
+    error: The argument '--command <COMMAND>' requires a value but none was supplied
 
-//     USAGE:
-//         just{} --color <COLOR> --dump-format <FORMAT> --shell <SHELL> \
-//         <--changelog|--choose|--command <COMMAND>|--completions <SHELL>|--dump|--edit|\
-//         --evaluate|--fmt|--init|--list|--show <RECIPE>|--summary|--variables>
+    USAGE:
+        just{} --color <COLOR> --dump-format <FORMAT> --shell <SHELL> \
+        <--changelog|--choose|--command <COMMAND>|--completions <SHELL>|--dump|--edit|\
+        --evaluate|--fmt|--init|--list|--show <RECIPE>|--summary|--variables>
 
-//     For more information try --help
-//   ", EXE_SUFFIX),
-//   status: EXIT_FAILURE,
-// }
+    For more information try --help
+  ", EXE_SUFFIX),
+  status: EXIT_FAILURE,
+}
 
 test! {
   name: env_is_loaded,

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -20,25 +20,27 @@ test! {
   stdout: "foo",
 }
 
-test! {
-  name: no_binary,
-  justfile: "
-    x:
-      echo XYZ
-  ",
-  args: ("--command"),
-  stderr: &format!("
-    error: The argument '--command <COMMAND>' requires a value but none was supplied
+// TODO: it remains to be decided how to easily include --evaluate as a subcommand in the usage
+//       while also allowing it to be used with --show and --list, but not others
+// test! {
+//   name: no_binary,
+//   justfile: "
+//     x:
+//       echo XYZ
+//   ",
+//   args: ("--command"),
+//   stderr: &format!("
+//     error: The argument '--command <COMMAND>' requires a value but none was supplied
 
-    USAGE:
-        just{} --color <COLOR> --dump-format <FORMAT> --shell <SHELL> \
-        <--changelog|--choose|--command <COMMAND>|--completions <SHELL>|--dump|--edit|\
-        --evaluate|--fmt|--init|--list|--show <RECIPE>|--summary|--variables>
+//     USAGE:
+//         just{} --color <COLOR> --dump-format <FORMAT> --shell <SHELL> \
+//         <--changelog|--choose|--command <COMMAND>|--completions <SHELL>|--dump|--edit|\
+//         --evaluate|--fmt|--init|--list|--show <RECIPE>|--summary|--variables>
 
-    For more information try --help
-  ", EXE_SUFFIX),
-  status: EXIT_FAILURE,
-}
+//     For more information try --help
+//   ", EXE_SUFFIX),
+//   status: EXIT_FAILURE,
+// }
 
 test! {
   name: env_is_loaded,


### PR DESCRIPTION
This is an initial draft for adding support to pass `--evaluate` as an option to `--list`  to evaluate expressions in parameter defaults. This PR addresses #1405.

A `justfile` like so:
```
key := "value"

recipe arg=key:
    echo {{ arg }}
```
Should then produce the following output:
```
$ just --evaluate --list
Available recipes:
    recipe arg='key'
```
Possible extensions, like evaluation for `--show` or `--dump` have been left for another PR (as discussed [here](https://github.com/casey/just/issues/1405#issuecomment-1312552643)).