### PR TITLE
Specify minimum rust version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,14 +51,6 @@ jobs:
         sudo apt-get install ripgrep
         ./bin/forbid
 
-    - name: cargo-msrv
-      uses: baptiste0928/cargo-install@v1
-      with:
-        crate: cargo-msrv
-
-    - name: Verify MSRV
-      run: cargo-msrv verify
-
   pages:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,15 @@ jobs:
         sudo apt-get update
         sudo apt-get install ripgrep
         ./bin/forbid
+
+    - name: cargo-msrv
+      uses: baptiste0928/cargo-install@v1
+      with:
+        crate: cargo-msrv
+
+    - name: Verify MSRV
+      run: cargo-msrv verify
+
   pages:
     runs-on: ubuntu-latest
     permissions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ autotests = false
 categories = ["command-line-utilities", "development-tools"]
 keywords = ["command-line", "task", "runner", "development", "utility"]
 exclude = ["/book", "/icon.png", "/screenshot.png", "/www"]
+rust-version = "1.63"
 
 [workspace]
 members = [".", "bin/ref-type", "bin/generate-book", "bin/update-contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "just"
 version = "1.11.0"
-description = "🤖 Just a command runner"
 authors = ["Casey Rodarmor <casey@rodarmor.com>"]
-license = "CC0-1.0"
-homepage = "https://github.com/casey/just"
-repository = "https://github.com/casey/just"
-readme = "crates-io-readme.md"
-edition = "2021"
 autotests = false
 categories = ["command-line-utilities", "development-tools"]
-keywords = ["command-line", "task", "runner", "development", "utility"]
+description = "🤖 Just a command runner"
+edition = "2021"
 exclude = ["/book", "/icon.png", "/screenshot.png", "/www"]
+homepage = "https://github.com/casey/just"
+keywords = ["command-line", "task", "runner", "development", "utility"]
+license = "CC0-1.0"
+readme = "crates-io-readme.md"
+repository = "https://github.com/casey/just"
 rust-version = "1.63"
 
 [workspace]


### PR DESCRIPTION
1.63 is required by Mutex::new added in https://github.com/casey/just/pull/1442

Sorta fixes #1495 ? Doesn't really fix it, but makes it more clear to users that they're not gonna have a good time :)

Example of the error Cargo gives:
> error: package `just v1.11.0 (/workspace)` cannot be built because it requires rustc 1.63 or newer, while the currently active rustc version is 1.62.1

It's not super clear at first glance but [rust-version](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) is just a minimum:
> If the currently selected version of the Rust compiler is older than the stated version, cargo will exit with an error, telling the user what version is required.

