### PR TITLE
install.sh: fix shellcheck and convert to sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,11 +36,16 @@ jobs:
         git diff --no-ext-diff --quiet --exit-code
         ./tests/completions/just.bash
 
-    - name: Check for Forbidden Words
+    - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install ripgrep
-        ./bin/forbid
+        sudo apt-get install ripgrep shellcheck
+
+    - name: Check for Forbidden Words
+      run: ./bin/forbid
+
+    - name: Check Install Script
+      run: shellcheck www/install.sh
 
   pages:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -39,6 +39,9 @@ build:
 fmt:
   cargo fmt --all
 
+shellcheck:
+  shellcheck www/install.sh
+
 man:
   cargo build --features help4help2man
   help2man \


### PR DESCRIPTION
This fixes all errors from https://www.shellcheck.net/. Also change the shebang to POSIX sh, which helps improve compatibility (e.g. this can now run in Alpine contianers).

The only bash-specific thing was `pipefail` which is easy to ignore. Most of these other fixes are just [SC2086](https://www.shellcheck.net/wiki/SC2086), and remove the unused `git` variable.

Tested on an alpine docker image.