### PR TITLE
Let pages run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,8 @@ jobs:
         ./bin/forbid
   pages:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     env:
       RUSTFLAGS: --deny warnings


### PR DESCRIPTION
Organizations can be configured to not give write permissions by default.
The pages job needs permissions to write.