### PR TITLE
chore(README): Remove toc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-↖️ Table of Contents
-
 <h1 align="center"><code>just</code></h1>
 
 <div align="center">

--- a/README.中文.md
+++ b/README.中文.md
@@ -1,5 +1,3 @@
-↖️ 目录
-
 <h1 align="center"><code>just</code></h1>
 
 <div align="center">


### PR DESCRIPTION
For logged-in users (might be only for the ones in the feature preview, not sure), the table of contents are on the other side:
![image](https://github.com/casey/just/assets/3979930/73fdf176-99e0-4312-a747-d6004cb3a155)

Since this is not consistent for every user and might change in future, I would be in favor of removing this notice from the readme. This is something GitHub has to fix, not us!