### PR TITLE
Analyzer::analyze borrows rather than clones Ast

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -14,7 +14,7 @@ impl<'src, 'a> Analyzer<'src> {
     Analyzer::default().justfile(ast)
   }
 
-  pub(crate) fn justfile(mut self, ast: &'a Ast<'src>) -> CompileResult<'src, Justfile<'src>> {
+  fn justfile(mut self, ast: &'a Ast<'src>) -> CompileResult<'src, Justfile<'src>> {
     let mut recipes = Vec::new();
 
     for item in &ast.items {

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -80,12 +80,12 @@ impl<'src, 'a> Analyzer<'src> {
 
     let assignments = self.assignments;
 
-    let mut recipes_table: Table<'src, UnresolvedRecipe<'src>> = Default::default();
+    let mut recipe_table: Table<'src, UnresolvedRecipe<'src>> = Default::default();
 
     AssignmentResolver::resolve_assignments(&assignments)?;
 
     for recipe in recipes {
-      if let Some(original) = recipes_table.get(recipe.name.lexeme()) {
+      if let Some(original) = recipe_table.get(recipe.name.lexeme()) {
         if !settings.allow_duplicate_recipes {
           return Err(recipe.name.token().error(DuplicateRecipe {
             recipe: original.name(),
@@ -93,10 +93,10 @@ impl<'src, 'a> Analyzer<'src> {
           }));
         }
       }
-      recipes_table.insert(recipe.clone());
+      recipe_table.insert(recipe.clone());
     }
 
-    let recipes = RecipeResolver::resolve_recipes(recipes_table, &assignments)?;
+    let recipes = RecipeResolver::resolve_recipes(recipe_table, &assignments)?;
 
     let mut aliases = Table::new();
     while let Some(alias) = self.aliases.pop() {

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -9,12 +9,12 @@ pub(crate) struct Analyzer<'src> {
   sets: Table<'src, Set<'src>>,
 }
 
-impl<'src, 'a> Analyzer<'src> {
-  pub(crate) fn analyze(ast: &'a Ast<'src>) -> CompileResult<'src, Justfile<'src>> {
+impl<'src> Analyzer<'src> {
+  pub(crate) fn analyze(ast: &Ast<'src>) -> CompileResult<'src, Justfile<'src>> {
     Analyzer::default().justfile(ast)
   }
 
-  fn justfile(mut self, ast: &'a Ast<'src>) -> CompileResult<'src, Justfile<'src>> {
+  fn justfile(mut self, ast: &Ast<'src>) -> CompileResult<'src, Justfile<'src>> {
     let mut recipes = Vec::new();
 
     for item in &ast.items {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -8,6 +8,6 @@ impl Compiler {
 
     let ast = Parser::parse(&tokens)?;
 
-    Analyzer::analyze(ast)
+    Analyzer::analyze(&ast)
   }
 }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -181,7 +181,7 @@ impl Subcommand {
 
     let tokens = Lexer::lex(src)?;
     let ast = Parser::parse(&tokens)?;
-    let justfile = Analyzer::analyze(ast.clone())?;
+    let justfile = Analyzer::analyze(&ast)?;
 
     if config.verbosity.loud() {
       for warning in &justfile.warnings {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -64,7 +64,7 @@ pub(crate) fn analysis_error(
 
   let ast = Parser::parse(&tokens).expect("Parsing failed in analysis test...");
 
-  match Analyzer::analyze(ast) {
+  match Analyzer::analyze(&ast) {
     Ok(_) => panic!("Analysis unexpectedly succeeded"),
     Err(have) => {
       let want = CompileError {


### PR DESCRIPTION
I was looking at the code around the Analyzer and I realized it was cloning the entire `Ast` object, which didn't seem to be necessary.