### PR TITLE
Add import path tests

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -20,7 +20,13 @@ impl Compiler {
       let (relative, src) = loader.load(root, &current.path)?;
       loaded.push(relative.into());
       let tokens = Lexer::lex(relative, src)?;
-      let mut ast = Parser::parse(&current.path, &current.namepath, current.depth, &tokens)?;
+      let mut ast = Parser::parse(
+        &current.path,
+        &current.namepath,
+        current.depth,
+        &tokens,
+        &current.working_directory,
+      )?;
 
       paths.insert(current.path.clone(), relative.into());
       srcs.insert(current.path.clone(), src);
@@ -162,7 +168,13 @@ impl Compiler {
   #[cfg(test)]
   pub(crate) fn test_compile(src: &str) -> CompileResult<Justfile> {
     let tokens = Lexer::test_lex(src)?;
-    let ast = Parser::parse(&PathBuf::new(), &Namepath::default(), 0, &tokens)?;
+    let ast = Parser::parse(
+      &PathBuf::new(),
+      &Namepath::default(),
+      0,
+      &tokens,
+      &PathBuf::new(),
+    )?;
     let root = PathBuf::from("justfile");
     let mut asts: HashMap<PathBuf, Ast> = HashMap::new();
     asts.insert(root.clone(), ast);

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -363,13 +363,13 @@ impl<'src, D> Recipe<'src, D> {
         })?;
     }
 
-    // make the script executable
+    // make script executable
     Platform::set_execute_permission(&path).map_err(|error| Error::TmpdirIo {
       recipe: self.name(),
       io_error: error,
     })?;
 
-    // create a command to run the script
+    // create command to run script
     let mut command =
       Platform::make_shebang_command(&path, self.working_directory(&context.search), shebang)
         .map_err(|output_error| Error::Cygpath {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -236,7 +236,7 @@ impl<'src, D> Recipe<'src, D> {
 
       let mut cmd = context.settings.shell_command(config);
 
-      if let Some(working_directory) = self.working_directory(&context.search) {
+      if let Some(working_directory) = self.working_directory(context.search) {
         cmd.current_dir(working_directory);
       }
 
@@ -371,7 +371,7 @@ impl<'src, D> Recipe<'src, D> {
 
     // create command to run script
     let mut command =
-      Platform::make_shebang_command(&path, self.working_directory(&context.search), shebang)
+      Platform::make_shebang_command(&path, self.working_directory(context.search), shebang)
         .map_err(|output_error| Error::Cygpath {
           recipe: self.name(),
           output_error,

--- a/src/source.rs
+++ b/src/source.rs
@@ -4,6 +4,7 @@ pub(crate) struct Source<'src> {
   pub(crate) path: PathBuf,
   pub(crate) depth: u32,
   pub(crate) namepath: Namepath<'src>,
+  pub(crate) working_directory: PathBuf,
 }
 
 impl<'src> Source<'src> {
@@ -12,6 +13,7 @@ impl<'src> Source<'src> {
       path: path.into(),
       depth: 0,
       namepath: Namepath::default(),
+      working_directory: path.parent().unwrap().into(),
     }
   }
 
@@ -20,11 +22,13 @@ impl<'src> Source<'src> {
       depth: self.depth + 1,
       path,
       namepath: self.namepath.clone(),
+      working_directory: self.working_directory.clone(),
     }
   }
 
   pub(crate) fn module(&self, name: Name<'src>, path: PathBuf) -> Self {
     Self {
+      working_directory: path.parent().unwrap().into(),
       path,
       depth: self.depth + 1,
       namepath: self.namepath.join(name),

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -59,8 +59,14 @@ pub(crate) fn analysis_error(
 ) {
   let tokens = Lexer::test_lex(src).expect("Lexing failed in parse test...");
 
-  let ast = Parser::parse(&PathBuf::new(), &Namepath::default(), 0, &tokens)
-    .expect("Parsing failed in analysis test...");
+  let ast = Parser::parse(
+    &PathBuf::new(),
+    &Namepath::default(),
+    0,
+    &tokens,
+    &PathBuf::new(),
+  )
+  .expect("Parsing failed in analysis test...");
 
   let root = PathBuf::from("justfile");
   let mut asts: HashMap<PathBuf, Ast> = HashMap::new();

--- a/src/unresolved_recipe.rs
+++ b/src/unresolved_recipe.rs
@@ -58,6 +58,7 @@ impl<'src> UnresolvedRecipe<'src> {
       private: self.private,
       quiet: self.quiet,
       shebang: self.shebang,
+      working_directory: self.working_directory,
     })
   }
 }

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -299,3 +299,22 @@ fn recipes_in_nested_imports_run_in_parent_module() {
     .stdout("BAZ")
     .run();
 }
+
+#[test]
+fn shebang_recipes_in_imports_in_root_run_in_justfile_directory() {
+  Test::new()
+    .write(
+      "foo/import.justfile",
+      "bar:\n #!/usr/bin/env bash\n cat baz",
+    )
+    .write("baz", "BAZ")
+    .justfile(
+      "
+        import 'foo/import.justfile'
+      ",
+    )
+    .test_round_trip(false)
+    .arg("bar")
+    .stdout("BAZ")
+    .run();
+}

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -279,9 +279,23 @@ fn nested_import_paths_are_relative_to_containing_submodule() {
   Test::new()
     .justfile("import 'foo/import.just'")
     .write("foo/import.just", "import 'bar.just'")
-    .write("bar.just", "bar:\n @echo BAR")
+    .write("foo/bar.just", "bar:\n @echo BAR")
     .test_round_trip(false)
     .arg("bar")
     .stdout("BAR\n")
+    .run();
+}
+
+#[test]
+fn recipes_in_nested_imports_run_in_parent_module() {
+  Test::new()
+    .justfile("import 'foo/import.just'")
+    .write("foo/import.just", "import 'bar/import.just'")
+    .write("foo/bar/import.just", "bar:\n @cat baz")
+    .write("baz", "BAZ")
+    .test_round_trip(false)
+    .arg("--unstable")
+    .arg("bar")
+    .stdout("BAZ")
     .run();
 }


### PR DESCRIPTION
This was reported by @michaelCTS in #1813.

Currently, imported recipes run in the directory containing the import source file, and not in the directory of the source file containing the import. This is a bug, since imported recipes are supposed to behave as if they were part of the justfile that imported them.

This adds tests, but doesn't include a fix yet.

Another issue that I identified is that the path of nested imports, i.e., imports within imports, are resolved relative to the directory containing the nested import source file. I think this is also a bug, and that, by the logic that imports are treated as being part of the importing justfile, they should be resolved relative to the importing justfile.