### PR TITLE
Move to dotenvy crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,10 +173,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
 name = "edit-distance"
@@ -312,7 +312,7 @@ dependencies = [
  "cradle",
  "ctrlc",
  "derivative",
- "dotenv",
+ "dotenvy",
  "edit-distance",
  "env_logger",
  "executable-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ camino = "1.0.4"
 clap = { version = "2.33.0", features = ["wrap_help"] }
 ctrlc = { version = "3.1.1", features = ["termination"] }
 derivative = "2.0.0"
-dotenv = "0.15.0"
+dotenvy = "0.15"
 edit-distance = "2.0.0"
 env_logger = "0.9.3"
 heck = "0.4.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,7 +62,7 @@ pub(crate) enum Error<'src> {
     min_arguments: usize,
   },
   Dotenv {
-    dotenv_error: dotenv::Error,
+    dotenv_error: dotenvy::Error,
   },
   DumpJson {
     serde_json_error: serde_json::Error,
@@ -192,8 +192,8 @@ impl<'src> From<ConfigError> for Error<'src> {
   }
 }
 
-impl<'src> From<dotenv::Error> for Error<'src> {
-  fn from(dotenv_error: dotenv::Error) -> Error<'src> {
+impl<'src> From<dotenvy::Error> for Error<'src> {
+  fn from(dotenv_error: dotenvy::Error) -> Error<'src> {
     Self::Dotenv { dotenv_error }
   }
 }

--- a/src/load_dotenv.rs
+++ b/src/load_dotenv.rs
@@ -35,11 +35,7 @@ pub(crate) fn load_dotenv(
 }
 
 fn load_from_file(path: &Path) -> RunResult<'static, BTreeMap<String, String>> {
-  // `dotenv::from_path_iter` should eventually be un-deprecated, see:
-  // https://github.com/dotenv-rs/dotenv/issues/13
-  #![allow(deprecated)]
-
-  let iter = dotenv::from_path_iter(path)?;
+  let iter = dotenvy::from_path_iter(path)?;
   let mut dotenv = BTreeMap::new();
   for result in iter {
     let (key, value) = result?;


### PR DESCRIPTION
In light of [RUSTSEC-2021-0141][], it's probably prudent to move off of the `dotenv` crate. The `dotenvy` crate is a maintained fork.

[RUSTSEC-2021-0141]: https://rustsec.org/advisories/RUSTSEC-2021-0141.html