### PR TITLE
Change setting defaults to lower-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,15 +655,15 @@ foo:
 
 | Name                      | Value              | Default | Description                                                                                   |
 | ------------------------- | ------------------ | --------|---------------------------------------------------------------------------------------------- |
-| `allow-duplicate-recipes` | boolean            | False   | Allow recipes appearing later in a `justfile` to override earlier recipes with the same name. |
-| `dotenv-load`             | boolean            | False   | Load a `.env` file, if present.                                                               |
-| `export`                  | boolean            | False   | Export all variables as environment variables.                                                |
-| `fallback`                | boolean            | False   | Search `justfile` in parent directory if the first recipe on the command line is not found.   |
-| `ignore-comments`         | boolean            | False   | Ignore recipe lines beginning with `#`.                                                       |
-| `positional-arguments`    | boolean            | False   | Pass positional arguments.                                                                    |
+| `allow-duplicate-recipes` | boolean            | false   | Allow recipes appearing later in a `justfile` to override earlier recipes with the same name. |
+| `dotenv-load`             | boolean            | false   | Load a `.env` file, if present.                                                               |
+| `export`                  | boolean            | false   | Export all variables as environment variables.                                                |
+| `fallback`                | boolean            | false   | Search `justfile` in parent directory if the first recipe on the command line is not found.   |
+| `ignore-comments`         | boolean            | false   | Ignore recipe lines beginning with `#`.                                                       |
+| `positional-arguments`    | boolean            | false   | Pass positional arguments.                                                                    |
 | `shell`                   | `[COMMAND, ARGS…]` | -       | Set the command used to invoke recipes and evaluate backticks.                                |
 | `tempdir`                 | string             | -       | Create temporary directories in `tempdir` instead of the system default temporary directory.  |
-| `windows-powershell`      | boolean            | False   | Use PowerShell on Windows as default shell. (Deprecated. Use `windows-shell` instead.         |
+| `windows-powershell`      | boolean            | false   | Use PowerShell on Windows as default shell. (Deprecated. Use `windows-shell` instead.         |
 | `windows-shell`           | `[COMMAND, ARGS…]` | -       | Set the command used to invoke recipes and evaluate backticks.                                |
 
 Boolean settings can be written as:


### PR DESCRIPTION
Using uppercase `False` gives the impression that you need to change it to `True`, but the accepted literals are case-sensitive `true` and `false`.