### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -390,7 +390,7 @@ Changelog
 - Split Recipe::run into Recipe::{run_shebang,run_linewise} ([#1270](https://github.com/casey/just/pull/1270))
 - Add asdf package to readme([#1264](https://github.com/casey/just/pull/1264) by [jaacko-torus](https://github.com/jaacko-torus))
 - Add mdbook deps for build-book recipe ([#1259](https://github.com/casey/just/pull/1259) by [TopherIsSwell](https://github.com/TopherIsSwell))
-- Fix typo: argument -> argument ([#1257](https://github.com/casey/just/pull/1257) by [kianmeng](https://github.com/kianmeng))
+- Fix typo: argumant -> argument ([#1257](https://github.com/casey/just/pull/1257) by [kianmeng](https://github.com/kianmeng))
 - Improve error message if `if` is missing the `else` ([#1252](https://github.com/casey/just/pull/1252) by [nk9](https://github.com/nk9))
 - Explain how to pass arguments of a command to a dependency ([#1254](https://github.com/casey/just/pull/1254) by [heavelock](https://github.com/heavelock))
 - Update Chinese translation of README.md ([#1253](https://github.com/casey/just/pull/1253) by [hustcer](https://github.com/hustcer))
@@ -1037,7 +1037,7 @@ Changelog
 
 ### Misc
 - Assert that lexer advances over entire input ([#560](https://github.com/casey/just/pull/560))
-- Fix typo: `character` -> `character` ([#561](https://github.com/casey/just/pull/561))
+- Fix typo: `chracter` -> `character` ([#561](https://github.com/casey/just/pull/561))
 - Improve pre-publish check ([#562](https://github.com/casey/just/pull/562))
 
 [0.5.2](https://github.com/casey/just/releases/tag/v0.5.2) - 2019-12-7
@@ -1162,7 +1162,7 @@ Changelog
 
 ### Documented
 - Fix readme command line ([#411](https://github.com/casey/just/pull/411))
-- Typo: "command equivalent" -> "command equivalent" ([#418](https://github.com/casey/just/pull/418))
+- Typo: "command equivelant" -> "command equivalent" ([#418](https://github.com/casey/just/pull/418))
 - Mention Make’s “phony target” workaround in the comparison ([#421](https://github.com/casey/just/pull/421) by [roryokane](https://github.com/roryokane))
 - Add Void Linux install instructions to readme ([#423](https://github.com/casey/just/pull/423))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,7 +227,7 @@ Changelog
 - Note that install.sh may fail on GitHub actions ([#1499](https://github.com/casey/just/pull/1499))
 - Fix readme typo ([#1489](https://github.com/casey/just/pull/1489) by [auberisky](https://github.com/auberisky))
 - Update install script and readmes to use tls v1.3 ([#1481](https://github.com/casey/just/pull/1481))
-- Renable install.sh test on CI([#1478](https://github.com/casey/just/pull/1478))
+- Re-enable install.sh test on CI([#1478](https://github.com/casey/just/pull/1478))
 - Don't test install.sh on CI ([#1477](https://github.com/casey/just/pull/1477))
 - Update Chinese translation of readme ([#1476](https://github.com/casey/just/pull/1476) by [hustcer](https://github.com/hustcer))
 - Fix install.sh for Windows ([#1474](https://github.com/casey/just/pull/1474) by [bloodearnest](https://github.com/bloodearnest))
@@ -390,7 +390,7 @@ Changelog
 - Split Recipe::run into Recipe::{run_shebang,run_linewise} ([#1270](https://github.com/casey/just/pull/1270))
 - Add asdf package to readme([#1264](https://github.com/casey/just/pull/1264) by [jaacko-torus](https://github.com/jaacko-torus))
 - Add mdbook deps for build-book recipe ([#1259](https://github.com/casey/just/pull/1259) by [TopherIsSwell](https://github.com/TopherIsSwell))
-- Fix typo: argumant -> argument ([#1257](https://github.com/casey/just/pull/1257) by [kianmeng](https://github.com/kianmeng))
+- Fix typo: argument -> argument ([#1257](https://github.com/casey/just/pull/1257) by [kianmeng](https://github.com/kianmeng))
 - Improve error message if `if` is missing the `else` ([#1252](https://github.com/casey/just/pull/1252) by [nk9](https://github.com/nk9))
 - Explain how to pass arguments of a command to a dependency ([#1254](https://github.com/casey/just/pull/1254) by [heavelock](https://github.com/heavelock))
 - Update Chinese translation of README.md ([#1253](https://github.com/casey/just/pull/1253) by [hustcer](https://github.com/hustcer))
@@ -1007,7 +1007,7 @@ Changelog
 - Build and upload release artifacts from GitHub Actions ([#581](https://github.com/casey/just/pull/581))
 - List solus package in readme ([#579](https://github.com/casey/just/pull/579))
 - Expand use of GitHub Actions ([#580](https://github.com/casey/just/pull/580))
-- Fix readme typo: interpetation -> interpretation ([#578](https://github.com/casey/just/pull/578) by [Plommonsorbet](https://github.com/Plommonsorbet))
+- Fix readme typo: interpretation -> interpretation ([#578](https://github.com/casey/just/pull/578) by [Plommonsorbet](https://github.com/Plommonsorbet))
 
 [0.5.5](https://github.com/casey/just/releases/tag/v0.5.5) - 2020-1-15
 ----------------------------------------------------------------------
@@ -1037,7 +1037,7 @@ Changelog
 
 ### Misc
 - Assert that lexer advances over entire input ([#560](https://github.com/casey/just/pull/560))
-- Fix typo: `chracter` -> `character` ([#561](https://github.com/casey/just/pull/561))
+- Fix typo: `character` -> `character` ([#561](https://github.com/casey/just/pull/561))
 - Improve pre-publish check ([#562](https://github.com/casey/just/pull/562))
 
 [0.5.2](https://github.com/casey/just/releases/tag/v0.5.2) - 2019-12-7
@@ -1162,7 +1162,7 @@ Changelog
 
 ### Documented
 - Fix readme command line ([#411](https://github.com/casey/just/pull/411))
-- Typo: "command equivelant" -> "command equivalent" ([#418](https://github.com/casey/just/pull/418))
+- Typo: "command equivalent" -> "command equivalent" ([#418](https://github.com/casey/just/pull/418))
 - Mention Make’s “phony target” workaround in the comparison ([#421](https://github.com/casey/just/pull/421) by [roryokane](https://github.com/roryokane))
 - Add Void Linux install instructions to readme ([#423](https://github.com/casey/just/pull/423))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1007,7 +1007,7 @@ Changelog
 - Build and upload release artifacts from GitHub Actions ([#581](https://github.com/casey/just/pull/581))
 - List solus package in readme ([#579](https://github.com/casey/just/pull/579))
 - Expand use of GitHub Actions ([#580](https://github.com/casey/just/pull/580))
-- Fix readme typo: interpretation -> interpretation ([#578](https://github.com/casey/just/pull/578) by [Plommonsorbet](https://github.com/Plommonsorbet))
+- Fix readme typo: interpetation -> interpretation ([#578](https://github.com/casey/just/pull/578) by [Plommonsorbet](https://github.com/Plommonsorbet))
 
 [0.5.5](https://github.com/casey/just/releases/tag/v0.5.5) - 2020-1-15
 ----------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -2766,7 +2766,7 @@ directory.
 
 Environment files are only loaded for the root justfile, and loaded environment
 variables are available in submodules. Settings in submodules that affect
-enviroment file loading are ignored.
+environment file loading are ignored.
 
 Recipes in submodules without the `[no-cd]` attribute run with the working
 directory set to the directory containing the submodule source file.
@@ -2939,7 +2939,7 @@ foo argument:
 ```
 
 This preserves `just`'s ability to catch variable name typos before running,
-for example if you were to write `{{arument}}`, but will not do what you want
+for example if you were to write `{{argument}}`, but will not do what you want
 if the value of `argument` contains single quotes.
 
 #### Positional Arguments
@@ -2978,7 +2978,7 @@ foo $argument:
 ```
 
 This defeats `just`'s ability to catch typos, for example if you type
-`$argumant`, but works for all possible values of `argument`, including those
+`$argument`, but works for all possible values of `argument`, including those
 with double quotes.
 
 ### Configuring the Shell

--- a/README.md
+++ b/README.md
@@ -2978,7 +2978,7 @@ foo $argument:
 ```
 
 This defeats `just`'s ability to catch typos, for example if you type
-`$argument`, but works for all possible values of `argument`, including those
+`$argumant`, but works for all possible values of `argument`, including those
 with double quotes.
 
 ### Configuring the Shell

--- a/README.中文.md
+++ b/README.中文.md
@@ -2242,7 +2242,7 @@ foo $argument:
   touch "$argument"
 ```
 
-这就破坏了 `just` 捕捉拼写错误的能力，例如你输入 `$argument`，但对 `argument` 的所有可能的值都有效，包括那些带双引号的。
+这就破坏了 `just` 捕捉拼写错误的能力，例如你输入 `$argumant`，但对 `argument` 的所有可能的值都有效，包括那些带双引号的。
 
 ### 配置 Shell
 

--- a/README.中文.md
+++ b/README.中文.md
@@ -2242,7 +2242,7 @@ foo $argument:
   touch "$argument"
 ```
 
-这就破坏了 `just` 捕捉拼写错误的能力，例如你输入 `$argumant`，但对 `argument` 的所有可能的值都有效，包括那些带双引号的。
+这就破坏了 `just` 捕捉拼写错误的能力，例如你输入 `$argument`，但对 `argument` 的所有可能的值都有效，包括那些带双引号的。
 
 ### 配置 Shell
 

--- a/www/install.sh
+++ b/www/install.sh
@@ -105,7 +105,7 @@ if [ -z ${tag-} ]; then
 fi
 
 if [ -z ${target-} ]; then
-  # bash compiled with MINGW (e.g. git-bash, used in github windows runnners),
+  # bash compiled with MINGW (e.g. git-bash, used in github windows runners),
   # unhelpfully includes a version suffix in `uname -s` output, so handle that.
   # e.g. MINGW64_NT-10-0.19044
   kernel=$(uname -s | cut -d- -f1)


### PR DESCRIPTION
% `codespell --ignore-words-list=crate,fo,ser --write-changes`
* https://github.com/codespell-project/codespell/blob/master/README.rst