### PR TITLE
Use the grep command instead of an alias in bash completions

### DIFF
--- a/completions/just.bash
+++ b/completions/just.bash
@@ -27,7 +27,7 @@ _just() {
                 elif [[ ${COMP_CWORD} -eq 1 ]]; then
                     local recipes=$(just --summary 2> /dev/null)
 
-                    if echo "${cur}" | grep -qF '/'; then
+                    if echo "${cur}" | \grep -qF '/'; then
                         local path_prefix=$(echo "${cur}" | sed 's/[/][^/]*$/\//')
                         local recipes=$(just --summary 2> /dev/null -- "${path_prefix}")
                         local recipes=$(printf "${path_prefix}%s\t" $recipes)

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -168,7 +168,7 @@ pub(crate) const BASH_COMPLETION_REPLACEMENTS: &[(&str, &str)] = &[
                 elif [[ ${COMP_CWORD} -eq 1 ]]; then
                     local recipes=$(just --summary 2> /dev/null)
 
-                    if echo "${cur}" | grep -qF '/'; then
+                    if echo "${cur}" | \grep -qF '/'; then
                         local path_prefix=$(echo "${cur}" | sed 's/[/][^/]*$/\//')
                         local recipes=$(just --summary 2> /dev/null -- "${path_prefix}")
                         local recipes=$(printf "${path_prefix}%s\t" $recipes)


### PR DESCRIPTION
**Problem**:

If a user has a grep alias, such as this:

```
  alias grep='grep --perl-regexp'
```

Running the bash completions script will break with the following output:

```
  grep: conflicting matchers specified
```

This happens because the script tries to use the `-F/--fixed-strings` flag, which conflicts with `--perl-regexp` flag.

**Solution**:

Prefix grep with `\` so that the grep command is always used instead of an alias.