### PR TITLE
1748-dotenv-files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ pub(crate) struct Config {
   pub(crate) color: Color,
   pub(crate) command_color: Option<ansi_term::Color>,
   pub(crate) dotenv_filename: Option<String>,
+  pub(crate) dotenv_files: Option<Vec<PathBuf>>,
   pub(crate) dotenv_path: Option<PathBuf>,
   pub(crate) dry_run: bool,
   pub(crate) dump_format: DumpFormat,
@@ -98,6 +99,7 @@ mod arg {
   pub(crate) const COMMAND_COLOR: &str = "COMMAND-COLOR";
   pub(crate) const DOTENV_FILENAME: &str = "DOTENV-FILENAME";
   pub(crate) const DOTENV_PATH: &str = "DOTENV-PATH";
+  pub(crate) const DOTENV_FILES: &str = "DOTENV-FILES";
   pub(crate) const DRY_RUN: &str = "DRY-RUN";
   pub(crate) const DUMP_FORMAT: &str = "DUMP-FORMAT";
   pub(crate) const HIGHLIGHT: &str = "HIGHLIGHT";
@@ -398,7 +400,18 @@ impl Config {
           .long("dotenv-filename")
           .takes_value(true)
           .help("Search for environment file named <DOTENV-FILENAME> instead of `.env`")
-          .conflicts_with(arg::DOTENV_PATH),
+          .conflicts_with(arg::DOTENV_PATH)
+          .conflicts_with(arg::DOTENV_FILES),
+      )
+      .arg(
+        Arg::with_name(arg::DOTENV_FILES)
+          .long("dotenv-files")
+          .takes_value(true)
+          .multiple(true)
+          .number_of_values(1)
+          .help("Search for environment list of files.")
+          .conflicts_with(arg::DOTENV_PATH)
+          .conflicts_with(arg::DOTENV_FILENAME),
       )
       .arg(
         Arg::with_name(arg::DOTENV_PATH)
@@ -653,6 +666,9 @@ impl Config {
       command_color,
       dotenv_filename: matches.value_of(arg::DOTENV_FILENAME).map(str::to_owned),
       dotenv_path: matches.value_of(arg::DOTENV_PATH).map(PathBuf::from),
+      dotenv_files: matches
+        .values_of(arg::DOTENV_FILES)
+        .map(|value| value.map(PathBuf::from).collect()),
       dry_run: matches.is_present(arg::DRY_RUN),
       dump_format: Self::dump_format_from_matches(matches)?,
       highlight: !matches.is_present(arg::NO_HIGHLIGHT),

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -8,6 +8,7 @@ pub(crate) enum Keyword {
   DotenvFilename,
   DotenvLoad,
   DotenvPath,
+  DotenvFiles,
   Else,
   Export,
   Fallback,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,17 +25,18 @@ pub(crate) use {
     fragment::Fragment, function::Function, function_context::FunctionContext,
     interrupt_guard::InterruptGuard, interrupt_handler::InterruptHandler, item::Item,
     justfile::Justfile, keyed::Keyed, keyword::Keyword, lexer::Lexer, line::Line, list::List,
-    load_dotenv::load_dotenv, loader::Loader, name::Name, namepath::Namepath, ordinal::Ordinal,
-    output::output, output_error::OutputError, parameter::Parameter, parameter_kind::ParameterKind,
-    parser::Parser, platform::Platform, platform_interface::PlatformInterface, position::Position,
-    positional::Positional, ran::Ran, range_ext::RangeExt, recipe::Recipe,
-    recipe_context::RecipeContext, recipe_resolver::RecipeResolver, scope::Scope, search::Search,
-    search_config::SearchConfig, search_error::SearchError, set::Set, setting::Setting,
-    settings::Settings, shebang::Shebang, shell::Shell, show_whitespace::ShowWhitespace,
-    source::Source, string_kind::StringKind, string_literal::StringLiteral, subcommand::Subcommand,
-    suggestion::Suggestion, table::Table, thunk::Thunk, token::Token, token_kind::TokenKind,
-    unresolved_dependency::UnresolvedDependency, unresolved_recipe::UnresolvedRecipe,
-    use_color::UseColor, variables::Variables, verbosity::Verbosity, warning::Warning,
+    load_dotenv::load_dotenv, loader::Loader, name::Name, namepath::Namepath,
+    ordered_list::OrderedList, ordinal::Ordinal, output::output, output_error::OutputError,
+    parameter::Parameter, parameter_kind::ParameterKind, parser::Parser, platform::Platform,
+    platform_interface::PlatformInterface, position::Position, positional::Positional, ran::Ran,
+    range_ext::RangeExt, recipe::Recipe, recipe_context::RecipeContext,
+    recipe_resolver::RecipeResolver, scope::Scope, search::Search, search_config::SearchConfig,
+    search_error::SearchError, set::Set, setting::Setting, settings::Settings, shebang::Shebang,
+    shell::Shell, show_whitespace::ShowWhitespace, source::Source, string_kind::StringKind,
+    string_literal::StringLiteral, subcommand::Subcommand, suggestion::Suggestion, table::Table,
+    thunk::Thunk, token::Token, token_kind::TokenKind, unresolved_dependency::UnresolvedDependency,
+    unresolved_recipe::UnresolvedRecipe, use_color::UseColor, variables::Variables,
+    verbosity::Verbosity, warning::Warning,
   },
   std::{
     cmp,
@@ -151,6 +152,7 @@ mod load_dotenv;
 mod loader;
 mod name;
 mod namepath;
+mod ordered_list;
 mod ordinal;
 mod output;
 mod output_error;

--- a/src/node.rs
+++ b/src/node.rs
@@ -284,6 +284,11 @@ impl<'src> Node<'src> for Set<'src> {
       Setting::DotenvFilename(value) | Setting::DotenvPath(value) | Setting::Tempdir(value) => {
         set.push_mut(Tree::string(value));
       }
+      Setting::DotenvFiles(ordered_list) => {
+        for item in ordered_list.list.iter() {
+          set.push_mut(Tree::string(&item.cooked));
+        }
+      }
     }
 
     set

--- a/src/ordered_list.rs
+++ b/src/ordered_list.rs
@@ -1,0 +1,23 @@
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct OrderedList<'src> {
+  pub(crate) list: Vec<StringLiteral<'src>>,
+}
+
+impl<'src> Display for OrderedList<'src> {
+  fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    write!(f, "[")?;
+    write!(
+      f,
+      "{}",
+      self
+        .list
+        .iter()
+        .map(|v| v.cooked.as_ref())
+        .collect::<Vec<&str>>()
+        .join(", ")
+    )?;
+    write!(f, "]")
+  }
+}

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -6,6 +6,7 @@ pub(crate) enum Setting<'src> {
   DotenvFilename(String),
   DotenvLoad(bool),
   DotenvPath(String),
+  DotenvFiles(OrderedList<'src>),
   Export(bool),
   Fallback(bool),
   IgnoreComments(bool),
@@ -29,6 +30,9 @@ impl<'src> Display for Setting<'src> {
       | Setting::Quiet(value)
       | Setting::WindowsPowerShell(value) => write!(f, "{value}"),
       Setting::Shell(shell) | Setting::WindowsShell(shell) => write!(f, "{shell}"),
+      Setting::DotenvFiles(value) => {
+        write!(f, "{value}")
+      }
       Setting::DotenvFilename(value) | Setting::DotenvPath(value) | Setting::Tempdir(value) => {
         write!(f, "{value:?}")
       }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,6 +9,7 @@ pub(crate) const WINDOWS_POWERSHELL_ARGS: &[&str] = &["-NoLogo", "-Command"];
 pub(crate) struct Settings<'src> {
   pub(crate) allow_duplicate_recipes: bool,
   pub(crate) dotenv_filename: Option<String>,
+  pub(crate) dotenv_files: Vec<PathBuf>,
   pub(crate) dotenv_load: Option<bool>,
   pub(crate) dotenv_path: Option<PathBuf>,
   pub(crate) export: bool,
@@ -66,6 +67,13 @@ impl<'src> Settings<'src> {
         }
         Setting::Tempdir(tempdir) => {
           settings.tempdir = Some(tempdir);
+        }
+        Setting::DotenvFiles(ordered_list) => {
+          settings.dotenv_files = ordered_list
+            .list
+            .iter()
+            .map(|path| PathBuf::from(&path.cooked))
+            .collect();
         }
       }
     }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -45,6 +45,7 @@ fn alias() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -81,6 +82,7 @@ fn assignment() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -132,6 +134,7 @@ fn body() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -195,6 +198,7 @@ fn dependencies() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -295,6 +299,7 @@ fn dependency_argument() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -358,6 +363,7 @@ fn duplicate_recipes() {
       "settings": {
         "allow_duplicate_recipes": true,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -402,6 +408,7 @@ fn doc_comment() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -432,6 +439,7 @@ fn empty_justfile() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -583,6 +591,7 @@ fn parameters() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -667,6 +676,7 @@ fn priors() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -711,6 +721,7 @@ fn private() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -755,6 +766,7 @@ fn quiet() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -811,6 +823,7 @@ fn settings() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": "filename",
+        "dotenv_files": [],
         "dotenv_load": true,
         "dotenv_path": "path",
         "export": true,
@@ -861,6 +874,7 @@ fn shebang() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -905,6 +919,7 @@ fn simple() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -952,6 +967,7 @@ fn attribute() {
       "settings": {
         "allow_duplicate_recipes": false,
         "dotenv_filename": null,
+        "dotenv_files": [],
         "dotenv_load": null,
         "dotenv_path": null,
         "export": false,
@@ -1012,6 +1028,7 @@ fn module() {
             "settings": {
               "allow_duplicate_recipes": false,
               "dotenv_filename": null,
+              "dotenv_files": [],
               "dotenv_load": null,
               "dotenv_path": null,
               "export": false,
@@ -1031,6 +1048,7 @@ fn module() {
         "settings": {
           "allow_duplicate_recipes": false,
           "dotenv_filename": null,
+          "dotenv_files": [],
           "dotenv_load": null,
           "dotenv_path": null,
           "export": false,


### PR DESCRIPTION
Dearest Reviewer,

I was looking at the parser and the format for a list of things [] was already support for shells. I reused that concept to make an ordered list of strings.

This now works
```
set dotenv-files := [".env1", ".env2"]
```

As does the command line
```
just --dotenv-files .env1 --dotenv-files .env2 echo
```

The new setting is applied last. It does not change how the other two settings currently work.

I do have a problem I cant get this to work
```
ENV := "prod"
set dotenv-files := [".env.{{ENV}}", ".env"]
```
it the `{{ENV}}` never turns in to prod.  I am using parse_string_literal.

the issue https://github.com/casey/just/issues/1748 asked about fallback justfiles. I have not used them and I would take any advice on what to change for that as well.

Any advice would be appreciated

Thanks
Becker