### PR TITLE
fish_completions: fix completion for macos

### DIFF
--- a/completions/just.fish
+++ b/completions/just.fish
@@ -1,5 +1,5 @@
 function __fish_just_complete_recipes
-    just --list 2> /dev/null | sed -e '1d; s/^\s*\([^[:space:]]*\)[^#]*$/\1/' -e 's/^\s*\([^[:space:]]*\)[^#]*# \(.*\)$/\1\t\2/'
+    just --list 2> /dev/null | sed -E -e '1d; s/^[[:space:]]*([^[:space:]]+)[[:space:]]*#[[:space:]]*(.*)$/\1\t\2/' -e 's/^[[:space:]]*([^[:space:]]+)[[:space:]]*$/\1/'
 end
 
 # don't suggest files right off

--- a/completions/just.fish
+++ b/completions/just.fish
@@ -1,5 +1,31 @@
 function __fish_just_complete_recipes
-    just --list 2> /dev/null | sed -E -e '1d; s/^[[:space:]]*([^[:space:]]+)[[:space:]]*#[[:space:]]*(.*)$/\1\t\2/' -e 's/^[[:space:]]*([^[:space:]]+)[[:space:]]*$/\1/'
+        just --list 2> /dev/null | tail -n +2 | awk '{
+        command = $1;
+        args = $0;
+        desc = "";
+        delim = "";
+        sub(/^[[:space:]]*[^[:space:]]*/, "", args);
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", args);
+
+        if (match(args, /#.*/)) {
+          desc = substr(args, RSTART+2, RLENGTH)
+          args = substr(args, 0, RSTART-1)
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", args);
+        }
+
+        gsub(/\+|=[`\'"][^`\'"]*[`\'"]/, "", args)
+        gsub(/ /, ",", args)
+
+        if (args != ""){
+          args = "Args: " args
+        }
+
+        if (args != "" && desc != "") {
+          delim = "; "
+        }
+
+        print command "\t" args delim desc
+  }'
 end
 
 # don't suggest files right off

--- a/completions/just.fish
+++ b/completions/just.fish
@@ -8,20 +8,20 @@ function __fish_just_complete_recipes
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", args);
 
         if (match(args, /#.*/)) {
-          desc = substr(args, RSTART+2, RLENGTH)
-          args = substr(args, 0, RSTART-1)
+          desc = substr(args, RSTART+2, RLENGTH);
+          args = substr(args, 0, RSTART-1);
           gsub(/^[[:space:]]+|[[:space:]]+$/, "", args);
         }
 
-        gsub(/\+|=[`\'"][^`\'"]*[`\'"]/, "", args)
-        gsub(/ /, ",", args)
+        gsub(/\+|=[`\'"][^`\'"]*[`\'"]/, "", args);
+        gsub(/ /, ",", args);
 
         if (args != ""){
-          args = "Args: " args
+          args = "Args: " args;
         }
 
         if (args != "" && desc != "") {
-          delim = "; "
+          delim = "; ";
         }
 
         print command "\t" args delim desc

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,5 +1,5 @@
 pub(crate) const FISH_RECIPE_COMPLETIONS: &str = r#"function __fish_just_complete_recipes
-    just --list 2> /dev/null | sed -e '1d; s/^\s*\([^[:space:]]*\)[^#]*$/\1/' -e 's/^\s*\([^[:space:]]*\)[^#]*# \(.*\)$/\1\t\2/'
+    just --list 2> /dev/null | sed -E -e '1d; s/^[[:space:]]*([^[:space:]]+)[[:space:]]*#[[:space:]]*(.*)$/\1\t\2/' -e 's/^[[:space:]]*([^[:space:]]+)[[:space:]]*$/\1/'
 end
 
 # don't suggest files right off

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -8,20 +8,20 @@ pub(crate) const FISH_RECIPE_COMPLETIONS: &str = r#"function __fish_just_complet
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", args);
 
         if (match(args, /#.*/)) {
-          desc = substr(args, RSTART+2, RLENGTH)
-          args = substr(args, 0, RSTART-1)
+          desc = substr(args, RSTART+2, RLENGTH);
+          args = substr(args, 0, RSTART-1);
           gsub(/^[[:space:]]+|[[:space:]]+$/, "", args);
         }
 
-        gsub(/\+|=[`\'"][^`\'"]*[`\'"]/, "", args)
-        gsub(/ /, ",", args)
+        gsub(/\+|=[`\'"][^`\'"]*[`\'"]/, "", args);
+        gsub(/ /, ",", args);
 
         if (args != ""){
-          args = "Args: " args
+          args = "Args: " args;
         }
 
         if (args != "" && desc != "") {
-          delim = "; "
+          delim = "; ";
         }
 
         print command "\t" args delim desc

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,5 +1,31 @@
 pub(crate) const FISH_RECIPE_COMPLETIONS: &str = r#"function __fish_just_complete_recipes
-    just --list 2> /dev/null | sed -E -e '1d; s/^[[:space:]]*([^[:space:]]+)[[:space:]]*#[[:space:]]*(.*)$/\1\t\2/' -e 's/^[[:space:]]*([^[:space:]]+)[[:space:]]*$/\1/'
+        just --list 2> /dev/null | tail -n +2 | awk '{
+        command = $1;
+        args = $0;
+        desc = "";
+        delim = "";
+        sub(/^[[:space:]]*[^[:space:]]*/, "", args);
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", args);
+
+        if (match(args, /#.*/)) {
+          desc = substr(args, RSTART+2, RLENGTH)
+          args = substr(args, 0, RSTART-1)
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", args);
+        }
+
+        gsub(/\+|=[`\'"][^`\'"]*[`\'"]/, "", args)
+        gsub(/ /, ",", args)
+
+        if (args != ""){
+          args = "Args: " args
+        }
+
+        if (args != "" && desc != "") {
+          delim = "; "
+        }
+
+        print command "\t" args delim desc
+  }'
 end
 
 # don't suggest files right off


### PR DESCRIPTION
tried to fix broken completion for macos #1703
edited `src/completions.rs` file and regenerated completions via `bin/generate-completions` script


tested on macos sonoma and archlinux machine, works the same
replaced `sed` with `awk` to have more flexible formatting on arguments (and because macos `sed` have differences)
![example image](https://media.discordapp.net/attachments/607675484209152012/1166781211881001092/image.png?ex=654bbcae&is=653947ae&hm=e7d5017b1972b637a74cc8e2e9b8c135738152ef473249e02463d0819c9511fa&=&width=2592&height=452)