### PR TITLE
Set codegen-units to 1 to reduce binary size for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [profile.release]
 lto = true
+codegen-units = 1
 
 [[test]]
 name = "integration"


### PR DESCRIPTION

* Before: 6737560
* After: 6506000

(per #1919)