### PR TITLE
Clarify that janus operates on public justfiles only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,5 +116,5 @@ jobs:
 
     - name: Test install.sh
       run: |
-        bash www/install.sh --to /tmp --tag 1.0.0
+        bash www/install.sh --to /tmp --tag 1.25.0
         /tmp/just --version

--- a/README.md
+++ b/README.md
@@ -3224,9 +3224,9 @@ under this license.
 
 ### Janus
 
-[Janus](https://github.com/casey/janus) is a tool that collects and analyzes
-`justfile`s, and can determine if a new version of `just` breaks or changes the
-interpretation of existing `justfile`s.
+[Janus](https://github.com/casey/janus) is a tool for checking whether a change
+to `just` breaks or changes the interpretation of existing `justfile`s. It
+collects and analyzes public `justfile`s on GitHub.
 
 Before merging a particularly large or gruesome change, Janus should be run to
 make sure that nothing breaks. Don't worry about running Janus yourself, Casey


### PR DESCRIPTION
Fixes #2020.