### PR TITLE
an include feature for justfiles

### DIFF
--- a/examples/included.just
+++ b/examples/included.just
@@ -1,0 +1,16 @@
+# This file gets included.
+
+# ANSI color escapes.
+BOLD := '\e[1m'
+RESET := '\e[0m'
+RED := '\e[31m'
+GREEN := '\e[32m'
+BROWN := '\e[34m'
+BLUE := '\e[34m'
+PURPLE := '\e[35m'
+CYAN := '\e[36m'
+GRAY := '\e[37m'
+
+# Report the animal with the best blep.
+blep:
+  @printf "{{BOLD}}Cat{{RESET}} {{BLUE}}blep{{RESET}} is best."

--- a/examples/included.just
+++ b/examples/included.just
@@ -1,15 +1,15 @@
 # This file gets included.
 
 # ANSI color escapes.
-BOLD := '\e[1m'
-RESET := '\e[0m'
-RED := '\e[31m'
-GREEN := '\e[32m'
-BROWN := '\e[34m'
 BLUE := '\e[34m'
-PURPLE := '\e[35m'
+BOLD := '\e[1m'
+BROWN := '\e[34m'
 CYAN := '\e[36m'
 GRAY := '\e[37m'
+GREEN := '\e[32m'
+PURPLE := '\e[35m'
+RED := '\e[31m'
+RESET := '\e[0m'
 
 # Report the animal with the best blep.
 blep:

--- a/examples/parent.just
+++ b/examples/parent.just
@@ -1,4 +1,4 @@
-#include "included.just"
+@include "included.just"
 
 # The recipes in this file rely on variables defined in the
 # included file!

--- a/examples/parent.just
+++ b/examples/parent.just
@@ -1,0 +1,16 @@
+#include "included.just"
+
+# The recipes in this file rely on variables defined in the
+# included file!
+
+# Report the animal with the best sploot.
+sploot:
+  @printf "{{BOLD}}Corgi{{RESET}} {{BLUE}}sploot{{RESET}} is best."
+
+# Report the animal with the highest cuteness.
+cute:
+  @printf "{{BOLD}}The baby sea otter{{RESET}} is, at 1.0 otters, the animal rated as most cute."
+
+help:
+  @just -l
+

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -19,8 +19,8 @@ impl Loader {
 
     // Parse include directives.
     // Include directives are lines that look like:
-    // #include "relative/path/to/file"
-    let include_regexp = Regex::new(r#"^#include "([^"]+)"$"#).unwrap();
+    // @include "relative/path/to/file"
+    let include_regexp = Regex::new(r#"^@include "([^"]+)"$"#).unwrap();
 
     let parent = path.parent().map_or_else(|| Path::new(""), |p| p);
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -16,6 +16,34 @@ impl Loader {
       path: path.to_owned(),
       io_error,
     })?;
-    Ok(self.arena.alloc(src))
+
+    // Parse include directives.
+    // Include directives are lines that look like:
+    // #include "relative/path/to/file"
+    let include_regexp = Regex::new(r#"^#include "([^"]+)"$"#).unwrap();
+
+    let parent = path.parent().map_or_else(|| Path::new(""), |p| p);
+
+    let mut buf = String::new();
+    let lines = src.lines();
+    for line in lines {
+      if let Some(captures) = include_regexp.captures(line) {
+        // safe because we don't get here without a match
+        let filename = captures.get(1).unwrap().as_str();
+        let mut include_path = PathBuf::from(&parent);
+        include_path.push(filename);
+
+        let contents = fs::read_to_string(&include_path).map_err(|io_error| Error::Load {
+          path: include_path.clone(),
+          io_error,
+        })?;
+        buf.push_str(&contents);
+      } else {
+        buf.push_str(line);
+      }
+      buf.push('\n');
+    }
+
+    Ok(self.arena.alloc(buf))
   }
 }


### PR DESCRIPTION
This design takes all lines that look like this:
`@include "relative/path/to/file"`
and replaces them with the contents of the pointed-to file. The resulting buffer is passed along to be parsed and executed as before. That's it: no attempt to look at the file or do anything with the contents. This is pure concatenation.

Feel free to tweak as needed!

Implements #1407 