### PR TITLE
Working on specifying a `.env` path with a string

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -60,7 +60,7 @@ assignment    : NAME ':=' expression eol
 export        : 'export' assignment
 
 setting       : 'set' 'allow-duplicate-recipes' boolean?
-              | 'set' 'dotenv-load' boolean?
+              | 'set' 'dotenv-load' boolean? | string?
               | 'set' 'export' boolean?
               | 'set' 'fallback' boolean?
               | 'set' 'ignore-comments' boolean?

--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ foo:
 | Name                      | Value              | Default | Description                                                                                   |
 | ------------------------- | ------------------ | ------- |---------------------------------------------------------------------------------------------- |
 | `allow-duplicate-recipes` | boolean            | `false` | Allow recipes appearing later in a `justfile` to override earlier recipes with the same name. |
-| `dotenv-load`             | boolean            | `false` | Load a `.env` file, if present.                                                               |
+| `dotenv-load`             | boolean | string   | `false` | Load a `.env` file, if present. Optionally specify the path with a string                     |
 | `export`                  | boolean            | `false` | Export all variables as environment variables.                                                |
 | `fallback`                | boolean            | `false` | Search `justfile` in parent directory if the first recipe on the command line is not found.   |
 | `ignore-comments`         | boolean            | `false` | Ignore recipe lines beginning with `#`.                                                       |
@@ -703,7 +703,7 @@ bar
 
 #### Dotenv Load
 
-If `dotenv-load` is `true`, a `.env` file will be loaded if present. Defaults to `false`.
+If `dotenv-load` is `true`, a `.env` file will be loaded if present. Defaults to `false`. If `dotenv-load` is a string, the path to the `.env` file will be used.
 
 #### Export
 
@@ -871,7 +871,7 @@ Available recipes:
 
 ### Dotenv Integration
 
-If [`dotenv-load`](#dotenv-load) is set, `just` will load environment variables from a file named `.env`. This file can be located in the same directory as your `justfile` or in a parent directory. These variables are environment variables, not `just` variables, and so must be accessed using `$VARIABLE_NAME` in recipes and backticks.
+If [`dotenv-load`](#dotenv-load) is set, `just` will load environment variables from a file named `.env`. This file can be located in the same directory as your `justfile` or in a parent directory. These variables are environment variables, not `just` variables, and so must be accessed using `$VARIABLE_NAME` in recipes and backticks. If `dotenv-load` is a string, the path to the `.env` file will be used.
 
 For example, if your `.env` file contains:
 
@@ -897,6 +897,16 @@ serve:
 $ just serve
 Starting server with database localhost:6379 on port 1337…
 ./server --database $DATABASE_ADDRESS --port $SERVER_PORT
+```
+
+Specifying a path string:
+
+```just
+set dotenv-load = "path/to/.env"
+
+serve:
+  @echo "Starting server with database $DATABASE_ADDRESS on port $SERVER_PORT…"
+  ./server --database $DATABASE_ADDRESS --port $SERVER_PORT
 ```
 
 ### Variables and Substitution

--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ foo:
 | Name                      | Value              | Default | Description                                                                                   |
 | ------------------------- | ------------------ | ------- |---------------------------------------------------------------------------------------------- |
 | `allow-duplicate-recipes` | boolean            | `false` | Allow recipes appearing later in a `justfile` to override earlier recipes with the same name. |
-| `dotenv-load`             | boolean | string   | `false` | Load a `.env` file, if present. Optionally specify the path with a string                     |
+| `dotenv-load`             | boolean | string   | `false` | Load a `.env` file, if present. Optionally specify the path with a string.                    |
 | `export`                  | boolean            | `false` | Export all variables as environment variables.                                                |
 | `fallback`                | boolean            | `false` | Search `justfile` in parent directory if the first recipe on the command line is not found.   |
 | `ignore-comments`         | boolean            | `false` | Ignore recipe lines beginning with `#`.                                                       |

--- a/README.中文.md
+++ b/README.中文.md
@@ -646,7 +646,7 @@ foo:
 | 名称                      | 值                 | 默认    | 描述                                                                           |
 | ------------------------- | ------------------ | --------|------------------------------------------------------------------------------- |
 | `allow-duplicate-recipes` | boolean            | False   | 允许在 `justfile` 后面出现的配方覆盖之前的同名配方                             |
-| `dotenv-load`             | boolean            | False   | 如果有`.env` 环境变量文件的话，则将其加载                                      |
+| `dotenv-load`             | boolean | string   | False   | 如果有`.env` 环境变量文件的话，则将其加载. 使用字符串指定路径                             |
 | `export`                  | boolean            | False   | 将所有变量导出为环境变量                                                       |
 | `fallback`                | boolean            | False   | 如果命令行中的第一个配方没有找到，则在父目录中搜索 `justfile`                  |
 | `ignore-comments`         | boolean            | False   | 忽略以`#`开头的配方行                                                          |
@@ -689,7 +689,7 @@ bar
 
 #### 环境变量加载
 
-如果将 `dotenv-load` 设置为 `true`，并且存在 `.env` 文件，则该环境配置文件将被加载。默认为 `false`。
+如果将 `dotenv-load` 设置为 `true`，并且存在 `.env` 文件，则该环境配置文件将被加载。默认为 `false`。如果`dotenv-load`是字符串，将使用`.env`文件的路径。如果`dotenv-load`是字符串，将使用`.env`文件的路径。
 
 #### 导出
 
@@ -883,6 +883,16 @@ serve:
 $ just serve
 Starting server with database localhost:6379 on port 1337…
 ./server --database $DATABASE_ADDRESS --port $SERVER_PORT
+```
+
+指定路径字符串：
+
+```just
+set dotenv-load = "path/to/.env"
+
+serve:
+  @echo "Starting server with database $DATABASE_ADDRESS on port $SERVER_PORT…"
+  ./server --database $DATABASE_ADDRESS --port $SERVER_PORT
 ```
 
 ### 变量和替换

--- a/README.中文.md
+++ b/README.中文.md
@@ -689,7 +689,7 @@ bar
 
 #### 环境变量加载
 
-如果将 `dotenv-load` 设置为 `true`，并且存在 `.env` 文件，则该环境配置文件将被加载。默认为 `false`。如果`dotenv-load`是字符串，将使用`.env`文件的路径。如果`dotenv-load`是字符串，将使用`.env`文件的路径。
+如果将 `dotenv-load` 设置为 `true`，并且存在 `.env` 文件，则该环境配置文件将被加载。默认为 `false`。如果`dotenv-load`是字符串，将使用`.env`文件的路径。如果`dotenv-load`是字符串，
 
 #### 导出
 

--- a/README.中文.md
+++ b/README.中文.md
@@ -689,7 +689,7 @@ bar
 
 #### 环境变量加载
 
-如果将 `dotenv-load` 设置为 `true`，并且存在 `.env` 文件，则该环境配置文件将被加载。默认为 `false`。如果`dotenv-load`是字符串，将使用`.env`文件的路径。如果`dotenv-load`是字符串，
+如果将 `dotenv-load` 设置为 `true`，并且存在 `.env` 文件，则该环境配置文件将被加载。默认为 `false`。如果`dotenv-load`是字符串，将使用`.env`文件的路径。
 
 #### 导出
 

--- a/README.中文.md
+++ b/README.中文.md
@@ -646,7 +646,7 @@ foo:
 | 名称                      | 值                 | 默认    | 描述                                                                           |
 | ------------------------- | ------------------ | --------|------------------------------------------------------------------------------- |
 | `allow-duplicate-recipes` | boolean            | False   | 允许在 `justfile` 后面出现的配方覆盖之前的同名配方                             |
-| `dotenv-load`             | boolean | string   | False   | 如果有`.env` 环境变量文件的话，则将其加载. 使用字符串指定路径                             |
+| `dotenv-load`             | boolean | string   | False   | 如果有`.env` 环境变量文件的话，则将其加载。 使用字符串指定路径。                            |
 | `export`                  | boolean            | False   | 将所有变量导出为环境变量                                                       |
 | `fallback`                | boolean            | False   | 如果命令行中的第一个配方没有找到，则在父目录中搜索 `justfile`                  |
 | `ignore-comments`         | boolean            | False   | 忽略以`#`开头的配方行                                                          |


### PR DESCRIPTION
As someone not well-versed in Rust yet, only a fan, this update in this project turns out to be non-trivial

But I did update some `README` files, so I'd like to draft a pull request as I've been pondering this feature for quite some time

I plan to revisit this, but would definitely appreciate any help or pointers

This addresses some posted issues such as https://github.com/casey/just/issues/945