### PR TITLE
Allow --unstable to be set with an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ This does not, however, preclude fixing outright bugs, even if doing so might br
 There will never be a `just` 2.0. Any desirable backwards-incompatible changes will be opt-in on a per-`justfile` basis, so users may migrate at their leisure.
 
 Features that aren't yet ready for stabilization are gated behind the `--unstable` flag. Features enabled by `--unstable` may change in backwards incompatible ways at any time. The unstable
-mode can also be set using the environment variable `JUST_ALLOW_UNSTABLE=true` (any other value for the variable besides `true` is treated as false).
+mode can also be set using the environment variable `JUST_UNSTABLE`; any value for this variable other than "false", "0", or the empty string will be treated as enabling unstable mode.
 
 
 Editor Support

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ This does not, however, preclude fixing outright bugs, even if doing so might br
 
 There will never be a `just` 2.0. Any desirable backwards-incompatible changes will be opt-in on a per-`justfile` basis, so users may migrate at their leisure.
 
-Features that aren't yet ready for stabilization are gated behind the `--unstable` flag. Features enabled by `--unstable` may change in backwards incompatible ways at any time. Unstable features also be enabled by setting the environment variable `JUST_UNSTABLE` to any value other than `false`, `0`, or the empty string.
+Features that aren't yet ready for stabilization are gated behind the `--unstable` flag. Features enabled by `--unstable` may change in backwards incompatible ways at any time. Unstable features can also be enabled by setting the environment variable `JUST_UNSTABLE` to any value other than `false`, `0`, or the empty string.
 
 
 Editor Support

--- a/README.md
+++ b/README.md
@@ -319,7 +319,9 @@ This does not, however, preclude fixing outright bugs, even if doing so might br
 
 There will never be a `just` 2.0. Any desirable backwards-incompatible changes will be opt-in on a per-`justfile` basis, so users may migrate at their leisure.
 
-Features that aren't yet ready for stabilization are gated behind the `--unstable` flag. Features enabled by `--unstable` may change in backwards incompatible ways at any time.
+Features that aren't yet ready for stabilization are gated behind the `--unstable` flag. Features enabled by `--unstable` may change in backwards incompatible ways at any time. The unstable
+mode can also be set using the environment variable `JUST_ALLOW_UNSTABLE=true` (any other value for the variable besides `true` is treated as false).
+
 
 Editor Support
 --------------

--- a/README.md
+++ b/README.md
@@ -325,8 +325,7 @@ This does not, however, preclude fixing outright bugs, even if doing so might br
 
 There will never be a `just` 2.0. Any desirable backwards-incompatible changes will be opt-in on a per-`justfile` basis, so users may migrate at their leisure.
 
-Features that aren't yet ready for stabilization are gated behind the `--unstable` flag. Features enabled by `--unstable` may change in backwards incompatible ways at any time. The unstable
-mode can also be set using the environment variable `JUST_UNSTABLE`; any value for this variable other than "false", "0", or the empty string will be treated as enabling unstable mode.
+Features that aren't yet ready for stabilization are gated behind the `--unstable` flag. Features enabled by `--unstable` may change in backwards incompatible ways at any time. Unstable features also be enabled by setting the environment variable `JUST_UNSTABLE` to any value other than `false`, `0`, or the empty string.
 
 
 Editor Support

--- a/src/config.rs
+++ b/src/config.rs
@@ -570,9 +570,9 @@ impl Config {
     };
 
     let unstable = matches.is_present(arg::UNSTABLE)
-      || std::env::var_os("JUST_UNSTABLE").map_or(false, |val| {
-        !["false", "0", ""].contains(&val.to_string_lossy().as_ref())
-      });
+      || std::env::var_os("JUST_UNSTABLE")
+        .map(|val| !["false", "0", ""].contains(&val.to_string_lossy().as_ref()))
+        .unwrap_or_default();
 
     Ok(Self {
       check: matches.is_present(arg::CHECK),

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,8 +3,6 @@ use {
   clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, ArgSettings},
 };
 
-pub(crate) const UNSTABLE_KEY: &str = "JUST_ALLOW_UNSTABLE";
-
 // These three strings should be kept in sync:
 pub(crate) const CHOOSER_DEFAULT: &str = "fzf --multi --preview 'just --show {}'";
 pub(crate) const CHOOSER_ENVIRONMENT_KEY: &str = "JUST_CHOOSER";
@@ -572,7 +570,9 @@ impl Config {
     };
 
     let unstable = matches.is_present(arg::UNSTABLE)
-      || std::env::var_os(UNSTABLE_KEY).map_or(false, |val| val.to_string_lossy() == "true");
+      || std::env::var_os("JUST_UNSTABLE").map_or(false, |val| {
+        !["false", "0", ""].contains(&val.to_string_lossy().as_ref())
+      });
 
     Ok(Self {
       check: matches.is_present(arg::CHECK),

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use {
   clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, ArgSettings},
 };
 
+pub(crate) const UNSTABLE_KEY: &str = "JUST_ALLOW_UNSTABLE";
+
 // These three strings should be kept in sync:
 pub(crate) const CHOOSER_DEFAULT: &str = "fzf --multi --preview 'just --show {}'";
 pub(crate) const CHOOSER_ENVIRONMENT_KEY: &str = "JUST_CHOOSER";
@@ -569,6 +571,9 @@ impl Config {
       None
     };
 
+    let unstable = matches.is_present(arg::UNSTABLE)
+      || std::env::var_os(UNSTABLE_KEY).map_or(false, |val| val.to_string_lossy() == "true");
+
     Ok(Self {
       check: matches.is_present(arg::CHECK),
       dry_run: matches.is_present(arg::DRY_RUN),
@@ -578,7 +583,7 @@ impl Config {
       load_dotenv: !matches.is_present(arg::NO_DOTENV),
       shell_command: matches.is_present(arg::SHELL_COMMAND),
       unsorted: matches.is_present(arg::UNSORTED),
-      unstable: matches.is_present(arg::UNSTABLE),
+      unstable,
       list_heading: matches
         .value_of(arg::LIST_HEADING)
         .unwrap_or("Available recipes:\n")

--- a/src/config.rs
+++ b/src/config.rs
@@ -571,7 +571,7 @@ impl Config {
 
     let unstable = matches.is_present(arg::UNSTABLE)
       || std::env::var_os("JUST_UNSTABLE")
-        .map(|val| !["false", "0", ""].contains(&val.to_string_lossy().as_ref()))
+        .map(|val| !(val == "false" || val == "0" || val.is_empty()))
         .unwrap_or_default();
 
     Ok(Self {

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::let_underscore_untyped)]
 use super::*;
 
 #[derive(Derivative)]

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::let_underscore_untyped)]
 use super::*;
 
 #[derive(Derivative)]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -86,6 +86,7 @@ mod string;
 mod subsequents;
 mod tempdir;
 mod undefined_variables;
+mod unstable;
 #[cfg(target_family = "windows")]
 mod windows_shell;
 mod working_directory;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -234,7 +234,7 @@ impl Test {
 
     if let Some(ref stdout_regex) = self.stdout_regex {
       if !stdout_regex.is_match(output_stdout) {
-        panic!("Stdout regex mismatch:\n{output_stderr:?}\n!~=\n/{stdout_regex:?}/");
+        panic!("Stdout regex mismatch:\n{output_stdout:?}\n!~=\n/{stdout_regex:?}/");
       }
     }
 

--- a/tests/unstable.rs
+++ b/tests/unstable.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[test]
+fn set_unstable_true_with_env_var() {
+  let justfile = r#"
+default:
+    echo 'foo'
+  "#;
+  Test::new()
+    .justfile(justfile)
+    .args(["--dump", "--dump-format", "json"])
+    .env("JUST_ALLOW_UNSTABLE", "true")
+    .status(EXIT_SUCCESS)
+    .stdout_regex("*")
+    .run();
+}
+
+#[test]
+fn set_unstable_false_with_env_var() {
+  let justfile = r#"
+default:
+    echo 'foo'
+  "#;
+  Test::new()
+    .justfile(justfile)
+    .args(["--dump", "--dump-format", "json"])
+    .env("JUST_ALLOW_UNSTABLE", "false")
+    .status(EXIT_FAILURE)
+    .stderr("error: The JSON dump format is currently unstable. Invoke `just` with the `--unstable` flag to enable unstable features.\n")
+    .run();
+}

--- a/tests/unstable.rs
+++ b/tests/unstable.rs
@@ -6,13 +6,16 @@ fn set_unstable_true_with_env_var() {
 default:
     echo 'foo'
   "#;
-  Test::new()
-    .justfile(justfile)
-    .args(["--dump", "--dump-format", "json"])
-    .env("JUST_ALLOW_UNSTABLE", "true")
-    .status(EXIT_SUCCESS)
-    .stdout_regex("*")
-    .run();
+
+  for val in ["true", "some-arbitrary-string"] {
+    Test::new()
+      .justfile(justfile)
+      .args(["--dump", "--dump-format", "json"])
+      .env("JUST_UNSTABLE", val)
+      .status(EXIT_SUCCESS)
+      .stdout_regex("*")
+      .run();
+  }
 }
 
 #[test]
@@ -21,10 +24,26 @@ fn set_unstable_false_with_env_var() {
 default:
     echo 'foo'
   "#;
+  for val in ["0", "", "false"] {
+    Test::new()
+    .justfile(justfile)
+    .args(["--dump", "--dump-format", "json"])
+    .env("JUST_UNSTABLE", val)
+    .status(EXIT_FAILURE)
+    .stderr("error: The JSON dump format is currently unstable. Invoke `just` with the `--unstable` flag to enable unstable features.\n")
+    .run();
+  }
+}
+
+#[test]
+fn set_unstable_false_with_env_var_unset() {
+  let justfile = r#"
+default:
+    echo 'foo'
+  "#;
   Test::new()
     .justfile(justfile)
     .args(["--dump", "--dump-format", "json"])
-    .env("JUST_ALLOW_UNSTABLE", "false")
     .status(EXIT_FAILURE)
     .stderr("error: The JSON dump format is currently unstable. Invoke `just` with the `--unstable` flag to enable unstable features.\n")
     .run();

--- a/tests/unstable.rs
+++ b/tests/unstable.rs
@@ -10,10 +10,10 @@ default:
   for val in ["true", "some-arbitrary-string"] {
     Test::new()
       .justfile(justfile)
-      .args(["--dump", "--dump-format", "json"])
+      .args(["--fmt"])
       .env("JUST_UNSTABLE", val)
       .status(EXIT_SUCCESS)
-      .stdout_regex("*")
+      .stderr_regex("Wrote justfile to `.*`\n")
       .run();
   }
 }
@@ -27,10 +27,10 @@ default:
   for val in ["0", "", "false"] {
     Test::new()
     .justfile(justfile)
-    .args(["--dump", "--dump-format", "json"])
+    .args(["--fmt"])
     .env("JUST_UNSTABLE", val)
     .status(EXIT_FAILURE)
-    .stderr("error: The JSON dump format is currently unstable. Invoke `just` with the `--unstable` flag to enable unstable features.\n")
+    .stderr("error: The `--fmt` command is currently unstable. Invoke `just` with the `--unstable` flag to enable unstable features.\n")
     .run();
   }
 }
@@ -43,8 +43,8 @@ default:
   "#;
   Test::new()
     .justfile(justfile)
-    .args(["--dump", "--dump-format", "json"])
+    .args(["--fmt"])
     .status(EXIT_FAILURE)
-    .stderr("error: The JSON dump format is currently unstable. Invoke `just` with the `--unstable` flag to enable unstable features.\n")
+    .stderr("error: The `--fmt` command is currently unstable. Invoke `just` with the `--unstable` flag to enable unstable features.\n")
     .run();
 }


### PR DESCRIPTION
Allow the environment variable JUST_ALLOW_UNSTABLE=true to act as equivalent to the --unstable flag. Any other value of JUST_ALLOW_UNSTABLE is treated as false. 

This addresses https://github.com/casey/just/issues/1575