### PR TITLE
docs: fix build badge for zh readme

### DIFF
--- a/README.中文.md
+++ b/README.中文.md
@@ -7,7 +7,7 @@
     <img src="https://img.shields.io/crates/v/just.svg" alt="crates.io version">
   </a>
   <a href="https://github.com/casey/just/actions">
-    <img src="https://github.com/casey/just/workflows/Build/badge.svg" alt="build status">
+    <img src="https://github.com/casey/just/actions/workflows/ci.yaml/badge.svg" alt="build status">
   </a>
   <a href="https://github.com/casey/just/releases">
     <img src="https://img.shields.io/github/downloads/casey/just/total.svg" alt="downloads">


### PR DESCRIPTION
![image](https://github.com/casey/just/assets/1580956/66a92397-2af5-4bb2-a0c7-ead50224ad12)
