### PR TITLE
Port some functions from make

### DIFF
--- a/src/assignment_resolver.rs
+++ b/src/assignment_resolver.rs
@@ -84,6 +84,15 @@ impl<'src: 'run, 'run> AssignmentResolver<'src, 'run> {
           }
           Ok(())
         }
+        Thunk::UnaryPlus {
+          args: ([a], rest), ..
+        } => {
+          self.resolve_expression(a)?;
+          for arg in rest {
+            self.resolve_expression(arg)?;
+          }
+          Ok(())
+        }
         Thunk::Binary { args: [a, b], .. } => {
           self.resolve_expression(a)?;
           self.resolve_expression(b)

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -72,6 +72,8 @@ impl<'src, 'run> Evaluator<'src, 'run> {
           dotenv: self.dotenv,
           invocation_directory: &self.config.invocation_directory,
           search: self.search,
+          settings: self.settings,
+          config: self.config,
         };
 
         match thunk {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -109,6 +109,24 @@ impl<'src, 'run> Evaluator<'src, 'run> {
               message,
             })
           }
+          UnaryPlus {
+            name,
+            function,
+            args: ([a], rest),
+            ..
+          } => {
+            let a = self.evaluate_expression(a)?;
+
+            let mut rest_evaluated = Vec::new();
+            for arg in rest {
+              rest_evaluated.push(self.evaluate_expression(arg)?);
+            }
+
+            function(&context, &a, &rest_evaluated).map_err(|message| Error::FunctionCall {
+              function: *name,
+              message,
+            })
+          }
           Binary {
             name,
             function,

--- a/src/function.rs
+++ b/src/function.rs
@@ -443,11 +443,7 @@ fn shell(context: &FunctionContext, cmdlike: &str, extras: &[String]) -> Result<
 
   let stdout = InterruptHandler::guard(|| {
     output(shelled_cmd).map_err(|output_error| output_error.to_string())
-  })?
-  .trim() // as per Make
-  .lines()
-  .collect::<Vec<&str>>()
-  .join(" "); // as per Make
+  })?;
 
   Ok(stdout)
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -21,6 +21,7 @@ pub(crate) fn get(name: &str) -> Option<Function> {
   let function = match name {
     "absolute_path" => Unary(absolute_path),
     "arch" => Nullary(arch),
+    "addprefix" => Binary(addprefix),
     "blake3" => Unary(blake3),
     "blake3_file" => Unary(blake3_file),
     "canonicalize" => Unary(canonicalize),
@@ -253,6 +254,16 @@ fn invocation_directory_native(context: &FunctionContext) -> Result<String, Stri
         context.invocation_directory.display()
       )
     })
+}
+
+fn addprefix(_context: &FunctionContext, pref: &str, base: &str) -> Result<String, String> {
+  Ok(
+    base
+      .split(" ")
+      .map(|s| format!("{pref}{s}"))
+      .collect::<Vec<String>>()
+      .join(" "),
+  )
 }
 
 fn join(

--- a/src/function.rs
+++ b/src/function.rs
@@ -22,6 +22,7 @@ pub(crate) fn get(name: &str) -> Option<Function> {
     "absolute_path" => Unary(absolute_path),
     "arch" => Nullary(arch),
     "addprefix" => Binary(addprefix),
+    "addsuffix" => Binary(addsuffix),
     "blake3" => Unary(blake3),
     "blake3_file" => Unary(blake3_file),
     "canonicalize" => Unary(canonicalize),
@@ -261,6 +262,16 @@ fn addprefix(_context: &FunctionContext, pref: &str, base: &str) -> Result<Strin
     base
       .split(" ")
       .map(|s| format!("{pref}{s}"))
+      .collect::<Vec<String>>()
+      .join(" "),
+  )
+}
+
+fn addsuffix(_context: &FunctionContext, suf: &str, base: &str) -> Result<String, String> {
+  Ok(
+    base
+      .split(" ")
+      .map(|s| format!("{s}{suf}"))
       .collect::<Vec<String>>()
       .join(" "),
   )

--- a/src/function_context.rs
+++ b/src/function_context.rs
@@ -4,4 +4,6 @@ pub(crate) struct FunctionContext<'run> {
   pub(crate) dotenv: &'run BTreeMap<String, String>,
   pub(crate) invocation_directory: &'run Path,
   pub(crate) search: &'run Search,
+  pub(crate) settings: &'run Settings<'run>,
+  pub(crate) config: &'run Config,
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -119,6 +119,17 @@ impl<'src> Node<'src> for Expression<'src> {
               tree.push_mut(b.tree());
             }
           }
+          UnaryPlus {
+            name,
+            args: ([a], rest),
+            ..
+          } => {
+            tree.push_mut(name.lexeme());
+            tree.push_mut(a.tree());
+            for arg in rest {
+              tree.push_mut(arg.tree());
+            }
+          }
           Binary {
             name, args: [a, b], ..
           } => {

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -246,6 +246,20 @@ impl Expression {
             arguments,
           }
         }
+        full::Thunk::UnaryPlus {
+          name,
+          args: ([a], rest),
+          ..
+        } => {
+          let mut arguments = vec![Expression::new(a)];
+          for arg in rest {
+            arguments.push(Expression::new(arg));
+          }
+          Expression::Call {
+            name: name.lexeme().to_owned(),
+            arguments,
+          }
+        }
         full::Thunk::Binary {
           name, args: [a, b], ..
         } => Expression::Call {

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -20,6 +20,12 @@ pub(crate) enum Thunk<'src> {
     function: fn(&FunctionContext, &str, Option<&str>) -> Result<String, String>,
     args: (Box<Expression<'src>>, Box<Option<Expression<'src>>>),
   },
+  UnaryPlus {
+    name: Name<'src>,
+    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    function: fn(&FunctionContext, &str, &[String]) -> Result<String, String>,
+    args: ([Box<Expression<'src>>; 1], Vec<Expression<'src>>),
+  },
   Binary {
     name: Name<'src>,
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
@@ -46,6 +52,7 @@ impl<'src> Thunk<'src> {
       Self::Nullary { name, .. }
       | Self::Unary { name, .. }
       | Self::UnaryOpt { name, .. }
+      | Self::UnaryPlus { name, .. }
       | Self::Binary { name, .. }
       | Self::BinaryPlus { name, .. }
       | Self::Ternary { name, .. } => name,
@@ -76,6 +83,15 @@ impl<'src> Thunk<'src> {
           Ok(Thunk::UnaryOpt {
             function,
             args: (a, b),
+            name,
+          })
+        }
+        (Function::UnaryPlus(function), 1..=usize::MAX) => {
+          let rest = arguments.drain(1..).collect();
+          let a = Box::new(arguments.pop().unwrap());
+          Ok(Thunk::UnaryPlus {
+            function,
+            args: ([a], rest),
             name,
           })
         }
@@ -133,6 +149,17 @@ impl Display for Thunk<'_> {
           write!(f, "{}({a})", name.lexeme())
         }
       }
+      UnaryPlus {
+        name,
+        args: ([a], rest),
+        ..
+      } => {
+        write!(f, "{}({a}", name.lexeme())?;
+        for arg in rest {
+          write!(f, ", {arg}")?;
+        }
+        write!(f, ")")
+      }
       Binary {
         name, args: [a, b], ..
       } => write!(f, "{}({a}, {b})", name.lexeme()),
@@ -173,6 +200,11 @@ impl<'src> Serialize for Thunk<'src> {
         seq.serialize_element(a)?;
         if let Some(b) = opt_b.as_ref() {
           seq.serialize_element(b)?;
+        }
+      }
+      Self::UnaryPlus { args, .. } => {
+        for arg in args.0.iter().map(Box::as_ref).chain(&args.1) {
+          seq.serialize_element(arg)?;
         }
       }
       Self::Binary { args, .. } => {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -28,6 +28,14 @@ impl<'expression, 'src> Iterator for Variables<'expression, 'src> {
               self.stack.push(b);
             }
           }
+          Thunk::UnaryPlus {
+            args: ([a], rest), ..
+          } => {
+            let first: &[&Expression] = &[a];
+            for arg in first.iter().copied().chain(rest).rev() {
+              self.stack.push(arg);
+            }
+          }
           Thunk::Binary { args, .. } => {
             for arg in args.iter().rev() {
               self.stack.push(arg);

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -496,6 +496,24 @@ fn addprefix() {
 }
 
 #[test]
+fn addsuffix() {
+  assert_eval_eq("addsuffix('8', 'r s t')", "r8 s8 t8");
+  assert_eval_eq("addsuffix('.c', 'main sar x11')", "main.c sar.c x11.c");
+  assert_eval_eq("addsuffix('-', 'c v h y')", "c- v- h- y-");
+  assert_eval_eq(
+    "addsuffix('0000', '11 10 01 00')",
+    "110000 100000 010000 000000",
+  );
+}
+
+#[test]
+fn addsuffix_addprefix() {
+  assert_eval_eq(
+    "addsuffix('=', addprefix(';', addsuffix('x', addprefix('-', 'i o u'))))",
+    ";-ix= ;-ox= ;-ux=",
+  );
+}
+#[test]
 #[cfg(not(windows))]
 fn join() {
   assert_eval_eq("join('a', 'b', 'c', 'd')", "a/b/c/d");

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -482,6 +482,20 @@ fn trim_end() {
 }
 
 #[test]
+fn addprefix() {
+  assert_eval_eq("addprefix('8', 'r s t')", "8r 8s 8t");
+  assert_eval_eq(
+    "addprefix('src/', 'main sar x11')",
+    "src/main src/sar src/x11",
+  );
+  assert_eval_eq("addprefix('-', 'c v h y')", "-c -v -h -y");
+  assert_eval_eq(
+    "addprefix('0000', '11 10 01 00')",
+    "000011 000010 000001 000000",
+  );
+}
+
+#[test]
 #[cfg(not(windows))]
 fn join() {
   assert_eval_eq("join('a', 'b', 'c', 'd')", "a/b/c/d");

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -513,6 +513,44 @@ fn addsuffix_addprefix() {
     ";-ix= ;-ox= ;-ux=",
   );
 }
+
+#[test]
+fn shell_no_arg_provided() {
+  Test::new()
+    .justfile("var := shell()")
+    .args(["--evaluate"])
+    .stderr(
+      "
+      error: Function `shell` called with 0 arguments but takes 1 or more
+       ——▶ justfile:1:8
+        │
+      1 │ var := shell()
+        │        ^^^^^
+      ",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn shell_minimal() {
+  Test::new()
+    .justfile(
+      r"
+      _ := '_'
+      var := shell('echo $0 $1', _, 'justice')
+      _:
+        @echo {{var}}",
+    )
+    .stdout(
+      "
+      _ justice
+      ",
+    )
+    .status(EXIT_SUCCESS)
+    .run();
+}
+
 #[test]
 #[cfg(not(windows))]
 fn join() {


### PR DESCRIPTION
This PR adds some useful functions found in [make](https://www.gnu.org/software/make/).

Please read the corresponding commit's message for how each works
#### To be added
- [ ] addprefix() ([#8c9a965](https://github.com/casey/just/pull/2012/commits/8c9a965e7304d8a2310c069630fc85af24ca7060))
- [ ] addsuffix() ([#766c817](https://github.com/casey/just/pull/2012/commits/766c817a4069e844b07fa8aa81ba59126624bcdf))
- [ ] shell() ([#f3fcf7a](https://github.com/casey/just/pull/2012/commits/f3fcf7aa0805ab161dbd9169e647269b3c24b86c)) - let one write something similar to this: 
  ```just
  var := `ls -hl {{ join('/usr/','bin','python3') }} {{ addsuffix('.rs', 'lib main runner') }}`
  ```
  as
  ```just
  var := shell("ls -hl $1 $2", 'justscript', join('/usr/', 'bin/', 'python3'), addsuffix('.rs', 'lib main runner'))
  ```
- [ ] call() - user-defined functions, when introduced, will benefit from this
- [ ] basename()
- [ ] wildcard()
