### PR TITLE
Pass `--unstable` and `--color always` to fzf's default preview command

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use {
 };
 
 // These three strings should be kept in sync:
-pub(crate) const CHOOSER_DEFAULT: &str = "fzf --multi --preview 'just --unstable --show {}'";
+pub(crate) const CHOOSER_DEFAULT: &str = "fzf --multi --preview 'just --unstable --color always --show {}'";
 pub(crate) const CHOOSER_ENVIRONMENT_KEY: &str = "JUST_CHOOSER";
 pub(crate) const CHOOSE_HELP: &str = "Select one or more recipes to run using a binary. If \
                                       `--chooser` is not passed the chooser defaults to the value \

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,8 @@ use {
 };
 
 // These three strings should be kept in sync:
-pub(crate) const CHOOSER_DEFAULT: &str = "fzf --multi --preview 'just --unstable --show {}'";
+pub(crate) const CHOOSER_DEFAULT: &str =
+  "fzf --multi --preview 'just --unstable --color always --show {}'";
 pub(crate) const CHOOSER_ENVIRONMENT_KEY: &str = "JUST_CHOOSER";
 pub(crate) const CHOOSE_HELP: &str = "Select one or more recipes to run using a binary. If \
                                       `--chooser` is not passed the chooser defaults to the value \

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use {
 };
 
 // These three strings should be kept in sync:
-pub(crate) const CHOOSER_DEFAULT: &str = "fzf --multi --preview 'just --unstable --color always --show {}'";
+pub(crate) const CHOOSER_DEFAULT: &str = "fzf --multi --preview 'just --unstable --show {}'";
 pub(crate) const CHOOSER_ENVIRONMENT_KEY: &str = "JUST_CHOOSER";
 pub(crate) const CHOOSE_HELP: &str = "Select one or more recipes to run using a binary. If \
                                       `--chooser` is not passed the chooser defaults to the value \

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use {
 };
 
 // These three strings should be kept in sync:
-pub(crate) const CHOOSER_DEFAULT: &str = "fzf --multi --preview 'just --show {}'";
+pub(crate) const CHOOSER_DEFAULT: &str = "fzf --multi --preview 'just --unstable --show {}'";
 pub(crate) const CHOOSER_ENVIRONMENT_KEY: &str = "JUST_CHOOSER";
 pub(crate) const CHOOSE_HELP: &str = "Select one or more recipes to run using a binary. If \
                                       `--chooser` is not passed the chooser defaults to the value \

--- a/tests/choose.rs
+++ b/tests/choose.rs
@@ -152,7 +152,7 @@ fn invoke_error_function() {
       ",
     )
     .stderr_regex(
-      r"error: Chooser `/ -cu fzf --multi --preview 'just --show \{\}'` invocation failed: .*\n",
+      r"error: Chooser `/ -cu fzf --multi --preview 'just --unstable --show \{\}'` invocation failed: .*\n",
     )
     .status(EXIT_FAILURE)
     .shell(false)

--- a/tests/choose.rs
+++ b/tests/choose.rs
@@ -152,7 +152,7 @@ fn invoke_error_function() {
       ",
     )
     .stderr_regex(
-      r"error: Chooser `/ -cu fzf --multi --preview 'just --unstable --show \{\}'` invocation failed: .*\n",
+      r"error: Chooser `/ -cu fzf --multi --preview 'just --unstable --color always --show \{\}'` invocation failed: .*\n",
     )
     .status(EXIT_FAILURE)
     .shell(false)


### PR DESCRIPTION
Pass `--unstable` to the preview command for the chooser, so that recipe previews can work even when the justfile relies on unstable features, such as `!include` directives.

Note that we're not taking the user by surprise by enabling unstable features in the preview: when the justfile includes unstable features, the user will need to pass `--unstable` explicitely to call `just --choose --unstable` already, or `just` will exit before launching the chooser.

Also tell `just`, in a second commit, to use colours for recipe previews.