### PR TITLE
Cached recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2995,12 +2995,13 @@ recipes also rerun if one of its prior (normal) dependencies has to rerun. A
 cache folder called `.justcache/` will be added to the directory containing the
 main `justfile`, and should NOT be added to version control.
 
-Cached recipes are currently an unstable feature (requires `--unstable` or
+Cached recipes are currently an unstable feature (Run with `--unstable` or
 similar) that only work with shebang or script recipes for now. Additionally,
 all prior dependencies must be cached recipes, but that is not required of
 subsequent deps.
 
 ```just
+set unstable
 variable := "My value could change by running `just variable=changed my-recipe ...`"
 
 [cached, script]
@@ -3032,7 +3033,7 @@ Until directories or glob patterns are supported as inputs to `sha256_file()`
 and `blake3_file()`, here is a useful pattern to run a cached recipe if any files in a
 directory change (or you can just pipe the output of find to sha256sum):
 
-```just
+```sh
 @# {{sha256(`find $DIR -type f -exec sha256sum "{}" ";"`)}}
 ```
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -155,7 +155,8 @@ impl<'run, 'src> Analyzer<'run, 'src> {
     for recipe in recipes.values() {
       if recipe.attributes.contains(AttributeDiscriminant::Script) {
         unstable_features.insert(UnstableFeature::ScriptAttribute);
-        break;
+      } else if recipe.attributes.contains(AttributeDiscriminant::Cached) {
+        unstable_features.insert(UnstableFeature::CachedRecipes);
       }
     }
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -9,6 +9,7 @@ use super::*;
 #[strum_discriminants(derive(EnumString, Ord, PartialOrd))]
 #[strum_discriminants(strum(serialize_all = "kebab-case"))]
 pub(crate) enum Attribute<'src> {
+  Cached,
   Confirm(Option<StringLiteral<'src>>),
   Doc(Option<StringLiteral<'src>>),
   ExitMessage,
@@ -33,7 +34,8 @@ impl AttributeDiscriminant {
     match self {
       Self::Confirm | Self::Doc => 0..=1,
       Self::Group | Self::Extension | Self::WorkingDirectory => 1..=1,
-      Self::ExitMessage
+      Self::Cached
+      | Self::ExitMessage
       | Self::Linux
       | Self::Macos
       | Self::NoCd
@@ -78,6 +80,7 @@ impl<'src> Attribute<'src> {
     }
 
     Ok(match discriminant {
+      AttributeDiscriminant::Cached => Self::Cached,
       AttributeDiscriminant::Confirm => Self::Confirm(arguments.into_iter().next()),
       AttributeDiscriminant::Doc => Self::Doc(arguments.into_iter().next()),
       AttributeDiscriminant::ExitMessage => Self::ExitMessage,
@@ -130,7 +133,8 @@ impl Display for Attribute<'_> {
       | Self::Group(argument)
       | Self::WorkingDirectory(argument) => write!(f, "({argument})")?,
       Self::Script(Some(shell)) => write!(f, "({shell})")?,
-      Self::Confirm(None)
+      Self::Cached
+      | Self::Confirm(None)
       | Self::Doc(None)
       | Self::ExitMessage
       | Self::Linux

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -54,6 +54,13 @@ impl Display for CompileError<'_> {
         }
       }
       BacktickShebang => write!(f, "Backticks may not start with `#!`"),
+      CachedRecipeDependsOnUncachedRecipe { recipe, dependency } => {
+        write!(
+          f,
+          "Cached recipe `{}` depends on uncached recipe `{}`",
+          recipe, dependency
+        )
+      }
       CircularRecipeDependency { recipe, circle } => {
         if circle.len() == 2 {
           write!(f, "Recipe `{recipe}` depends on itself")

--- a/src/compile_error_kind.rs
+++ b/src/compile_error_kind.rs
@@ -9,6 +9,10 @@ pub(crate) enum CompileErrorKind<'src> {
     max: usize,
   },
   BacktickShebang,
+  CachedRecipeDependsOnUncachedRecipe {
+    recipe: &'src str,
+    dependency: &'src str,
+  },
   CircularRecipeDependency {
     recipe: &'src str,
     circle: Vec<&'src str>,

--- a/src/unresolved_recipe.rs
+++ b/src/unresolved_recipe.rs
@@ -15,6 +15,8 @@ impl<'src> UnresolvedRecipe<'src> {
       resolved.len()
     );
 
+    let self_cached = self.attributes.contains(AttributeDiscriminant::Cached);
+
     for (unresolved, resolved) in self.dependencies.iter().zip(&resolved) {
       assert_eq!(unresolved.recipe.lexeme(), resolved.name.lexeme());
       if !resolved
@@ -29,6 +31,15 @@ impl<'src> UnresolvedRecipe<'src> {
               found: unresolved.arguments.len(),
               min: resolved.min_arguments(),
               max: resolved.max_arguments(),
+            }),
+        );
+      } else if self_cached && !resolved.attributes.contains(AttributeDiscriminant::Cached) {
+        return Err(
+          self
+            .name
+            .error(CompileErrorKind::CachedRecipeDependsOnUncachedRecipe {
+              recipe: self.name(),
+              dependency: resolved.name(),
             }),
         );
       }

--- a/src/unstable_feature.rs
+++ b/src/unstable_feature.rs
@@ -2,6 +2,7 @@ use super::*;
 
 #[derive(Copy, Clone, Debug, PartialEq, Ord, Eq, PartialOrd)]
 pub(crate) enum UnstableFeature {
+  CachedRecipes,
   FormatSubcommand,
   LogicalOperators,
   ScriptAttribute,
@@ -12,6 +13,7 @@ pub(crate) enum UnstableFeature {
 impl Display for UnstableFeature {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
     match self {
+      Self::CachedRecipes => write!(f, "The [cached] attribute is currently unstable."),
       Self::FormatSubcommand => write!(f, "The `--fmt` command is currently unstable."),
       Self::LogicalOperators => write!(
         f,

--- a/tests/cached_recipes.rs
+++ b/tests/cached_recipes.rs
@@ -1,6 +1,20 @@
 use super::*;
 
 #[test]
+fn cached_attribute_is_unstable() {
+  Test::new()
+    .justfile(
+      "
+    [cached]
+    recipe:
+  ",
+    )
+    .stderr_regex(r#"error: The \[cached\] attribute is currently unstable\..*"#)
+    .status(1)
+    .run();
+}
+
+#[test]
 fn cached_recipe_cannot_depend_on_uncached_recipe() {
   Test::new()
     .justfile(

--- a/tests/cached_recipes.rs
+++ b/tests/cached_recipes.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+#[test]
+fn cached_recipe_cannot_depend_on_uncached_recipe() {
+  Test::new()
+    .justfile(
+      "
+      set unstable
+      [cached]
+      a: b
+
+      b:
+
+      ",
+    )
+    .stderr(
+      "
+      error: Cached recipe `a` depends on uncached recipe `b`
+       ——▶ justfile:3:1
+        │
+      3 │ a: b
+        │ ^
+        ",
+    )
+    .status(1)
+    .run();
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -54,6 +54,7 @@ mod assignment;
 mod attributes;
 mod backticks;
 mod byte_order_mark;
+mod cached_recipes;
 mod changelog;
 mod choose;
 mod command;


### PR DESCRIPTION
Closes #867, #1861, cc #1685

Putting this out there to get some preliminary feedback, ask questions, and take advantage of self-inflicted peer pressure :grin:

### What's in this PR?

Adds a `[cached]` recipe attribute that marks that recipe as cacheable. A cacheable recipe only reruns when the body of the recipe changes **after variables and other `{{interpolations}}` are evaluated**. [See examples](https://github.com/casey/just/issues/867#issuecomment-1936921368) in #867.

### TODOs

- [x] Set up basic recipe caching.
- [ ] Finish work on how dependencies work with cached recipes.
- [ ] Add `--no-cache` to force run cached recipes.
- [ ] Add `--delete-cache` to delete the cache file for this project.
- [ ] Update README.
- [ ] Future PRs (I may or may not get to these):
  - [ ] Prevent double work in the evaluator when checking if the recipe needs to be run or not.
  - [ ] Expand `sha256_file()` and `blake3_file()` to take directories and/or globs, or add a more explicit `cache_files()`/`hash_files()` with this functionality.
  - [ ] Add `cache_env_vars()` to allow caching by a glob of different environment variables, e.g. `CARGO_.*`.
  - [ ] Add `cache_ignore()` to ignore certain content while caching that will always/often change such as `uuid()` and `just_pid()`.
  - [ ] Allow arguments like `[cached("expression")]` that 'stratify' a recipe so you can cache a recipe by independent targets.

### Decisions, decisions... Edge cases and questions

- [ ] Besides backtick expressions and calls to `uuid()` and `just_pid()`, are there other impure interpolations that you can think of off the top of your head? I've already scanned the README, but wanted to double check.
- [ ] Cached recipes with dependencies do not have perfectly obvious behaviors. Here is how I am going to go with it (I'm looking for feedback on these):
  - [ ] The *prior* dependencies of cached recipes must also be cached, otherwise, it's ambiguous if you would run a dependency if the main recipe matched the last cached run.
  - [ ] Subsequent dependencies (`&& after`) do not need to be cached and do not run if the recipe matches the last run. I don't think they need to run because they are typically clean-up jobs and are only needed if the recipe actually ran. If the user wants them to run every time, they should set up a separate recipe that depends on the main recipe and subsequent in that order.
  - [ ] An unchanged recipe with a changed dependency will re-run both.
  - [ ] A changed recipe with an unchanged dependency only re-run the former and not the dependency.
- [ ] Did I miss any stupidly obvious issue that needs addressing? I am writing this at 3 in the morning, so I wouldn't be surprised.