### PR TITLE
Add test that passing dot as argument between justfiles works

### DIFF
--- a/tests/search_arguments.rs
+++ b/tests/search_arguments.rs
@@ -24,6 +24,6 @@ fn passing_dot_as_argument_is_allowed() {
     .current_dir("child")
     .args(["say", "."])
     .stdout(".\n")
-    .stderr_regex("'.*just' ../say .\necho .\n")
+    .stderr_regex("'.*' ../say .\necho .\n")
     .run();
 }

--- a/tests/search_arguments.rs
+++ b/tests/search_arguments.rs
@@ -7,3 +7,23 @@ fn argument_with_different_path_prefix_is_allowed() {
     .args(["./foo", "../bar"])
     .run();
 }
+
+#[test]
+fn passing_dot_as_argument_is_allowed() {
+  Test::new()
+    .justfile(
+      "
+        say ARG:
+          echo {{ARG}}
+      ",
+    )
+    .write(
+      "child/justfile",
+      "say ARG:\n {{just_executable()}} ../say {{ARG}}",
+    )
+    .current_dir("child")
+    .args(["say", "."])
+    .stdout(".\n")
+    .stderr_regex(".*just ../say .\necho .\n")
+    .run();
+}

--- a/tests/search_arguments.rs
+++ b/tests/search_arguments.rs
@@ -19,7 +19,7 @@ fn passing_dot_as_argument_is_allowed() {
     )
     .write(
       "child/justfile",
-      "say ARG:\n {{just_executable()}} ../say {{ARG}}",
+      "say ARG:\n '{{just_executable()}}' ../say {{ARG}}",
     )
     .current_dir("child")
     .args(["say", "."])

--- a/tests/search_arguments.rs
+++ b/tests/search_arguments.rs
@@ -24,6 +24,6 @@ fn passing_dot_as_argument_is_allowed() {
     .current_dir("child")
     .args(["say", "."])
     .stdout(".\n")
-    .stderr_regex(".*just ../say .\necho .\n")
+    .stderr_regex("'.*just' ../say .\necho .\n")
     .run();
 }


### PR DESCRIPTION
#1519 was fixed by #1528. Add a test so that we don't accidentally break it again.