### PR TITLE
New function alias: env()

### DIFF
--- a/src/assignment_resolver.rs
+++ b/src/assignment_resolver.rs
@@ -73,11 +73,9 @@ impl<'src: 'run, 'run> AssignmentResolver<'src, 'run> {
       Expression::Call { thunk } => match thunk {
         Thunk::Nullary { .. } => Ok(()),
         Thunk::Unary { arg, .. } => self.resolve_expression(arg),
-        Thunk::UnaryOpt {
-          args: (a, opt_b), ..
-        } => {
+        Thunk::UnaryOpt { args: (a, b), .. } => {
           self.resolve_expression(a)?;
-          if let Some(b) = opt_b.as_ref() {
+          if let Some(b) = b.as_ref() {
             self.resolve_expression(b)?;
           }
           Ok(())

--- a/src/assignment_resolver.rs
+++ b/src/assignment_resolver.rs
@@ -73,6 +73,15 @@ impl<'src: 'run, 'run> AssignmentResolver<'src, 'run> {
       Expression::Call { thunk } => match thunk {
         Thunk::Nullary { .. } => Ok(()),
         Thunk::Unary { arg, .. } => self.resolve_expression(arg),
+        Thunk::UnaryPlus {
+          args: (a, rest), ..
+        } => {
+          self.resolve_expression(a)?;
+          for arg in rest {
+            self.resolve_expression(arg)?;
+          }
+          Ok(())
+        }
         Thunk::Binary { args: [a, b], .. } => {
           self.resolve_expression(a)?;
           self.resolve_expression(b)

--- a/src/assignment_resolver.rs
+++ b/src/assignment_resolver.rs
@@ -73,12 +73,12 @@ impl<'src: 'run, 'run> AssignmentResolver<'src, 'run> {
       Expression::Call { thunk } => match thunk {
         Thunk::Nullary { .. } => Ok(()),
         Thunk::Unary { arg, .. } => self.resolve_expression(arg),
-        Thunk::UnaryPlus {
-          args: (a, rest), ..
+        Thunk::UnaryOpt {
+          args: (a, opt_b), ..
         } => {
           self.resolve_expression(a)?;
-          for arg in rest {
-            self.resolve_expression(arg)?;
+          if let Some(b) = opt_b.as_ref() {
+            self.resolve_expression(b)?;
           }
           Ok(())
         }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -92,6 +92,24 @@ impl<'src, 'run> Evaluator<'src, 'run> {
               message,
             }
           }),
+          UnaryPlus {
+            name,
+            function,
+            args: (a, rest),
+            ..
+          } => {
+            let a = self.evaluate_expression(a)?;
+
+            let mut rest_evaluated = Vec::new();
+            for arg in rest {
+              rest_evaluated.push(self.evaluate_expression(arg)?);
+            }
+
+            function(&context, &a, &rest_evaluated).map_err(|message| Error::FunctionCall {
+              function: *name,
+              message,
+            })
+          }
           Binary {
             name,
             function,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -92,20 +92,20 @@ impl<'src, 'run> Evaluator<'src, 'run> {
               message,
             }
           }),
-          UnaryPlus {
+          UnaryOpt {
             name,
             function,
-            args: (a, rest),
+            args: (a, opt_b),
             ..
           } => {
-            let a = self.evaluate_expression(a)?;
+            let a_val = self.evaluate_expression(a)?;
+            let mut b_val: Option<String> = None;
 
-            let mut rest_evaluated = Vec::new();
-            for arg in rest {
-              rest_evaluated.push(self.evaluate_expression(arg)?);
+            if let Some(b) = opt_b.as_ref() {
+              b_val = Some(self.evaluate_expression(b)?);
             }
 
-            function(&context, &a, &rest_evaluated).map_err(|message| Error::FunctionCall {
+            function(&context, &a_val, b_val.as_deref()).map_err(|message| Error::FunctionCall {
               function: *name,
               message,
             })

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -95,17 +95,16 @@ impl<'src, 'run> Evaluator<'src, 'run> {
           UnaryOpt {
             name,
             function,
-            args: (a, opt_b),
+            args: (a, b),
             ..
           } => {
-            let a_val = self.evaluate_expression(a)?;
-            let mut b_val: Option<String> = None;
+            let a = self.evaluate_expression(a)?;
+            let b = match b.as_ref() {
+              Some(b) => Some(self.evaluate_expression(b)?),
+              None => None,
+            };
 
-            if let Some(b) = opt_b.as_ref() {
-              b_val = Some(self.evaluate_expression(b)?);
-            }
-
-            function(&context, &a_val, b_val.as_deref()).map_err(|message| Error::FunctionCall {
+            function(&context, &a, b.as_deref()).map_err(|message| Error::FunctionCall {
               function: *name,
               message,
             })

--- a/src/function.rs
+++ b/src/function.rs
@@ -13,7 +13,7 @@ use {
 pub(crate) enum Function {
   Nullary(fn(&FunctionContext) -> Result<String, String>),
   Unary(fn(&FunctionContext, &str) -> Result<String, String>),
-  UnaryPlus(fn(&FunctionContext, &str, &[String]) -> Result<String, String>),
+  UnaryOpt(fn(&FunctionContext, &str, Option<&str>) -> Result<String, String>),
   Binary(fn(&FunctionContext, &str, &str) -> Result<String, String>),
   BinaryPlus(fn(&FunctionContext, &str, &str, &[String]) -> Result<String, String>),
   Ternary(fn(&FunctionContext, &str, &str, &str) -> Result<String, String>),
@@ -25,7 +25,7 @@ pub(crate) fn get(name: &str) -> Option<Function> {
     "arch" => Nullary(arch),
     "capitalize" => Unary(capitalize),
     "clean" => Unary(clean),
-    "env" => UnaryPlus(env),
+    "env" => UnaryOpt(env),
     "env_var" => Unary(env_var),
     "env_var_or_default" => Binary(env_var_or_default),
     "error" => Unary(error),
@@ -75,7 +75,7 @@ impl Function {
     match *self {
       Nullary(_) => 0..0,
       Unary(_) => 1..1,
-      UnaryPlus(_) => 1..usize::MAX,
+      UnaryOpt(_) => 1..2,
       Binary(_) => 2..2,
       BinaryPlus(_) => 2..usize::MAX,
       Ternary(_) => 3..3,
@@ -150,11 +150,10 @@ fn env_var_or_default(
   }
 }
 
-fn env(context: &FunctionContext, key: &str, default: &[String]) -> Result<String, String> {
-  if !default.is_empty() {
-    env_var_or_default(context, key, &default[0])
-  } else {
-    env_var(context, key)
+fn env(context: &FunctionContext, key: &str, default: Option<&str>) -> Result<String, String> {
+  match default {
+    Some(val) => env_var_or_default(context, key, val),
+    None => env_var(context, key),
   }
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -25,6 +25,7 @@ pub(crate) fn get(name: &str) -> Option<Function> {
     "capitalize" => Unary(capitalize),
     "clean" => Unary(clean),
     "env_var" => Unary(env_var),
+    "env" => Unary(env),
     "env_var_or_default" => Binary(env_var_or_default),
     "error" => Unary(error),
     "extension" => Unary(extension),
@@ -144,6 +145,13 @@ fn env_var_or_default(
       "environment variable `{key}` not unicode: {os_string:?}"
     )),
     Ok(value) => Ok(value),
+  }
+}
+
+fn env(context: &FunctionContext, key: &str, default: Option<&str>) -> Result<String, String> {
+  match default {
+    Some(default) => env_var_or_default(context, key, default),
+    None => env_var(context, key),
   }
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -25,9 +25,9 @@ pub(crate) fn get(name: &str) -> Option<Function> {
     "arch" => Nullary(arch),
     "capitalize" => Unary(capitalize),
     "clean" => Unary(clean),
+    "env" => UnaryPlus(env),
     "env_var" => Unary(env_var),
     "env_var_or_default" => Binary(env_var_or_default),
-    "env" => UnaryPlus(env),
     "error" => Unary(error),
     "extension" => Unary(extension),
     "file_name" => Unary(file_name),
@@ -75,7 +75,7 @@ impl Function {
     match *self {
       Nullary(_) => 0..0,
       Unary(_) => 1..1,
-      UnaryPlus(_) => 2..usize::MAX,
+      UnaryPlus(_) => 1..usize::MAX,
       Binary(_) => 2..2,
       BinaryPlus(_) => 2..usize::MAX,
       Ternary(_) => 3..3,
@@ -151,8 +151,6 @@ fn env_var_or_default(
 }
 
 fn env(context: &FunctionContext, key: &str, default: &[String]) -> Result<String, String> {
-  // Is an "" env var the same as a None env var?
-  // Other option here would be to use an Opton<&str>
   if !default.is_empty() {
     env_var_or_default(context, key, &default[0])
   } else {

--- a/src/node.rs
+++ b/src/node.rs
@@ -80,13 +80,11 @@ impl<'src> Node<'src> for Expression<'src> {
             tree.push_mut(arg.tree());
           }
           UnaryOpt {
-            name,
-            args: (a, opt_b),
-            ..
+            name, args: (a, b), ..
           } => {
             tree.push_mut(name.lexeme());
             tree.push_mut(a.tree());
-            if let Some(b) = opt_b.as_ref() {
+            if let Some(b) = b.as_ref() {
               tree.push_mut(b.tree());
             }
           }

--- a/src/node.rs
+++ b/src/node.rs
@@ -79,15 +79,15 @@ impl<'src> Node<'src> for Expression<'src> {
             tree.push_mut(name.lexeme());
             tree.push_mut(arg.tree());
           }
-          UnaryPlus {
+          UnaryOpt {
             name,
-            args: (a, rest),
+            args: (a, opt_b),
             ..
           } => {
             tree.push_mut(name.lexeme());
             tree.push_mut(a.tree());
-            for arg in rest {
-              tree.push_mut(arg.tree());
+            if let Some(b) = opt_b.as_ref() {
+              tree.push_mut(b.tree());
             }
           }
           Binary {

--- a/src/node.rs
+++ b/src/node.rs
@@ -79,6 +79,17 @@ impl<'src> Node<'src> for Expression<'src> {
             tree.push_mut(name.lexeme());
             tree.push_mut(arg.tree());
           }
+          UnaryPlus {
+            name,
+            args: (a, rest),
+            ..
+          } => {
+            tree.push_mut(name.lexeme());
+            tree.push_mut(a.tree());
+            for arg in rest {
+              tree.push_mut(arg.tree());
+            }
+          }
           Binary {
             name, args: [a, b], ..
           } => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2335,7 +2335,7 @@ mod tests {
   }
 
   error! {
-    name: function_argument_count_unary_plus,
+    name: function_argument_count_unary_opt,
     input: "x := env()",
     offset: 5,
     line: 0,
@@ -2344,7 +2344,7 @@ mod tests {
     kind: FunctionArgumentCountMismatch {
       function: "env",
       found: 0,
-      expected: 1..usize::MAX,
+      expected: 1..2,
     },
   }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2335,7 +2335,21 @@ mod tests {
   }
 
   error! {
-    name: function_argument_count_unary_opt,
+    name: function_argument_count_too_high_unary_opt,
+    input: "x := env('foo', 'foo', 'foo')",
+    offset: 5,
+    line: 0,
+    column: 5,
+    width: 3,
+    kind: FunctionArgumentCountMismatch {
+      function: "env",
+      found: 3,
+      expected: 1..2,
+    },
+  }
+
+  error! {
+    name: function_argument_count_too_low_unary_opt,
     input: "x := env()",
     offset: 5,
     line: 0,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2335,6 +2335,20 @@ mod tests {
   }
 
   error! {
+    name: function_argument_count_unary_plus,
+    input: "x := env()",
+    offset: 5,
+    line: 0,
+    column: 5,
+    width: 3,
+    kind: FunctionArgumentCountMismatch {
+      function: "env",
+      found: 0,
+      expected: 1..usize::MAX,
+    },
+  }
+
+  error! {
     name: function_argument_count_binary,
     input: "x := env_var_or_default('foo')",
     offset: 5,

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -225,15 +225,18 @@ impl Expression {
           name: name.lexeme().to_owned(),
           arguments: vec![Expression::new(arg)],
         },
-        full::Thunk::UnaryPlus {
+        full::Thunk::UnaryOpt {
           name,
-          args: (a, rest),
+          args: (a, opt_b),
           ..
         } => {
-          let mut arguments = vec![Expression::new(a)];
-          for arg in rest {
-            arguments.push(Expression::new(arg));
+          let mut arguments = vec![];
+
+          if let Some(b) = opt_b.as_ref() {
+            arguments.push(Expression::new(b));
           }
+
+          arguments.push(Expression::new(a));
           Expression::Call {
             name: name.lexeme().to_owned(),
             arguments,

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -225,6 +225,20 @@ impl Expression {
           name: name.lexeme().to_owned(),
           arguments: vec![Expression::new(arg)],
         },
+        full::Thunk::UnaryPlus {
+          name,
+          args: (a, rest),
+          ..
+        } => {
+          let mut arguments = vec![Expression::new(a)];
+          for arg in rest {
+            arguments.push(Expression::new(arg));
+          }
+          Expression::Call {
+            name: name.lexeme().to_owned(),
+            arguments,
+          }
+        }
         full::Thunk::Binary {
           name, args: [a, b], ..
         } => Expression::Call {

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -89,7 +89,7 @@ impl<'src> Thunk<'src> {
           })
         }
         (Function::BinaryPlus(function), 2..=usize::MAX) => {
-          let rest: Vec<Expression> = arguments.drain(2..).collect();
+          let rest = arguments.drain(2..).collect();
           let b = Box::new(arguments.pop().unwrap());
           let a = Box::new(arguments.pop().unwrap());
           Ok(Thunk::BinaryPlus {

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -69,13 +69,13 @@ impl<'src> Thunk<'src> {
         }),
         (Function::UnaryOpt(function), 1..=2) => {
           let a = Box::new(arguments.remove(0));
-          let opt_b = match arguments.pop() {
+          let b = match arguments.pop() {
             Some(value) => Box::new(Some(value)),
             None => Box::new(None),
           };
           Ok(Thunk::UnaryOpt {
             function,
-            args: (a, opt_b),
+            args: (a, b),
             name,
           })
         }
@@ -125,11 +125,9 @@ impl Display for Thunk<'_> {
       Nullary { name, .. } => write!(f, "{}()", name.lexeme()),
       Unary { name, arg, .. } => write!(f, "{}({arg})", name.lexeme()),
       UnaryOpt {
-        name,
-        args: (a, opt_b),
-        ..
+        name, args: (a, b), ..
       } => {
-        if let Some(b) = opt_b.as_ref() {
+        if let Some(b) = b.as_ref() {
           write!(f, "{}({a}, {b})", name.lexeme())
         } else {
           write!(f, "{}({a})", name.lexeme())

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -20,12 +20,12 @@ impl<'expression, 'src> Iterator for Variables<'expression, 'src> {
         Expression::Call { thunk } => match thunk {
           Thunk::Nullary { .. } => {}
           Thunk::Unary { arg, .. } => self.stack.push(arg),
-          Thunk::UnaryPlus {
-            args: (a, rest), ..
+          Thunk::UnaryOpt {
+            args: (a, opt_b), ..
           } => {
-            let first: &[&Expression] = &[a];
-            for arg in first.iter().copied().chain(rest).rev() {
-              self.stack.push(arg);
+            self.stack.push(a);
+            if let Some(b) = opt_b.as_ref() {
+              self.stack.push(b);
             }
           }
           Thunk::Binary { args, .. } => {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -20,6 +20,14 @@ impl<'expression, 'src> Iterator for Variables<'expression, 'src> {
         Expression::Call { thunk } => match thunk {
           Thunk::Nullary { .. } => {}
           Thunk::Unary { arg, .. } => self.stack.push(arg),
+          Thunk::UnaryPlus {
+            args: (a, rest), ..
+          } => {
+            let first: &[&Expression] = &[a];
+            for arg in first.iter().copied().chain(rest).rev() {
+              self.stack.push(arg);
+            }
+          }
           Thunk::Binary { args, .. } => {
             for arg in args.iter().rev() {
               self.stack.push(arg);

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1915,7 +1915,22 @@ test! {
 }
 
 test! {
-  name: dependency_argument_function_foo,
+  name: env_function_as_env_var,
+  justfile: "
+    foo: (bar env('x'))
+
+    bar arg:
+      echo {{arg}}
+  ",
+  args: (),
+  env: { "x": "z", },
+  stdout: "z\n",
+  stderr: "echo z\n",
+  shell: false,
+}
+
+test! {
+  name: env_function_as_env_var_or_default,
   justfile: "
     foo: (bar env('x', 'y'))
 
@@ -1923,8 +1938,39 @@ test! {
       echo {{arg}}
   ",
   args: (),
-  stdout: "y\n",
-  stderr: "echo y\n",
+  env: { "x": "z", },
+  stdout: "z\n",
+  stderr: "echo z\n",
+  shell: false,
+}
+
+test! {
+  name: env_function_as_env_var_with_existing_env_var,
+  justfile: "
+    foo: (bar env('x'))
+
+    bar arg:
+      echo {{arg}}
+  ",
+  args: (),
+  env: { "x": "z", },
+  stdout: "z\n",
+  stderr: "echo z\n",
+  shell: false,
+}
+
+test! {
+  name: env_function_as_env_var_or_default_with_existing_env_var,
+  justfile: "
+    foo: (bar env('x', 'y'))
+
+    bar arg:
+      echo {{arg}}
+  ",
+  args: (),
+  env: { "x": "z", },
+  stdout: "z\n",
+  stderr: "echo z\n",
   shell: false,
 }
 

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1915,6 +1915,20 @@ test! {
 }
 
 test! {
+  name: dependency_argument_function_foo,
+  justfile: "
+    foo: (bar env('x', 'y'))
+
+    bar arg:
+      echo {{arg}}
+  ",
+  args: (),
+  stdout: "y\n",
+  stderr: "echo y\n",
+  shell: false,
+}
+
+test! {
   name: dependency_argument_backtick,
   justfile: "
     export X := 'X'


### PR DESCRIPTION
In relation to https://github.com/casey/just/issues/1278, this PR adds a new `env` function which acts as an alias to both `env_var` and `env_var_or_default`:
```just
env_var('x') => env('x')
env_var_or_default('x', 42) => env('x', 42)
```

To make such a function signature possible, a new `UnaryOpt` enum variant was added which accounts for the majority of the touched files!