### PR TITLE
Correct Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,8 +726,8 @@ default:
   @just --list
 ```
 
-Note that you may need to add `--justfile {{justfile()}}` to the line above
-above. Without it, if you executed `just -f /some/distant/justfile -d .` or
+Note that you may need to add `--justfile {{justfile()}}` to the line above.
+Without it, if you executed `just -f /some/distant/justfile -d .` or
 `just -f ./non-standard-justfile`, the plain `just --list` inside the recipe
 would not necessarily use the file you provided. It would try to find a
 justfile in your current path, maybe even resulting in a `No justfile found`


### PR DESCRIPTION
As I was reading through the README, I noticed there were two words repeated immediately after one another. This fixes the typo.