### PR TITLE
Make include_shebang_line clearer

### DIFF
--- a/src/shebang.rs
+++ b/src/shebang.rs
@@ -47,7 +47,7 @@ impl<'line> Shebang<'line> {
   }
 
   pub(crate) fn include_shebang_line(&self) -> bool {
-    !cfg!(windows) && !matches!(self.interpreter_filename(), "cmd" | "cmd.exe")
+    !(cfg!(windows) || matches!(self.interpreter_filename(), "cmd" | "cmd.exe"))
   }
 }
 


### PR DESCRIPTION
@pfmoore Check out this version, it should be clearer. We don't want to include the shebang line if we're on windows or if the interpreter is cmd. Strictly speaking, I don't think the second condition is required, since it's unlikely that anyone will use `cmd` anywhere but windows, but I wanted to change as little as possible.