### PR TITLE
Support append()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1397,7 +1397,8 @@ The process ID is: 420
 
 
 #### String Manipulation
-
+- `append(suffix, base)` Append `suffix` to each word in (whitespace-separated) `base`.
+  `append('/src', 'foo bar baz')` -> `'foo/src bar/src baz/src'`
 - `quote(s)` - Replace all single quotes with `'\''` and prepend and append
   single quotes to `s`. This is sufficient to escape special characters for
   many shells, including most Bourne shell descendants.

--- a/README.md
+++ b/README.md
@@ -1397,8 +1397,8 @@ The process ID is: 420
 
 
 #### String Manipulation
-- `append(suffix, base)` Append `suffix` to each word in (whitespace-separated) `base`.
-  `append('/src', 'foo bar baz')` -> `'foo/src bar/src baz/src'`
+- `append(suffix, s)`<sup>master</sup> Append `suffix` to whitespace-separated
+  strings in `s`.
 - `quote(s)` - Replace all single quotes with `'\''` and prepend and append
   single quotes to `s`. This is sufficient to escape special characters for
   many shells, including most Bourne shell descendants.

--- a/src/function.rs
+++ b/src/function.rs
@@ -106,11 +106,10 @@ fn absolute_path(context: &FunctionContext, path: &str) -> Result<String, String
   }
 }
 
-fn append(_context: &FunctionContext, suf: &str, base: &str) -> Result<String, String> {
+fn append(_context: &FunctionContext, suffix: &str, s: &str) -> Result<String, String> {
   Ok(
-    base
-      .split_whitespace()
-      .map(|s| format!("{s}{suf}"))
+    s.split_whitespace()
+      .map(|s| format!("{s}{suffix}"))
       .collect::<Vec<String>>()
       .join(" "),
   )

--- a/src/function.rs
+++ b/src/function.rs
@@ -20,7 +20,7 @@ pub(crate) enum Function {
 pub(crate) fn get(name: &str) -> Option<Function> {
   let function = match name {
     "absolute_path" => Unary(absolute_path),
-    "addsuffix" => Binary(addsuffix),
+    "append" => Binary(append),
     "arch" => Nullary(arch),
     "blake3" => Unary(blake3),
     "blake3_file" => Unary(blake3_file),
@@ -106,10 +106,10 @@ fn absolute_path(context: &FunctionContext, path: &str) -> Result<String, String
   }
 }
 
-fn addsuffix(_context: &FunctionContext, suf: &str, base: &str) -> Result<String, String> {
+fn append(_context: &FunctionContext, suf: &str, base: &str) -> Result<String, String> {
   Ok(
     base
-      .split(" ")
+      .split_whitespace()
       .map(|s| format!("{s}{suf}"))
       .collect::<Vec<String>>()
       .join(" "),

--- a/src/function.rs
+++ b/src/function.rs
@@ -20,6 +20,7 @@ pub(crate) enum Function {
 pub(crate) fn get(name: &str) -> Option<Function> {
   let function = match name {
     "absolute_path" => Unary(absolute_path),
+    "addsuffix" => Binary(addsuffix),
     "arch" => Nullary(arch),
     "blake3" => Unary(blake3),
     "blake3_file" => Unary(blake3_file),
@@ -103,6 +104,16 @@ fn absolute_path(context: &FunctionContext, path: &str) -> Result<String, String
       context.search.working_directory.display()
     )),
   }
+}
+
+fn addsuffix(_context: &FunctionContext, suf: &str, base: &str) -> Result<String, String> {
+  Ok(
+    base
+      .split(" ")
+      .map(|s| format!("{s}{suf}"))
+      .collect::<Vec<String>>()
+      .join(" "),
+  )
 }
 
 fn arch(_context: &FunctionContext) -> Result<String, String> {

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -482,13 +482,22 @@ fn trim_end() {
 }
 
 #[test]
-fn addsuffix() {
-  assert_eval_eq("addsuffix('8', 'r s t')", "r8 s8 t8");
-  assert_eval_eq("addsuffix('.c', 'main sar x11')", "main.c sar.c x11.c");
-  assert_eval_eq("addsuffix('-', 'c v h y')", "c- v- h- y-");
+fn append() {
+  assert_eval_eq("append('8', 'r s t')", "r8 s8 t8");
+  assert_eval_eq("append('.c', 'main sar x11')", "main.c sar.c x11.c");
+  assert_eval_eq("append('-', 'c v h y')", "c- v- h- y-");
   assert_eval_eq(
-    "addsuffix('0000', '11 10 01 00')",
+    "append('0000', '11 10 01 00')",
     "110000 100000 010000 000000",
+  );
+  assert_eval_eq(
+    "append('tion', '
+    Determina
+    Acquisi
+    Motiva
+    Conjuc
+    ')",
+    "Determination Acquisition Motivation Conjuction",
   );
 }
 

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -482,6 +482,17 @@ fn trim_end() {
 }
 
 #[test]
+fn addsuffix() {
+  assert_eval_eq("addsuffix('8', 'r s t')", "r8 s8 t8");
+  assert_eval_eq("addsuffix('.c', 'main sar x11')", "main.c sar.c x11.c");
+  assert_eval_eq("addsuffix('-', 'c v h y')", "c- v- h- y-");
+  assert_eval_eq(
+    "addsuffix('0000', '11 10 01 00')",
+    "110000 100000 010000 000000",
+  );
+}
+
+#[test]
 #[cfg(not(windows))]
 fn join() {
   assert_eval_eq("join('a', 'b', 'c', 'd')", "a/b/c/d");


### PR DESCRIPTION
`append(suffix, base)` takes a `append` and a `base` string with space-separated words,
and append `suffix` to the end of each word in the base string.

For example, `append('.c', 'foo bar baz')` -> 'foo.c bar.c baz.c'
