### PR TITLE
Document `just` 1.15.0 line continuation syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -2123,7 +2123,7 @@ dep2 \
     echo 'Dependency with parameter {{param}}'
 ```
 
-Backslash line continuations can also be used in interpolations.  The line following the backslash must start with the same indentation as the recipe body, though additional indentation can be appended.
+Backslash line continuations can also be used in interpolations. The line following the backslash must start with the same indentation as the recipe body, although additional indentation is accepted.
 
 ```just
 recipe:

--- a/README.md
+++ b/README.md
@@ -2076,7 +2076,7 @@ while:
   done
 ```
 
-#### Outside recipe bodies
+#### Outside Recipe Bodies
 
 Parenthesized expressions can span multiple lines:
 

--- a/README.md
+++ b/README.md
@@ -2076,6 +2076,64 @@ while:
   done
 ```
 
+#### Outside recipe bodies
+
+Parenthesized expressions can span multiple lines:
+
+```just
+abc := ('a' +
+        'b'
+         + 'c')
+
+abc2 := (
+  'a' +
+  'b' +
+  'c'
+)
+
+foo param=('foo'
+      + 'bar'
+    ):
+  echo {{param}}
+
+bar: (foo
+        'Foo'
+     )
+  echo 'Bar!'
+```
+
+Lines ending with a backslash continue on to the next line as if the lines were joined by whitespace<sup>1.15.0</sup>:
+
+```just
+a := 'foo' + \
+     'bar'
+
+foo param1 \
+  param2='foo' \
+  *varparam='': dep1 \
+                (dep2 'foo')
+  echo {{param1}} {{param2}} {{varparam}}
+
+dep1: \
+    # this comment is not part of the recipe body
+  echo 'dep1'
+
+dep2 \
+  param:
+    echo 'Dependency with parameter {{param}}'
+```
+
+Backslash line continuations can also be used in interpolations.  The line following the backslash must start with the same indentation as the recipe body, though additional indentation can be appended.
+
+```just
+recipe:
+  echo '{{ \
+  "This interpolation " + \
+    "has a lot of text." \
+  }}'
+  echo 'back to recipe body'
+```
+
 ### Command Line Options
 
 `just` supports a number of useful command line options for listing, dumping, and debugging recipes and variables:


### PR DESCRIPTION
[`just` 1.15.0 release notes](https://github.com/casey/just/blob/master/CHANGELOG.md#1150---2023-10-09) include
> Allow escaping newlines ([#1551](https://github.com/casey/just/pull/1551) by [ids1024](https://github.com/ids1024))

AFAIK this has not yet been documented.  This pull request is an attempt to document it.  Also documented [parenthesis-based multi-line construct](https://github.com/casey/just/issues/1157#issuecomment-1100751733).