### PR TITLE
Clarify aliases documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ $ just --list --list-heading ''
 
 ### Aliases
 
-Aliases allow using alternative names for recipes when invoking them on the command line:
+Aliases allow recipes to be invoked on the command line with alternative names:
 
 ```just
 alias b := build

--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ $ just --list --list-heading ''
 
 ### Aliases
 
-Aliases allow recipes to be invoked with alternative names:
+Aliases allow using alternative names for recipes when invoking them on the command line:
 
 ```just
 alias b := build
@@ -645,7 +645,6 @@ build:
 
 ```sh
 $ just b
-build
 echo 'Building!'
 Building!
 ```


### PR DESCRIPTION
Resolves https://github.com/casey/just/issues/1725 by documenting the scope of the alternative names defined with `alias`.  Also updated the output of the example `just b` command to match what current `just` would do.