### PR TITLE
Set just flags through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,6 @@ cc main.c foo.c bar.c -o main
 testing… all tests passed!
 ```
 
-
 Examples
 --------
 
@@ -1395,7 +1394,6 @@ pid:
 $ just
 The process ID is: 420
 ```
-
 
 #### String Manipulation
 

--- a/README.md
+++ b/README.md
@@ -2515,22 +2515,21 @@ $ just --show polyglot
 polyglot: python js perl sh ruby
 ```
 
-The value of some command-line options can be read from environment variables
-of the form `JUST_<option name>`. For instance:
+Some command-line options can be set with environment variables. For example:
 
 ```sh
 $ export JUST_UNSTABLE=1
 $ just
 ```
 
- is equivalent to:
+Is equivalent to:
 
- ```sh
- $ just --unstable
- ```
+```sh
+$ just --unstable
+```
 
-Run `just --help` to see all the options and environment variable names.
-
+Consult `just --help` to see which options can be set from environment
+variables.
 
 ### Private Recipes
 

--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ cc main.c foo.c bar.c -o main
 testing… all tests passed!
 ```
 
+
 Examples
 --------
 
@@ -2509,7 +2510,22 @@ $ just --show polyglot
 polyglot: python js perl sh ruby
 ```
 
-Run `just --help` to see all the options.
+The value of some command-line options can be read from environment variables
+of the form `JUST_<option name>`. For instance:
+
+```sh
+$ export JUST_UNSTABLE=1
+$ just
+```
+
+ is equivalent to:
+
+ ```sh
+ $ just --unstable
+ ```
+
+Run `just --help` to see all the options and environment variable names.
+
 
 ### Private Recipes
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,6 +176,7 @@ impl Config {
       .arg(
         Arg::new(arg::COLOR)
           .long("color")
+          .env("JUST_COLOR")
           .action(ArgAction::Set)
           .value_parser(PossibleValuesParser::new(arg::COLOR_VALUES))
           .default_value(arg::COLOR_AUTO)
@@ -184,6 +185,7 @@ impl Config {
       .arg(
         Arg::new(arg::COMMAND_COLOR)
           .long("command-color")
+          .env("JUST_COMMAND_COLOR")
           .action(ArgAction::Set)
           .value_parser(PossibleValuesParser::new(arg::COMMAND_COLOR_VALUES))
           .help("Echo recipe lines in <COMMAND-COLOR>"),
@@ -193,6 +195,7 @@ impl Config {
         Arg::new(arg::DRY_RUN)
           .short('n')
           .long("dry-run")
+          .env("JUST_DRY_RUN")
           .action(ArgAction::SetTrue)
           .help("Print what just would do without doing it")
           .conflicts_with(arg::QUIET),
@@ -257,6 +260,7 @@ impl Config {
         Arg::new(arg::JUSTFILE)
           .short('f')
           .long("justfile")
+          .env("JUST_JUSTFILE")
           .action(ArgAction::Set)
           .value_parser(value_parser!(PathBuf))
           .help("Use <JUSTFILE> as justfile"),
@@ -265,6 +269,7 @@ impl Config {
         Arg::new(arg::QUIET)
           .short('q')
           .long("quiet")
+          .env("JUST_QUIET")
           .action(ArgAction::SetTrue)
           .help("Suppress all output")
           .conflicts_with(arg::DRY_RUN),
@@ -324,6 +329,7 @@ impl Config {
         Arg::new(arg::VERBOSE)
           .short('v')
           .long("verbose")
+          .env("JUST_VERBOSE")
           .action(ArgAction::Count)
           .help("Use verbose output"),
       )
@@ -331,6 +337,7 @@ impl Config {
         Arg::new(arg::WORKING_DIRECTORY)
           .short('d')
           .long("working-directory")
+          .env("JUST_WORKING_DIRECTORY")
           .action(ArgAction::Set)
           .value_parser(value_parser!(PathBuf))
           .help("Use <WORKING-DIRECTORY> as working directory. --justfile must also be set")


### PR DESCRIPTION
Configure clap to set some configuration options via `JUST_<name>` environment variables.

Resolves https://github.com/casey/just/issues/1979 and https://github.com/casey/just/issues/1934