### PR TITLE
Update depedencies, remove atty and general cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e7cf40684ae96ade6232ed84582f40ce0a66efcd43a5117aef610534f8e0b8"
+checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "home"
@@ -455,7 +455,6 @@ name = "just"
 version = "1.24.0"
 dependencies = [
  "ansi_term",
- "atty",
  "blake3",
  "camino",
  "clap",
@@ -570,7 +569,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.5",
+ "hermit-abi 0.3.6",
  "libc",
 ]
 
@@ -764,41 +763,41 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -844,7 +843,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -896,7 +895,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -912,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -985,7 +984,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,40 +18,39 @@ rust-version = "1.63"
 members = [".", "bin/ref-type", "bin/generate-book", "bin/update-contributors"]
 
 [dependencies]
-ansi_term = "0.12.0"
-atty = "0.2.0"
+ansi_term = "0.12.1"
 blake3 = { version = "1.5.0", features = ["rayon", "mmap"] }
-camino = "1.0.4"
+camino = "1.1.6"
 clap = { version = "2.33.0", features = ["wrap_help"] }
-ctrlc = { version = "3.1.1", features = ["termination"] }
+ctrlc = { version = "3.4.2", features = ["termination"] }
 derivative = "2.0.0"
 dirs = "5.0.1"
-dotenvy = "0.15"
+dotenvy = "0.15.7"
 edit-distance = "2.0.0"
-env_logger = "0.11.0"
-heck = "0.4.0"
+env_logger = "0.11.2"
+heck = "0.4.1"
 lexiclean = "0.0.1"
-libc = "0.2.0"
-log = "0.4.4"
-num_cpus = "1.15.0"
-regex = "1.5.4"
-semver = "1.0.20"
-serde = { version = "1.0.130", features = ["derive", "rc"] }
-serde_json = "1.0.68"
-sha2 = "0.10"
-similar = { version = "2.1.0", features = ["unicode"] }
+libc = "0.2.153"
+log = "0.4.20"
+num_cpus = "1.16.0"
+regex = "1.10.3"
+semver = "1.0.22"
+serde = { version = "1.0.197", features = ["derive", "rc"] }
+serde_json = "1.0.114"
+sha2 = "0.10.8"
+similar = { version = "2.4.0", features = ["unicode"] }
 snafu = "0.8.0"
-strum = { version = "0.26.0", features = ["derive"] }
+strum = { version = "0.26.1", features = ["derive"] }
 target = "2.0.0"
-tempfile = "3.0.0"
-typed-arena = "2.0.1"
-unicode-width = "0.1.0"
-uuid = { version = "1.0.0", features = ["v4"] }
+tempfile = "3.10.0"
+typed-arena = "2.0.2"
+unicode-width = "0.1.11"
+uuid = { version = "1.7.0", features = ["v4"] }
 
 [dev-dependencies]
-cradle = "0.2.0"
+cradle = "0.2.2"
 executable-path = "1.0.0"
-pretty_assertions = "1.0.0"
+pretty_assertions = "1.4.0"
 temptree = "0.2.0"
 which = "6.0.0"
 yaml-rust = "0.4.5"
@@ -79,6 +78,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [profile.release]
 lto = true
+codegen-units = 1
+strip = true
 
 [[test]]
 name = "integration"

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,7 +1,7 @@
 use {
   super::*,
   ansi_term::{ANSIGenericString, Color::*, Prefix, Style, Suffix},
-  atty::Stream,
+  std::io::{self, IsTerminal},
 };
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -16,9 +16,9 @@ impl Color {
     Self { style, ..self }
   }
 
-  fn redirect(self, stream: Stream) -> Self {
+  fn redirect<T: IsTerminal>(self, stream: T) -> Self {
     Self {
-      atty: atty::is(stream),
+      atty: stream.is_terminal(),
       ..self
     }
   }
@@ -53,11 +53,11 @@ impl Color {
   }
 
   pub(crate) fn stderr(self) -> Self {
-    self.redirect(Stream::Stderr)
+    self.redirect(io::stderr())
   }
 
   pub(crate) fn stdout(self) -> Self {
-    self.redirect(Stream::Stdout)
+    self.redirect(io::stdout())
   }
 
   pub(crate) fn context(self) -> Self {


### PR DESCRIPTION
This pr is fairly simple. 
- It updates all the dependencies to their latest version, purposely omitting clap since that needs a proper migrations. 
- It  makes the manifest much cleaner by making all the dependencies versions consistent with each other whereas before some of them only specified the major version. 
- The atty crate is also removed since it is no longer maintained and has security vulnerabilities, instead it replaces it with the std implementation.
- Finally it also makes the release profile more optimized and smaller by reducing the codegen units and stripping

I plan to make more prs to modernize the codebase and replace other dependencies. This project is old enough (relatively speaking) that the rust ecosystem has grown a lot since. This pr is a good starting point to ensure a clean and updated base to work on