### PR TITLE
I think accepting an all as param is misguiding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1588,7 +1588,7 @@ that requires confirmation.
 
 ```just
 [confirm]
-delete all:
+delete-all:
   rm -rf *
 ```
 


### PR DESCRIPTION
Delete is taking param all, which is not used, and this may cause confusion as if "delete all" is name of the command. so, for clarification, I added a hyphen.