### PR TITLE
GitHub Actions: Remove actions-rs/toolchain which is end-of-life

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,12 +22,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Rust Toolchain Components
-      uses: actions-rs/toolchain@v1
-      with:
-        components: clippy, rustfmt
-        toolchain: stable
-
     - uses: Swatinem/rust-cache@v2
 
     - name: Clippy
@@ -58,12 +52,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Install Rust Toolchain Components
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
 
     - uses: Swatinem/rust-cache@v2
 
@@ -117,13 +105,6 @@ jobs:
         takeown /F C:\Windows\System32\bash.exe
         icacls C:\Windows\System32\bash.exe /grant administrators:F
         del C:\Windows\System32\bash.exe
-
-    - name: Install Rust Toolchain Components
-      uses: actions-rs/toolchain@v1
-      with:
-        components: clippy, rustfmt
-        override: true
-        toolchain: stable
 
     - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,13 +49,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Rust Toolchain Components
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        target: ${{ matrix.target }}
-        toolchain: stable
-
     - name: Install AArch64 Toolchain
       if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
       run: |

--- a/bin/package
+++ b/bin/package
@@ -10,7 +10,7 @@ echo "Packaging just $VERSION for $TARGET…"
 test -f Cargo.lock || cargo generate-lockfile
 
 echo "Install rust toolchain for $TARGET…"
-rustup toolchain add --profile minimal $TARGET
+rustup target add $TARGET
 
 echo "Building just…"
 RUSTFLAGS="--deny warnings --codegen target-feature=+crt-static $TARGET_RUSTFLAGS" \

--- a/bin/package
+++ b/bin/package
@@ -5,14 +5,14 @@ set -euxo pipefail
 VERSION=${REF#"refs/tags/"}
 DIST=`pwd`/dist
 
-echo "Packaging just $VERSION for $TARGET…"
+echo "Packaging just $VERSION for $TARGET..."
 
 test -f Cargo.lock || cargo generate-lockfile
 
-echo "Install rust toolchain for $TARGET…"
+echo "Install rust toolchain for $TARGET..."
 rustup target add $TARGET
 
-echo "Building just…"
+echo "Building just..."
 RUSTFLAGS="--deny warnings --codegen target-feature=+crt-static $TARGET_RUSTFLAGS" \
   cargo build --bin just --target $TARGET --release
 EXECUTABLE=target/$TARGET/release/just
@@ -21,7 +21,7 @@ if [[ $OS == windows-latest ]]; then
   EXECUTABLE=$EXECUTABLE.exe
 fi
 
-echo "Copying release files…"
+echo "Copying release files..."
 mkdir dist
 cp -r \
   $EXECUTABLE \
@@ -35,7 +35,7 @@ cp -r \
   $DIST
 
 cd $DIST
-echo "Creating release archive…"
+echo "Creating release archive..."
 case $OS in
   ubuntu-latest | macos-latest)
     ARCHIVE=$DIST/just-$VERSION-$TARGET.tar.gz

--- a/bin/package
+++ b/bin/package
@@ -5,11 +5,14 @@ set -euxo pipefail
 VERSION=${REF#"refs/tags/"}
 DIST=`pwd`/dist
 
-echo "Packaging just $VERSION for $TARGET..."
+echo "Packaging just $VERSION for $TARGET…"
 
 test -f Cargo.lock || cargo generate-lockfile
 
-echo "Building just..."
+echo "Install rust toolchain for $TARGET…"
+rustup toolchain add $TARGET
+
+echo "Building just…"
 RUSTFLAGS="--deny warnings --codegen target-feature=+crt-static $TARGET_RUSTFLAGS" \
   cargo build --bin just --target $TARGET --release
 EXECUTABLE=target/$TARGET/release/just
@@ -18,7 +21,7 @@ if [[ $OS == windows-latest ]]; then
   EXECUTABLE=$EXECUTABLE.exe
 fi
 
-echo "Copying release files..."
+echo "Copying release files…"
 mkdir dist
 cp -r \
   $EXECUTABLE \
@@ -32,7 +35,7 @@ cp -r \
   $DIST
 
 cd $DIST
-echo "Creating release archive..."
+echo "Creating release archive…"
 case $OS in
   ubuntu-latest | macos-latest)
     ARCHIVE=$DIST/just-$VERSION-$TARGET.tar.gz

--- a/bin/package
+++ b/bin/package
@@ -10,7 +10,7 @@ echo "Packaging just $VERSION for $TARGET…"
 test -f Cargo.lock || cargo generate-lockfile
 
 echo "Install rust toolchain for $TARGET…"
-rustup toolchain add $TARGET
+rustup toolchain add --profile minimal $TARGET
 
 echo "Building just…"
 RUSTFLAGS="--deny warnings --codegen target-feature=+crt-static $TARGET_RUSTFLAGS" \

--- a/bin/package
+++ b/bin/package
@@ -9,7 +9,7 @@ echo "Packaging just $VERSION for $TARGET..."
 
 test -f Cargo.lock || cargo generate-lockfile
 
-echo "Install rust toolchain for $TARGET..."
+echo "Installing rust toolchain for $TARGET..."
 rustup target add $TARGET
 
 echo "Building just..."


### PR DESCRIPTION
Fixes: #1873 
* #1873 

Use the version of `cargo` that is pre-installed in the GHA base image.