### PR TITLE
Add -n as a short option for dry-run

### DIFF
--- a/completions/just.bash
+++ b/completions/just.bash
@@ -20,7 +20,7 @@ _just() {
 
     case "${cmd}" in
         just)
-            opts=" -q -u -v -e -l -h -V -f -d -c -s  --check --dry-run --highlight --no-dotenv --no-highlight --quiet --shell-command --clear-shell-args --unsorted --unstable --verbose --changelog --choose --dump --edit --evaluate --fmt --init --list --summary --variables --help --version --chooser --color --dump-format --list-heading --list-prefix --justfile --set --shell --shell-arg --working-directory --command --completions --show --dotenv-filename --dotenv-path  <ARGUMENTS>... "
+            opts=" -n -q -u -v -e -l -h -V -f -d -c -s  --check --dry-run --highlight --no-dotenv --no-highlight --quiet --shell-command --clear-shell-args --unsorted --unstable --verbose --changelog --choose --dump --edit --evaluate --fmt --init --list --summary --variables --help --version --chooser --color --dump-format --list-heading --list-prefix --justfile --set --shell --shell-arg --working-directory --command --completions --show --dotenv-filename --dotenv-path  <ARGUMENTS>... "
                 if [[ ${cur} == -* ]] ; then
                     COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                     return 0

--- a/completions/just.elvish
+++ b/completions/just.elvish
@@ -34,6 +34,7 @@ edit:completion:arg-completer[just] = [@words]{
             cand --dotenv-filename 'Search for environment file named <DOTENV-FILENAME> instead of `.env`'
             cand --dotenv-path 'Load environment file at <DOTENV-PATH> instead of searching for one'
             cand --check 'Run `--fmt` in ''check'' mode. Exits with 0 if justfile is formatted correctly. Exits with 1 and prints a diff if formatting is required.'
+            cand -n 'Print what just would do without doing it'
             cand --dry-run 'Print what just would do without doing it'
             cand --highlight 'Highlight echoed recipe lines in bold'
             cand --no-dotenv 'Don''t load `.env` file'

--- a/completions/just.fish
+++ b/completions/just.fish
@@ -25,7 +25,7 @@ complete -c just -n "__fish_use_subcommand" -s s -l show -d 'Show information ab
 complete -c just -n "__fish_use_subcommand" -l dotenv-filename -d 'Search for environment file named <DOTENV-FILENAME> instead of `.env`'
 complete -c just -n "__fish_use_subcommand" -l dotenv-path -d 'Load environment file at <DOTENV-PATH> instead of searching for one'
 complete -c just -n "__fish_use_subcommand" -l check -d 'Run `--fmt` in \'check\' mode. Exits with 0 if justfile is formatted correctly. Exits with 1 and prints a diff if formatting is required.'
-complete -c just -n "__fish_use_subcommand" -l dry-run -d 'Print what just would do without doing it'
+complete -c just -n "__fish_use_subcommand" -s n -l dry-run -d 'Print what just would do without doing it'
 complete -c just -n "__fish_use_subcommand" -l highlight -d 'Highlight echoed recipe lines in bold'
 complete -c just -n "__fish_use_subcommand" -l no-dotenv -d 'Don\'t load `.env` file'
 complete -c just -n "__fish_use_subcommand" -l no-highlight -d 'Don\'t highlight echoed recipe lines in bold'

--- a/completions/just.powershell
+++ b/completions/just.powershell
@@ -39,6 +39,7 @@ Register-ArgumentCompleter -Native -CommandName 'just' -ScriptBlock {
             [CompletionResult]::new('--dotenv-filename', 'dotenv-filename', [CompletionResultType]::ParameterName, 'Search for environment file named <DOTENV-FILENAME> instead of `.env`')
             [CompletionResult]::new('--dotenv-path', 'dotenv-path', [CompletionResultType]::ParameterName, 'Load environment file at <DOTENV-PATH> instead of searching for one')
             [CompletionResult]::new('--check', 'check', [CompletionResultType]::ParameterName, 'Run `--fmt` in ''check'' mode. Exits with 0 if justfile is formatted correctly. Exits with 1 and prints a diff if formatting is required.')
+            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Print what just would do without doing it')
             [CompletionResult]::new('--dry-run', 'dry-run', [CompletionResultType]::ParameterName, 'Print what just would do without doing it')
             [CompletionResult]::new('--highlight', 'highlight', [CompletionResultType]::ParameterName, 'Highlight echoed recipe lines in bold')
             [CompletionResult]::new('--no-dotenv', 'no-dotenv', [CompletionResultType]::ParameterName, 'Don''t load `.env` file')

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -35,12 +35,13 @@ _just() {
 '(--dotenv-path)--dotenv-filename=[Search for environment file named <DOTENV-FILENAME> instead of `.env`]' \
 '--dotenv-path=[Load environment file at <DOTENV-PATH> instead of searching for one]' \
 '--check[Run `--fmt` in '\''check'\'' mode. Exits with 0 if justfile is formatted correctly. Exits with 1 and prints a diff if formatting is required.]' \
+'(-q --quiet)-n[Print what just would do without doing it]' \
 '(-q --quiet)--dry-run[Print what just would do without doing it]' \
 '--highlight[Highlight echoed recipe lines in bold]' \
 '--no-dotenv[Don'\''t load `.env` file]' \
 '--no-highlight[Don'\''t highlight echoed recipe lines in bold]' \
-'(--dry-run)-q[Suppress all output]' \
-'(--dry-run)--quiet[Suppress all output]' \
+'(-n --dry-run)-q[Suppress all output]' \
+'(-n --dry-run)--quiet[Suppress all output]' \
 '--shell-command[Invoke <COMMAND> with the shell used to run recipe lines and backticks]' \
 '--clear-shell-args[Clear shell arguments]' \
 '-u[Return list and summary entries in source order]' \

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,6 +143,7 @@ impl Config {
       )
       .arg(
         Arg::with_name(arg::DRY_RUN)
+          .short("n")
           .long("dry-run")
           .help("Print what just would do without doing it")
           .conflicts_with(arg::QUIET),
@@ -771,8 +772,14 @@ mod tests {
   }
 
   test! {
-    name: dry_run_true,
+    name: dry_run_long,
     args: ["--dry-run"],
+    dry_run: true,
+  }
+
+  test! {
+    name: dry_run_short,
+    args: ["-n"],
     dry_run: true,
   }
 


### PR DESCRIPTION
Thank you for very interesting application. I am a heavy user of make and have one point of concern.

In `make`, the first and most frequently executed command is `-n`. It is very practical to be able to check that it works by **just adding a few letters** just before executing the command.

In `just`, a nice dry-run feature is also implemented, but unfortunately not comfortable **due to its length**. This PR introduces `-n` to make migration from `make` easier and to make just more convenient.

Best regards,