### PR TITLE
Implement loading justfile from stdin

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -129,6 +129,7 @@ pub(crate) enum Error<'src> {
   },
   NoChoosableRecipes,
   NoDefaultRecipe,
+  JustfileIsNotAFile,
   NoRecipes,
   NotConfirmed {
     recipe: &'src str,
@@ -403,6 +404,7 @@ impl<'src> ColorDisplay for Error<'src> {
           _ => write!(f, "Recipe `{recipe}` could not be run because of an IO error while launching the shell: {io_error}"),
         }?;
       }
+      JustfileIsNotAFile => write!(f, "Justfile is not a file.")?,
       Load { io_error, path } => {
         write!(f, "Failed to read justfile at `{}`: {io_error}", path.display())?;
       }

--- a/src/function.rs
+++ b/src/function.rs
@@ -397,12 +397,14 @@ fn justfile(context: Context) -> FunctionResult {
     .context
     .search
     .justfile
+    .as_ref()
+    .ok_or(String::from("Justfile is not a file"))?
     .to_str()
     .map(str::to_owned)
     .ok_or_else(|| {
       format!(
-        "Justfile path is not valid unicode: {}",
-        context.evaluator.context.search.justfile.display()
+        "Justfile path is not valid unicode: {:?}",
+        context.evaluator.context.search.justfile
       )
     })
 }
@@ -413,11 +415,13 @@ fn justfile_directory(context: Context) -> FunctionResult {
     .context
     .search
     .justfile
+    .as_ref()
+    .ok_or(String::from("Justfile is not a file"))?
     .parent()
     .ok_or_else(|| {
       format!(
-        "Could not resolve justfile directory. Justfile `{}` had no parent.",
-        context.evaluator.context.search.justfile.display()
+        "Could not resolve justfile directory. Justfile `{:?}` had no parent.",
+        context.evaluator.context.search.justfile
       )
     })?;
 
@@ -450,6 +454,8 @@ fn module_directory(context: Context) -> FunctionResult {
     .context
     .search
     .justfile
+    .as_ref()
+    .ok_or(String::from("Module is not a file"))?
     .parent()
     .unwrap()
     .join(&context.evaluator.context.module.source)
@@ -478,6 +484,8 @@ fn module_file(context: Context) -> FunctionResult {
     .context
     .search
     .justfile
+    .as_ref()
+    .ok_or(String::from("Module is not a file"))?
     .parent()
     .unwrap()
     .join(&context.evaluator.context.module.source)
@@ -589,6 +597,8 @@ fn source_directory(context: Context) -> FunctionResult {
     .context
     .search
     .justfile
+    .as_ref()
+    .ok_or(String::from("Source is not a file"))?
     .parent()
     .unwrap()
     .join(context.name.token.path)
@@ -610,6 +620,8 @@ fn source_file(context: Context) -> FunctionResult {
     .context
     .search
     .justfile
+    .as_ref()
+    .ok_or(String::from("Source is not a file"))?
     .parent()
     .unwrap()
     .join(context.name.token.path)

--- a/src/search_error.rs
+++ b/src/search_error.rs
@@ -16,6 +16,8 @@ pub(crate) enum SearchError {
     directory: PathBuf,
     io_error: io::Error,
   },
+  #[snafu(display("Justfile is not a file"))]
+  JustfileIsNotAFile,
   #[snafu(display("Justfile path had no parent: {}", path.display()))]
   JustfileHadNoParent { path: PathBuf },
   #[snafu(display(

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -104,7 +104,8 @@ impl Subcommand {
     arguments: &[String],
     overrides: &BTreeMap<String, String>,
   ) -> RunResult<'src> {
-    let starting_parent = search.justfile.parent().as_ref().unwrap().lexiclean();
+    let justfile = search.justfile.as_ref().ok_or(Error::JustfileIsNotAFile)?;
+    let starting_parent = justfile.parent().as_ref().unwrap().lexiclean();
 
     loop {
       let justfile = &compilation.justfile;
@@ -119,17 +120,18 @@ impl Subcommand {
       if fallback {
         if let Err(err @ (Error::UnknownRecipe { .. } | Error::UnknownSubmodule { .. })) = result {
           search = search.search_parent_directory().map_err(|_| err)?;
+          let justfile = search.justfile.as_ref().ok_or(Error::JustfileIsNotAFile)?;
 
           if config.verbosity.loquacious() {
             eprintln!(
               "Trying {}",
               starting_parent
-                .strip_prefix(search.justfile.parent().unwrap())
+                .strip_prefix(justfile.parent().unwrap())
                 .unwrap()
                 .components()
                 .map(|_| path::Component::ParentDir)
                 .collect::<PathBuf>()
-                .join(search.justfile.file_name().unwrap())
+                .join(justfile.file_name().unwrap())
                 .display()
             );
           }
@@ -149,7 +151,9 @@ impl Subcommand {
     loader: &'src Loader,
     search: &Search,
   ) -> RunResult<'src, Compilation<'src>> {
-    let compilation = Compiler::compile(loader, &search.justfile)?;
+    let justfile = search.justfile.as_ref().ok_or(Error::JustfileIsNotAFile)?;
+
+    let compilation = Compiler::compile(loader, justfile)?;
 
     compilation.justfile.check_unstable(config)?;
 
@@ -192,9 +196,10 @@ impl Subcommand {
     let chooser = if let Some(chooser) = chooser {
       OsString::from(chooser)
     } else {
+      let justfile = search.justfile.as_ref().ok_or(Error::JustfileIsNotAFile)?;
       let mut chooser = OsString::new();
       chooser.push("fzf --multi --preview 'just --unstable --color always --justfile \"");
-      chooser.push(&search.justfile);
+      chooser.push(justfile);
       chooser.push("\" --show {}'");
       chooser
     };
@@ -279,9 +284,10 @@ impl Subcommand {
       .or_else(|| env::var_os("EDITOR"))
       .unwrap_or_else(|| "vim".into());
 
+    let justfile = search.justfile.as_ref().ok_or(Error::JustfileIsNotAFile)?;
     let error = Command::new(&editor)
       .current_dir(&search.working_directory)
-      .arg(&search.justfile)
+      .arg(&justfile)
       .status();
 
     let status = match error {
@@ -333,36 +339,38 @@ impl Subcommand {
       };
     }
 
-    fs::write(&search.justfile, formatted).map_err(|io_error| Error::WriteJustfile {
-      justfile: search.justfile.clone(),
+    let justfile = search.justfile.as_ref().ok_or(Error::JustfileIsNotAFile)?;
+
+    fs::write(justfile, formatted).map_err(|io_error| Error::WriteJustfile {
+      justfile: justfile.clone(),
       io_error,
     })?;
 
     if config.verbosity.loud() {
-      eprintln!("Wrote justfile to `{}`", search.justfile.display());
+      eprintln!("Wrote justfile to `{}`", justfile.display());
     }
 
     Ok(())
   }
 
   fn init(config: &Config) -> RunResult<'static> {
-    let search = Search::init(&config.search_config, &config.invocation_directory)?;
+    let justfile = Search::init(&config.search_config, &config.invocation_directory)?;
 
-    if search.justfile.is_file() {
+    if justfile.is_file() {
       return Err(Error::InitExists {
-        justfile: search.justfile,
+        justfile: justfile.clone(),
       });
     }
 
-    if let Err(io_error) = fs::write(&search.justfile, INIT_JUSTFILE) {
+    if let Err(io_error) = fs::write(&justfile, INIT_JUSTFILE) {
       return Err(Error::WriteJustfile {
-        justfile: search.justfile,
+        justfile: justfile.clone(),
         io_error,
       });
     }
 
     if config.verbosity.loud() {
-      eprintln!("Wrote justfile to `{}`", search.justfile.display());
+      eprintln!("Wrote justfile to `{}`", justfile.display());
     }
 
     Ok(())

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -20,7 +20,7 @@ pub(crate) fn search(config: &Config) -> Search {
   let justfile = working_directory.join("justfile");
 
   Search {
-    justfile,
+    justfile: Some(justfile),
     working_directory,
   }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -100,6 +100,7 @@ mod shell;
 mod shell_expansion;
 mod show;
 mod slash_operator;
+mod stdin;
 mod string;
 mod subsequents;
 mod summary;

--- a/tests/stdin.rs
+++ b/tests/stdin.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+#[test]
+fn list_recipes_loaded_from_stdin() {
+  Test::new()
+    .no_justfile()
+    .arg("--list")
+    .stdin(
+      r#"
+        one:
+            echo 111
+
+        two:
+            echo 222
+
+        three:
+            echo 333
+    "#,
+    )
+    .stdout(
+      r#"
+        one
+        two
+        three
+    "#,
+    )
+    .status(0)
+    .run();
+}


### PR DESCRIPTION
I think it would be nice to have the possibility to pipe justfiles into just, like so:
```bash
cat input.txt | just --dump --justfile - > output.txt
```
It would work by detecting a special symbol "-" as the -f / --justfile argument.

Benefits:
 - Some code editors like helix require this in order to make auto formatting to work,
 - Many command line tools work like this and it seems it will not hurt to have,

The plan:
 1. Move `Search{}` functionality into `Source{}`
 2. Implement `Source::from_stdin()`
 3. Add "-" detection to the argument parser.
 
 Here is the first of the commits, more commits will be added while work progresses.