### PR TITLE
Support shell()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1340,6 +1340,53 @@ that work on various operating systems. For an example, see
 [cross-platform.just](https://github.com/casey/just/blob/master/examples/cross-platform.just)
 file.
 
+#### Running External Commands/Scripts
+- `shell(command, args...)` expands to the output of running its given command.
+  - `command` is a script snippet or command. Use the catch-all parameter/argument to get all
+    passed arguments/options, '$@'(bash), '$argv' (fish), 'argv' etc.
+
+  > *Note*
+  > 1. Due to the way Just currently works, `set shell` overrides all assumed shell in `shell()` calls.
+  > 2. Any statements in the script-like command that writes to standard output will affect the output.
+  > 3. For Python and similar shells, the last `n` (number of args passed in) members of `argv` are the arguments you passed in.
+  >    (See examples)
+
+  Examples
+  --------
+    1. without external args
+        `bat_stat := shell("cat /sys/class/power_supply/BAT0/status")`
+    2. with external args using sh
+        `bat_stat := shell("cat $@", "/sys/class/power_supply/BAT0/status")`
+    3. This won't print "adstronaut": 
+       `shell("echo", "adstronaut")`, use `shell("echo $0", "adstronaut")` instead
+    4. using python as command interpreter:
+        ```just
+        set shell := ["python3", "-c"]
+        bat_stat := shell("
+        import sys,subprocess
+
+        statfile = '/sys/class/power_supply/BAT0/status'
+        batstat = subprocess.run(['cat', statfile], capture_output=True).stdout
+        print(batstat.decode(), end='')
+        ")
+
+        _:
+          echo {{ bat_stat }}
+        ```
+    5.  ```just
+        set shell := ["python3", "-c"]
+        bat_stat := shell("
+        import sys
+        print(sys.argv)
+        ", "killers", "of the", "flower-moon")
+        _:
+          print({{ bat_stat }})
+        ```
+        output:
+        ```
+        ['-c', 'killers', 'of the', 'flower-moon']
+        `
+
 #### Environment Variables
 
 - `env_var(key)` — Retrieves the environment variable with name `key`, aborting

--- a/README.md
+++ b/README.md
@@ -1340,52 +1340,32 @@ that work on various operating systems. For an example, see
 [cross-platform.just](https://github.com/casey/just/blob/master/examples/cross-platform.just)
 file.
 
-#### Running External Commands/Scripts
-- `shell(command, args...)` expands to the output of running its given command.
-  - `command` is a script snippet or command. Use the catch-all parameter/argument to get all
-    passed arguments/options, '$@'(bash), '$argv' (fish), 'argv' etc.
+#### External Commands
 
-  > *Note*
-  > 1. Due to the way Just currently works, `set shell` overrides all assumed shell in `shell()` calls.
-  > 2. Any statements in the script-like command that writes to standard output will affect the output.
-  > 3. For Python and similar shells, the last `n` (number of args passed in) members of `argv` are the arguments you passed in.
-  >    (See examples)
+- `shell(command, args...)` returns the standard output of shell script
+  `command` with zero or more positional arguments `args`. The shell used to
+  interpret `command` is the same shell that is used to evaluate recipe lines,
+  and can be changed with `set shell := […]`.
 
-  Examples
-  --------
-    1. without external args
-        `bat_stat := shell("cat /sys/class/power_supply/BAT0/status")`
-    2. with external args using sh
-        `bat_stat := shell("cat $@", "/sys/class/power_supply/BAT0/status")`
-    3. This won't print "adstronaut": 
-       `shell("echo", "adstronaut")`, use `shell("echo $0", "adstronaut")` instead
-    4. using python as command interpreter:
-        ```just
-        set shell := ["python3", "-c"]
-        bat_stat := shell("
-        import sys,subprocess
+```just
+# arguments can be variables
+file := '/sys/class/power_supply/BAT0/status'
+bat0stat := shell('cat $1', file)
 
-        statfile = '/sys/class/power_supply/BAT0/status'
-        batstat = subprocess.run(['cat', statfile], capture_output=True).stdout
-        print(batstat.decode(), end='')
-        ")
+# commands can be variables
+command := 'wc -l $1'
+output := shell(command, 'main.c')
 
-        _:
-          echo {{ bat_stat }}
-        ```
-    5.  ```just
-        set shell := ["python3", "-c"]
-        bat_stat := shell("
-        import sys
-        print(sys.argv)
-        ", "killers", "of the", "flower-moon")
-        _:
-          print({{ bat_stat }})
-        ```
-        output:
-        ```
-        ['-c', 'killers', 'of the', 'flower-moon']
-        `
+# note that arguments must be used
+empty := shell('echo', 'foo')
+full := shell('echo $1', 'foo')
+```
+
+```just
+# using python as the shell
+set shell := ["python3", "-c"]
+olleh := shell('import sys; print(sys.argv[1][::-1]))', 'hello')
+```
 
 #### Environment Variables
 

--- a/src/assignment_resolver.rs
+++ b/src/assignment_resolver.rs
@@ -77,7 +77,7 @@ impl<'src: 'run, 'run> AssignmentResolver<'src, 'run> {
           Ok(())
         }
         Thunk::UnaryPlus {
-          args: ([a], rest), ..
+          args: (a, rest), ..
         } => {
           self.resolve_expression(a)?;
           for arg in rest {

--- a/src/assignment_resolver.rs
+++ b/src/assignment_resolver.rs
@@ -76,6 +76,15 @@ impl<'src: 'run, 'run> AssignmentResolver<'src, 'run> {
           }
           Ok(())
         }
+        Thunk::UnaryPlus {
+          args: ([a], rest), ..
+        } => {
+          self.resolve_expression(a)?;
+          for arg in rest {
+            self.resolve_expression(arg)?;
+          }
+          Ok(())
+        }
         Thunk::Binary { args: [a, b], .. } => {
           self.resolve_expression(a)?;
           self.resolve_expression(b)

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -105,7 +105,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
           UnaryPlus {
             name,
             function,
-            args: ([a], rest),
+            args: (a, rest),
             ..
           } => {
             let a = self.evaluate_expression(a)?;
@@ -143,7 +143,6 @@ impl<'src, 'run> Evaluator<'src, 'run> {
             for arg in rest {
               rest_evaluated.push(self.evaluate_expression(arg)?);
             }
-
             function(self, &a, &b, &rest_evaluated).map_err(|message| Error::FunctionCall {
               function: *name,
               message,
@@ -229,24 +228,16 @@ impl<'src, 'run> Evaluator<'src, 'run> {
 
   pub(crate) fn run_command(&self, command: &str, args: &[String]) -> Result<String, OutputError> {
     let mut cmd = self.settings.shell_command(self.config);
-
     cmd.arg(command);
-    if !args.is_empty() {
-      cmd.args(args);
-    }
-
+    cmd.args(args);
     cmd.current_dir(&self.search.working_directory);
-
     cmd.export(self.settings, self.dotenv, &self.scope);
-
     cmd.stdin(Stdio::inherit());
-
     cmd.stderr(if self.config.verbosity.quiet() {
       Stdio::null()
     } else {
       Stdio::inherit()
     });
-
     InterruptHandler::guard(|| output(cmd))
   }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -102,6 +102,22 @@ impl<'src, 'run> Evaluator<'src, 'run> {
               message,
             })
           }
+          UnaryPlus {
+            name,
+            function,
+            args: ([a], rest),
+            ..
+          } => {
+            let a = self.evaluate_expression(a)?;
+            let mut rest_evaluated = Vec::new();
+            for arg in rest {
+              rest_evaluated.push(self.evaluate_expression(arg)?);
+            }
+            function(&context, &a, &rest_evaluated).map_err(|message| Error::FunctionCall {
+              function: *name,
+              message,
+            })
+          }
           Binary {
             name,
             function,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -113,7 +113,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
             for arg in rest {
               rest_evaluated.push(self.evaluate_expression(arg)?);
             }
-            function(&self, &a, &rest_evaluated).map_err(|message| Error::FunctionCall {
+            function(self, &a, &rest_evaluated).map_err(|message| Error::FunctionCall {
               function: *name,
               message,
             })
@@ -232,7 +232,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
 
     cmd.arg(command);
     if !args.is_empty() {
-      cmd.args(&args[..]);
+      cmd.args(args);
     }
 
     cmd.current_dir(&self.search.working_directory);

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -113,7 +113,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
             for arg in rest {
               rest_evaluated.push(self.evaluate_expression(arg)?);
             }
-            function(&context, &a, &rest_evaluated).map_err(|message| Error::FunctionCall {
+            function(&self, &a, &rest_evaluated).map_err(|message| Error::FunctionCall {
               function: *name,
               message,
             })

--- a/src/function.rs
+++ b/src/function.rs
@@ -465,7 +465,7 @@ fn shell(_evaluator: &Evaluator, cmdlike: &str, extras: &[String]) -> Result<Str
   shelled_cmd.args(args); // for the shell
 
   shelled_cmd.arg(cmdlike);
-  if extras.len() > 0 {
+  if !extras.is_empty() {
     shelled_cmd.args(&extras[..]);
   }
   shelled_cmd

--- a/src/function.rs
+++ b/src/function.rs
@@ -459,23 +459,10 @@ fn sha256_file(evaluator: &Evaluator, path: &str) -> Result<String, String> {
   Ok(format!("{hash:x}"))
 }
 
-fn shell(_evaluator: &Evaluator, cmdlike: &str, extras: &[String]) -> Result<String, String> {
-  let (command, args) = context.settings.shell(context.config);
-  let mut shelled_cmd = Command::new(command);
-  shelled_cmd.args(args); // for the shell
-
-  shelled_cmd.arg(cmdlike);
-  if !extras.is_empty() {
-    shelled_cmd.args(&extras[..]);
-  }
-  shelled_cmd
-    .current_dir(&context.search.working_directory)
-    .stdin(Stdio::inherit())
-    .stderr(Stdio::inherit());
-
-  Ok(InterruptHandler::guard(|| {
-    output(shelled_cmd).map_err(|output_error| output_error.to_string())
-  })?)
+fn shell(evaluator: &Evaluator, cmdlike: &str, extras: &[String]) -> Result<String, String> {
+  evaluator
+    .run_command(cmdlike, extras)
+    .map_err(|output_error| output_error.to_string())
 }
 
 fn shoutykebabcase(_evaluator: &Evaluator, s: &str) -> Result<String, String> {

--- a/src/function.rs
+++ b/src/function.rs
@@ -459,9 +459,9 @@ fn sha256_file(evaluator: &Evaluator, path: &str) -> Result<String, String> {
   Ok(format!("{hash:x}"))
 }
 
-fn shell(evaluator: &Evaluator, cmdlike: &str, extras: &[String]) -> Result<String, String> {
+fn shell(evaluator: &Evaluator, command: &str, args: &[String]) -> Result<String, String> {
   evaluator
-    .run_command(cmdlike, extras)
+    .run_command(command, args)
     .map_err(|output_error| output_error.to_string())
 }
 

--- a/src/function_context.rs
+++ b/src/function_context.rs
@@ -1,9 +1,0 @@
-use super::*;
-
-pub(crate) struct FunctionContext<'run> {
-  pub(crate) dotenv: &'run BTreeMap<String, String>,
-  pub(crate) invocation_directory: &'run Path,
-  pub(crate) search: &'run Search,
-  pub(crate) settings: &'run Settings<'run>,
-  pub(crate) config: &'run Config,
-}

--- a/src/function_context.rs
+++ b/src/function_context.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+pub(crate) struct FunctionContext<'run> {
+  pub(crate) dotenv: &'run BTreeMap<String, String>,
+  pub(crate) invocation_directory: &'run Path,
+  pub(crate) search: &'run Search,
+  pub(crate) settings: &'run Settings<'run>,
+  pub(crate) config: &'run Config,
+}

--- a/src/node.rs
+++ b/src/node.rs
@@ -127,7 +127,7 @@ impl<'src> Node<'src> for Expression<'src> {
           }
           UnaryPlus {
             name,
-            args: ([a], rest),
+            args: (a, rest),
             ..
           } => {
             tree.push_mut(name.lexeme());

--- a/src/node.rs
+++ b/src/node.rs
@@ -125,6 +125,17 @@ impl<'src> Node<'src> for Expression<'src> {
               tree.push_mut(b.tree());
             }
           }
+          UnaryPlus {
+            name,
+            args: ([a], rest),
+            ..
+          } => {
+            tree.push_mut(name.lexeme());
+            tree.push_mut(a.tree());
+            for arg in rest {
+              tree.push_mut(arg.tree());
+            }
+          }
           Binary {
             name, args: [a, b], ..
           } => {

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -261,6 +261,20 @@ impl Expression {
             arguments,
           }
         }
+        full::Thunk::UnaryPlus {
+          name,
+          args: ([a], rest),
+          ..
+        } => {
+          let mut arguments = vec![Expression::new(a)];
+          for arg in rest {
+            arguments.push(Expression::new(arg));
+          }
+          Expression::Call {
+            name: name.lexeme().to_owned(),
+            arguments,
+          }
+        }
         full::Thunk::Binary {
           name, args: [a, b], ..
         } => Self::Call {

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -263,7 +263,7 @@ impl Expression {
         }
         full::Thunk::UnaryPlus {
           name,
-          args: ([a], rest),
+          args: (a, rest),
           ..
         } => {
           let mut arguments = vec![Expression::new(a)];

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -23,7 +23,7 @@ pub(crate) enum Thunk<'src> {
   UnaryPlus {
     name: Name<'src>,
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
-    function: fn(&FunctionContext, &str, &[String]) -> Result<String, String>,
+    function: fn(&Evaluator, &str, &[String]) -> Result<String, String>,
     args: ([Box<Expression<'src>>; 1], Vec<Expression<'src>>),
   },
   Binary {

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -24,7 +24,7 @@ pub(crate) enum Thunk<'src> {
     name: Name<'src>,
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
     function: fn(&Evaluator, &str, &[String]) -> Result<String, String>,
-    args: ([Box<Expression<'src>>; 1], Vec<Expression<'src>>),
+    args: (Box<Expression<'src>>, Vec<Expression<'src>>),
   },
   Binary {
     name: Name<'src>,
@@ -91,7 +91,7 @@ impl<'src> Thunk<'src> {
           let a = Box::new(arguments.pop().unwrap());
           Ok(Thunk::UnaryPlus {
             function,
-            args: ([a], rest),
+            args: (a, rest),
             name,
           })
         }
@@ -151,7 +151,7 @@ impl Display for Thunk<'_> {
       }
       UnaryPlus {
         name,
-        args: ([a], rest),
+        args: (a, rest),
         ..
       } => {
         write!(f, "{}({a}", name.lexeme())?;
@@ -202,8 +202,11 @@ impl<'src> Serialize for Thunk<'src> {
           seq.serialize_element(b)?;
         }
       }
-      Self::UnaryPlus { args, .. } => {
-        for arg in args.0.iter().map(Box::as_ref).chain(&args.1) {
+      Self::UnaryPlus {
+        args: (a, rest), ..
+      } => {
+        seq.serialize_element(a)?;
+        for arg in rest {
           seq.serialize_element(arg)?;
         }
       }

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -29,7 +29,7 @@ impl<'expression, 'src> Iterator for Variables<'expression, 'src> {
             }
           }
           Thunk::UnaryPlus {
-            args: ([a], rest), ..
+            args: (a, rest), ..
           } => {
             let first: &[&Expression] = &[a];
             for arg in first.iter().copied().chain(rest).rev() {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -28,6 +28,14 @@ impl<'expression, 'src> Iterator for Variables<'expression, 'src> {
               self.stack.push(b);
             }
           }
+          Thunk::UnaryPlus {
+            args: ([a], rest), ..
+          } => {
+            let first: &[&Expression] = &[a];
+            for arg in first.iter().copied().chain(rest).rev() {
+              self.stack.push(arg);
+            }
+          }
           Thunk::Binary { args, .. } => {
             for arg in args.iter().rev() {
               self.stack.push(arg);

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -760,6 +760,43 @@ fn just_pid() {
 }
 
 #[test]
+fn shell_no_arg_provided() {
+  Test::new()
+    .justfile("var := shell()")
+    .args(["--evaluate"])
+    .stderr(
+      "
+      error: Function `shell` called with 0 arguments but takes 1 or more
+       ——▶ justfile:1:8
+        │
+      1 │ var := shell()
+        │        ^^^^^
+      ",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn shell_minimal() {
+  Test::new()
+    .justfile(
+      r"
+      _ := '_'
+      var := shell('echo $0 $1', _, 'justice')
+      _:
+        @echo {{var}}",
+    )
+    .stdout(
+      "
+      _ justice
+      ",
+    )
+    .status(EXIT_SUCCESS)
+    .run();
+}
+
+#[test]
 fn blake3() {
   Test::new()
     .justfile("x := blake3('5943ee37-0000-1000-8000-010203040506')")

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -782,15 +782,31 @@ fn shell_minimal() {
   Test::new()
     .justfile(
       r"
-      _ := '_'
-      var := shell('echo $0 $1', _, 'justice')
+      var := shell('echo $0 $1', 'justice', 'legs')
       _:
-        @echo {{var}}",
+        @echo {{var}}
+      ",
     )
     .stdout(
-      "
-      _ justice
+      "justice legs\n",
+    )
+    .status(EXIT_SUCCESS)
+    .run();
+}
+
+#[test]
+fn shell_from_variable() {
+  Test::new()
+    .justfile(
+      r"
+      echo := 'echo $0 $1'
+      var := shell(echo, 'justice', 'legs')
+      _:
+        @echo {{var}}
       ",
+    )
+    .stdout(
+      "justice legs\n",
     )
     .status(EXIT_SUCCESS)
     .run();

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -787,9 +787,7 @@ fn shell_minimal() {
         @echo {{var}}
       ",
     )
-    .stdout(
-      "justice legs\n",
-    )
+    .stdout("justice legs\n")
     .status(EXIT_SUCCESS)
     .run();
 }
@@ -805,9 +803,7 @@ fn shell_from_variable() {
         @echo {{var}}
       ",
     )
-    .stdout(
-      "justice legs\n",
-    )
+    .stdout("justice legs\n")
     .status(EXIT_SUCCESS)
     .run();
 }

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -760,7 +760,7 @@ fn just_pid() {
 }
 
 #[test]
-fn shell_no_arg_provided() {
+fn shell_no_argument() {
   Test::new()
     .justfile("var := shell()")
     .args(["--evaluate"])
@@ -779,32 +779,24 @@ fn shell_no_arg_provided() {
 
 #[test]
 fn shell_minimal() {
-  Test::new()
-    .justfile(
-      r"
-      var := shell('echo $0 $1', 'justice', 'legs')
-      _:
-        @echo {{var}}
-      ",
-    )
-    .stdout("justice legs\n")
-    .status(EXIT_SUCCESS)
-    .run();
+  assert_eval_eq("shell('echo $0 $1', 'justice', 'legs')", "justice legs");
 }
 
 #[test]
-fn shell_from_variable() {
+fn shell_error() {
   Test::new()
-    .justfile(
-      r"
-      echo := 'echo $0 $1'
-      var := shell(echo, 'justice', 'legs')
-      _:
-        @echo {{var}}
+    .justfile("var := shell('exit 1')")
+    .args(["--evaluate"])
+    .stderr(
+      "
+      error: Call to function `shell` failed: Process exited with status code 1
+       ——▶ justfile:1:8
+        │
+      1 │ var := shell('exit 1')
+        │        ^^^^^
       ",
     )
-    .stdout("justice legs\n")
-    .status(EXIT_SUCCESS)
+    .status(EXIT_FAILURE)
     .run();
 }
 


### PR DESCRIPTION
This PR add support for the `shell()`, which expands to the output of running its given command. 

Example:
```just
set shell := ["fish", "-c"]
v := shell("
set p $argv
for i in $p
	echo "$i"
end
",  "Nightmares", "on", "Elms", "Street")

_:
  @echo "{{ v }}"
```
output:
```console
Nightmares
on
Elms
Street
```