### PR TITLE
Chooser: Pass justfile path to preview command for default chooser

### DIFF
--- a/completions/just.elvish
+++ b/completions/just.elvish
@@ -51,7 +51,7 @@ edit:completion:arg-completer[just] = [@words]{
             cand -v 'Use verbose output'
             cand --verbose 'Use verbose output'
             cand --changelog 'Print changelog'
-            cand --choose 'Select one or more recipes to run using a binary. If `--chooser` is not passed the chooser defaults to the value of $JUST_CHOOSER, falling back to `fzf`'
+            cand --choose 'Select one or more recipes to run using a binary chooser. If `--chooser` is not passed the chooser defaults to the value of $JUST_CHOOSER, falling back to `fzf`'
             cand --dump 'Print justfile'
             cand -e 'Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`'
             cand --edit 'Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`'

--- a/completions/just.fish
+++ b/completions/just.fish
@@ -64,7 +64,7 @@ complete -c just -n "__fish_use_subcommand" -s u -l unsorted -d 'Return list and
 complete -c just -n "__fish_use_subcommand" -l unstable -d 'Enable unstable features'
 complete -c just -n "__fish_use_subcommand" -s v -l verbose -d 'Use verbose output'
 complete -c just -n "__fish_use_subcommand" -l changelog -d 'Print changelog'
-complete -c just -n "__fish_use_subcommand" -l choose -d 'Select one or more recipes to run using a binary. If `--chooser` is not passed the chooser defaults to the value of $JUST_CHOOSER, falling back to `fzf`'
+complete -c just -n "__fish_use_subcommand" -l choose -d 'Select one or more recipes to run using a binary chooser. If `--chooser` is not passed the chooser defaults to the value of $JUST_CHOOSER, falling back to `fzf`'
 complete -c just -n "__fish_use_subcommand" -l dump -d 'Print justfile'
 complete -c just -n "__fish_use_subcommand" -s e -l edit -d 'Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`'
 complete -c just -n "__fish_use_subcommand" -l evaluate -d 'Evaluate and print all variables. If a variable name is given as an argument, only print that variable\'s value.'

--- a/completions/just.powershell
+++ b/completions/just.powershell
@@ -56,7 +56,7 @@ Register-ArgumentCompleter -Native -CommandName 'just' -ScriptBlock {
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Use verbose output')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Use verbose output')
             [CompletionResult]::new('--changelog', 'changelog', [CompletionResultType]::ParameterName, 'Print changelog')
-            [CompletionResult]::new('--choose', 'choose', [CompletionResultType]::ParameterName, 'Select one or more recipes to run using a binary. If `--chooser` is not passed the chooser defaults to the value of $JUST_CHOOSER, falling back to `fzf`')
+            [CompletionResult]::new('--choose', 'choose', [CompletionResultType]::ParameterName, 'Select one or more recipes to run using a binary chooser. If `--chooser` is not passed the chooser defaults to the value of $JUST_CHOOSER, falling back to `fzf`')
             [CompletionResult]::new('--dump', 'dump', [CompletionResultType]::ParameterName, 'Print justfile')
             [CompletionResult]::new('-e', 'e', [CompletionResultType]::ParameterName, 'Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`')
             [CompletionResult]::new('--edit', 'edit', [CompletionResultType]::ParameterName, 'Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`')

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -52,7 +52,7 @@ _just() {
 '*-v[Use verbose output]' \
 '*--verbose[Use verbose output]' \
 '--changelog[Print changelog]' \
-'--choose[Select one or more recipes to run using a binary. If `--chooser` is not passed the chooser defaults to the value of $JUST_CHOOSER, falling back to `fzf`]' \
+'--choose[Select one or more recipes to run using a binary chooser. If `--chooser` is not passed the chooser defaults to the value of $JUST_CHOOSER, falling back to `fzf`]' \
 '--dump[Print justfile]' \
 '-e[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' \
 '--edit[Edit justfile with editor given by $VISUAL or $EDITOR, falling back to `vim`]' \

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,13 +3,21 @@ use {
   clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, ArgSettings},
 };
 
-// These three strings should be kept in sync:
-pub(crate) const CHOOSER_DEFAULT: &str =
-  "fzf --multi --preview 'just --unstable --color always --show {}'";
+// These two strings, and the two in function chooser_default below should be kept in sync:
 pub(crate) const CHOOSER_ENVIRONMENT_KEY: &str = "JUST_CHOOSER";
 pub(crate) const CHOOSE_HELP: &str = "Select one or more recipes to run using a binary. If \
                                       `--chooser` is not passed the chooser defaults to the value \
                                       of $JUST_CHOOSER, falling back to `fzf`";
+
+// Return the string for the default chooser. This is a function and not a const, because we want
+// to edit the preview command and pass it the right justfile path for the target.
+pub(crate) fn chooser_default(justfile: &Path) -> OsString {
+  let mut chooser = OsString::new();
+  chooser.push("fzf --multi --preview 'just --unstable --color always --justfile ");
+  chooser.push(justfile);
+  chooser.push(" --show {}'");
+  chooser
+}
 
 #[derive(Debug, PartialEq)]
 #[allow(clippy::struct_excessive_bools)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,19 +3,17 @@ use {
   clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, ArgSettings},
 };
 
-// These two strings, and the two in function chooser_default below should be kept in sync:
 pub(crate) const CHOOSER_ENVIRONMENT_KEY: &str = "JUST_CHOOSER";
-pub(crate) const CHOOSE_HELP: &str = "Select one or more recipes to run using a binary. If \
-                                      `--chooser` is not passed the chooser defaults to the value \
-                                      of $JUST_CHOOSER, falling back to `fzf`";
 
-// Return the string for the default chooser. This is a function and not a const, because we want
-// to edit the preview command and pass it the right justfile path for the target.
+pub(crate) const CHOOSE_HELP: &str = "Select one or more recipes to run using a binary chooser. \
+                                      If `--chooser` is not passed the chooser defaults to the \
+                                      value of $JUST_CHOOSER, falling back to `fzf`";
+
 pub(crate) fn chooser_default(justfile: &Path) -> OsString {
   let mut chooser = OsString::new();
-  chooser.push("fzf --multi --preview 'just --unstable --color always --justfile ");
+  chooser.push("fzf --multi --preview 'just --unstable --color always --justfile \"");
   chooser.push(justfile);
-  chooser.push(" --show {}'");
+  chooser.push("\" --show {}'");
   chooser
 }
 

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -216,7 +216,7 @@ impl Subcommand {
     let chooser = chooser
       .map(OsString::from)
       .or_else(|| env::var_os(config::CHOOSER_ENVIRONMENT_KEY))
-      .unwrap_or_else(|| OsString::from(config::CHOOSER_DEFAULT));
+      .unwrap_or_else(|| config::chooser_default(&search.justfile));
 
     let result = justfile
       .settings

--- a/tests/choose.rs
+++ b/tests/choose.rs
@@ -152,7 +152,7 @@ fn invoke_error_function() {
       ",
     )
     .stderr_regex(
-      r"error: Chooser `/ -cu fzf --multi --preview 'just --unstable --color always --show \{\}'` invocation failed: .*\n",
+      r"error: Chooser `/ -cu fzf --multi --preview 'just --unstable --color always --justfile [^ ]*justfile --show \{\}'` invocation failed: .*\n",
     )
     .status(EXIT_FAILURE)
     .shell(false)

--- a/tests/choose.rs
+++ b/tests/choose.rs
@@ -152,7 +152,7 @@ fn invoke_error_function() {
       ",
     )
     .stderr_regex(
-      r"error: Chooser `/ -cu fzf --multi --preview 'just --unstable --color always --justfile [^ ]*justfile --show \{\}'` invocation failed: .*\n",
+      r#"error: Chooser `/ -cu fzf --multi --preview 'just --unstable --color always --justfile ".*justfile" --show \{\}'` invocation failed: .*\n"#,
     )
     .status(EXIT_FAILURE)
     .shell(false)


### PR DESCRIPTION
The default chooser is fzf, and we pass it a command to generate the preview with `just --show` from the recipe name. This has been working well as long as we rely on the default justfile available in the directory, given that the preview command can find it too. However, passing `--chose` alongside `--justfile` to select a specific file results in the preview command not being able to find the right justfile to process.

To address this issue, we turn the const string defining the preview command into a function that takes the internal representation of the justfile as an argument, and updates the preview command with the right file.

Fixes: https://github.com/casey/just/issues/1638