### PR TITLE
Updated repository details for gentoo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ You can also set the shell using command-line arguments. For example, to use Pow
     <tr>
       <td><a href="https://www.gentoo.org">Gentoo Linux</a></td>
       <td><a href="https://wiki.gentoo.org/wiki/Portage">Portage</a></td>
-      <td><a href="https://github.com/gentoo-mirror/dm9pZCAq/tree/master/sys-devel/just">dm9pZCAq/sys-devel/just</a></td>
+      <td><a href="https://github.com/gentoo-mirror/guru/tree/master/sys-devel/just">guru/sys-devel/just</a></td>
       <td>
-        <code>eselect repository enable dm9pZCAq</code><br>
-        <code>emerge --sync dm9pZCAq</code><br>
+        <code>eselect repository enable guru</code><br>
+        <code>emerge --sync guru</code><br>
         <code>emerge sys-devel/just</code>
       </td>
     </tr>

--- a/README.中文.md
+++ b/README.中文.md
@@ -186,10 +186,10 @@ list:
   <tr>
     <td><a href="https://www.gentoo.org">Gentoo Linux</a></td>
     <td><a href="https://wiki.gentoo.org/wiki/Portage">Portage</a></td>
-    <td><a href="https://github.com/gentoo-mirror/dm9pZCAq/tree/master/sys-devel/just">dm9pZCAq/sys-devel/just</a></td>
+    <td><a href="https://github.com/gentoo-mirror/guru/tree/master/sys-devel/just">guru/sys-devel/just</a></td>
     <td>
-      <code>eselect repository enable dm9pZCAq</code><br>
-      <code>emerge --sync dm9pZCAq</code><br>
+      <code>eselect repository enable guru</code><br>
+      <code>emerge --sync guru</code><br>
       <code>emerge sys-devel/just</code>
     </td>
   </tr>


### PR DESCRIPTION
The ebuild for gentoo appears to have been moved to the guru repository. These changes update the README files with the correct details.
