### PR TITLE
Add functions to return standard directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1421,7 +1421,7 @@ These functions return paths to user-specific directories for things like
 configuration, data, caches, executables, and the user's home directory. These
 functions follow the
 [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html),
-and use implementation provided by the
+and are implemented with the
 [`dirs`](https://docs.rs/dirs/latest/dirs/index.html) crate.
 
 - `cache_directory()` - The user-specific cache directory.

--- a/README.md
+++ b/README.md
@@ -1424,20 +1424,13 @@ functions follow the
 and use implementation provided by the
 [`dirs`](https://docs.rs/dirs/latest/dirs/index.html) crate.
 
-- `cache_directory()` - Locate the user-specific cache directory. Returns an
-   empty string if it could not be found.
-- `config_directory()` - Locate the user-specific config directory. Returns an
-   empty string if it could not be found.
-- `config_local_directory()` - Locate the user-specific config_local directory.
-   Returns an empty string if it could not be found.
-- `data_directory()` - Locate the user-specific data directory. Returns an empty
-   string if it could not be found.
-- `data_local_directory()` - Locate the user-specific data_local directory.
-   Returns an empty string if it could not be found.
-- `executable_directory()` - Locate the user-specific executable directory.
-   Returns an empty string if it could not be found.
-- `home_directory()` - Locate the user-specific home directory. Returns an empty
-   string if it could not be found.
+- `cache_directory()` - The user-specific cache directory.
+- `config_directory()` - The user-specific configuration directory.
+- `config_local_directory()` - The local user-specific configuration directory.
+- `data_directory()` - The user-specific data directory.
+- `data_local_directory()` - The local user-specific data directory.
+- `executable_directory()` - The user-specific executable directory.
+- `home_directory()` - The user's home directory.
 
 ### Recipe Attributes
 

--- a/README.md
+++ b/README.md
@@ -1415,6 +1415,30 @@ which will halt execution.
   `requirement`, e.g., `">=0.1.0"`, returning `"true"` if so and `"false"`
   otherwise.
 
+##### Directory Locaters
+
+- `cache_directory()` - Locate the user-specific cache directory. Returns an
+   empty string if it could not be found.
+- `config_directory()` - Locate the user-specific config directory. Returns an
+   empty string if it could not be found.
+- `config_local_directory()` - Locate the user-specific config_local directory.
+   Returns an empty string if it could not be found.
+- `data_directory()` - Locate the user-specific data directory. Returns an empty
+   string if it could not be found.
+- `data_local_directory()` - Locate the user-specific data_local directory.
+   Returns an empty string if it could not be found.
+- `executable_directory()` - Locate the user-specific executable directory.
+   Returns an empty string if it could not be found.
+- `home_directory()` - Locate the user-specific home directory. Returns an empty
+   string if it could not be found.
+
+The output for these commands is produced by the
+[`dirs`](https://docs.rs/dirs/latest/dirs/index.html) crate, which first checks
+for `XDG_*` environment variables then falls back to platform defaults.
+
+The XDG specification is available here:
+<https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>
+
 ### Recipe Attributes
 
 Recipes may be annotated with attributes that change their behavior.

--- a/README.md
+++ b/README.md
@@ -1418,7 +1418,8 @@ which will halt execution.
 ##### XDG Directories
 
 These functions return paths to user-specific directories for things like
-configuration, data, and caches. These functions follow the
+configuration, data, caches, executables, and the user's home directory. These
+functions follow the
 [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html),
 and use implementation provided by the
 [`dirs`](https://docs.rs/dirs/latest/dirs/index.html) crate.

--- a/README.md
+++ b/README.md
@@ -1415,7 +1415,13 @@ which will halt execution.
   `requirement`, e.g., `">=0.1.0"`, returning `"true"` if so and `"false"`
   otherwise.
 
-##### Directory Locaters
+##### XDG Directories
+
+These functions return paths to user-specific directories for things like
+configuration, data, and caches. These functions follow the
+[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html),
+and use implementation provided by the
+[`dirs`](https://docs.rs/dirs/latest/dirs/index.html) crate.
 
 - `cache_directory()` - Locate the user-specific cache directory. Returns an
    empty string if it could not be found.
@@ -1431,13 +1437,6 @@ which will halt execution.
    Returns an empty string if it could not be found.
 - `home_directory()` - Locate the user-specific home directory. Returns an empty
    string if it could not be found.
-
-The output for these commands is produced by the
-[`dirs`](https://docs.rs/dirs/latest/dirs/index.html) crate, which first checks
-for `XDG_*` environment variables then falls back to platform defaults.
-
-The XDG specification is available here:
-<https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>
 
 ### Recipe Attributes
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -21,22 +21,22 @@ pub(crate) fn get(name: &str) -> Option<Function> {
   let function = match name {
     "absolute_path" => Unary(absolute_path),
     "arch" => Nullary(arch),
-    "cache_directory" => Nullary(|_| dir(dirs::cache_dir, "cache")),
+    "cache_directory" => Nullary(|_| dir("cache", dirs::cache_dir)),
     "capitalize" => Unary(capitalize),
-    "config_directory" => Nullary(|_| dir(dirs::config_dir, "config")),
-    "config_local_directory" => Nullary(|_| dir(dirs::config_local_dir, "local config")),
     "clean" => Unary(clean),
-    "data_directory" => Nullary(|_| dir(dirs::data_dir, "data")),
-    "data_local_directory" => Nullary(|_| dir(dirs::data_local_dir, "local data")),
+    "config_directory" => Nullary(|_| dir("config", dirs::config_dir)),
+    "config_local_directory" => Nullary(|_| dir("local config", dirs::config_local_dir)),
+    "data_directory" => Nullary(|_| dir("data", dirs::data_dir)),
+    "data_local_directory" => Nullary(|_| dir("local data", dirs::data_local_dir)),
     "env" => UnaryOpt(env),
     "env_var" => Unary(env_var),
     "env_var_or_default" => Binary(env_var_or_default),
     "error" => Unary(error),
-    "executable_directory" => Nullary(|_| dir(dirs::executable_dir, "executable")),
+    "executable_directory" => Nullary(|_| dir("executable", dirs::executable_dir)),
     "extension" => Unary(extension),
     "file_name" => Unary(file_name),
     "file_stem" => Unary(file_stem),
-    "home_directory" => Nullary(|_| dir(dirs::home_dir, "home")),
+    "home_directory" => Nullary(|_| dir("home", dirs::home_dir)),
     "invocation_directory" => Nullary(invocation_directory),
     "invocation_directory_native" => Nullary(invocation_directory_native),
     "join" => BinaryPlus(join),
@@ -121,17 +121,20 @@ fn clean(_context: &FunctionContext, path: &str) -> Result<String, String> {
   Ok(Path::new(path).lexiclean().to_str().unwrap().to_owned())
 }
 
-fn dir(f: fn() -> Option<PathBuf>, name: &'static str) -> Result<String, String> {
-  let res = match f() {
-    Some(p) => p.into_os_string().into_string().map_err(|err_p| {
-      format!(
-        "unable to convert {name} directory path to a string: {}",
-        err_p.to_string_lossy()
-      )
-    })?,
-    None => String::new(),
-  };
-  Ok(res)
+fn dir(name: &'static str, f: fn() -> Option<PathBuf>) -> Result<String, String> {
+  match f() {
+    Some(path) => path
+      .as_os_str()
+      .to_str()
+      .map(str::to_string)
+      .ok_or_else(|| {
+        format!(
+          "unable to convert {name} directory path to string: {}",
+          path.display(),
+        )
+      }),
+    None => Err(format!("{name} directory not found")),
+  }
 }
 
 fn env_var(context: &FunctionContext, key: &str) -> Result<String, String> {
@@ -452,4 +455,25 @@ fn semver_matches(
       )
       .to_string(),
   )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn dir_not_found() {
+    assert_eq!(dir("foo", || None).unwrap_err(), "foo directory not found");
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn dir_not_unicode() {
+    use std::os::unix::ffi::OsStrExt;
+
+    assert_eq!(
+      dir("foo", || Some(OsStr::from_bytes(b"\xe0\x80\x80").into())).unwrap_err(),
+      "unable to convert foo directory path to string: ���",
+    );
+  }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -470,7 +470,6 @@ mod tests {
   #[test]
   fn dir_not_unicode() {
     use std::os::unix::ffi::OsStrExt;
-
     assert_eq!(
       dir("foo", || Some(OsStr::from_bytes(b"\xe0\x80\x80").into())).unwrap_err(),
       "unable to convert foo directory path to string: ���",

--- a/tests/directories.rs
+++ b/tests/directories.rs
@@ -1,0 +1,68 @@
+use super::*;
+
+#[test]
+fn cache_directory() {
+  Test::new()
+    .justfile("x := cache_directory()")
+    .args(["--evaluate", "x"])
+    .stdout(dirs::cache_dir().unwrap_or_default().to_string_lossy())
+    .run();
+}
+
+#[test]
+fn config_directory() {
+  Test::new()
+    .justfile("x := config_directory()")
+    .args(["--evaluate", "x"])
+    .stdout(dirs::config_dir().unwrap_or_default().to_string_lossy())
+    .run();
+}
+
+#[test]
+fn config_local_directory() {
+  Test::new()
+    .justfile("x := config_local_directory()")
+    .args(["--evaluate", "x"])
+    .stdout(
+      dirs::config_local_dir()
+        .unwrap_or_default()
+        .to_string_lossy(),
+    )
+    .run();
+}
+
+#[test]
+fn data_directory() {
+  Test::new()
+    .justfile("x := data_directory()")
+    .args(["--evaluate", "x"])
+    .stdout(dirs::data_dir().unwrap_or_default().to_string_lossy())
+    .run();
+}
+
+#[test]
+fn data_local_directory() {
+  Test::new()
+    .justfile("x := data_local_directory()")
+    .args(["--evaluate", "x"])
+    .stdout(dirs::data_local_dir().unwrap_or_default().to_string_lossy())
+    .run();
+}
+
+#[test]
+fn executable_directory() {
+  Test::new()
+    .justfile("x := executable_directory()")
+    .args(["--evaluate", "x"])
+    .stdout(dirs::executable_dir().unwrap_or_default().to_string_lossy())
+    .run();
+}
+
+#[test]
+fn home_directory() {
+  Test::new()
+    .justfile("x := home_directory()")
+    .args(["--evaluate", "x"])
+    .stdout(dirs::home_dir().unwrap_or_default().to_string_lossy())
+    .run();
+}

--- a/tests/directories.rs
+++ b/tests/directories.rs
@@ -51,11 +51,28 @@ fn data_local_directory() {
 
 #[test]
 fn executable_directory() {
-  Test::new()
-    .justfile("x := executable_directory()")
-    .args(["--evaluate", "x"])
-    .stdout(dirs::executable_dir().unwrap_or_default().to_string_lossy())
-    .run();
+  if let Some(executable_dir) = dirs::executable_dir() {
+    Test::new()
+      .justfile("x := executable_directory()")
+      .args(["--evaluate", "x"])
+      .stdout(executable_dir.to_string_lossy())
+      .run();
+  } else {
+    Test::new()
+      .justfile("x := executable_directory()")
+      .args(["--evaluate", "x"])
+      .stderr(
+        "
+          error: Call to function `executable_directory` failed: executable directory not found
+           ——▶ justfile:1:6
+            │
+          1 │ x := executable_directory()
+            │      ^^^^^^^^^^^^^^^^^^^^
+        ",
+      )
+      .status(EXIT_FAILURE)
+      .run();
+  }
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -44,6 +44,7 @@ mod completions;
 mod conditional;
 mod confirm;
 mod delimiters;
+mod directories;
 mod dotenv;
 mod edit;
 mod equals;


### PR DESCRIPTION
Add the following builtin functions:

- `cache_directory()`
- `config_directory()`
- `config_local_directory()`
- `data_directory()`
- `data_local_directory()`
- `executable_directory()`
- `home_directory()`

These use the `dirs` crate to return XDG-compliant paths, or the system defaults.

Fixes: https://github.com/casey/just/issues/1820