### PR TITLE
`doc` attribute for docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,6 +1079,30 @@ Available recipes:
     test # test stuff
 ```
 
+You can also add a documentation comment with the `doc` attribute. This suppresses
+a pre-recipe comment from appearing in `just --list`:
+
+```just
+
+# This comment won't appear in the list output
+[doc("Build stuff")]
+build:
+  ./bin/build
+
+# This one won't either
+[doc]
+test:
+  ./bin/test
+```
+
+```sh
+$ just --list
+Available recipes:
+    build # Build stuff
+    test
+```
+
+
 ### Variables and Substitution
 
 Variables, strings, concatenation, path joining, and substitution using `{{…}}`
@@ -1611,6 +1635,7 @@ Recipes may be annotated with attributes that change their behavior.
 |------|-------------|
 | `[confirm]`<sup>1.17.0</sup> | Require confirmation prior to executing recipe. |
 | `[confirm('prompt')]`<sup>1.23.0</sup> | Require confirmation prior to executing recipe with a custom prompt. |
+| `[doc('documentation comment')]`<sup>1.27.0</sup> | Add a [documentation comment](#documentation-comments). |
 | `[group('NAME"']`<sup>master</sup> | Put recipe in [recipe group](#recipe-groups) `NAME`.
 | `[linux]`<sup>1.8.0</sup> | Enable recipe on Linux. |
 | `[macos]`<sup>1.8.0</sup> | Enable recipe on MacOS. |

--- a/README.md
+++ b/README.md
@@ -1644,7 +1644,7 @@ Recipes may be annotated with attributes that change their behavior.
 |------|-------------|
 | `[confirm]`<sup>1.17.0</sup> | Require confirmation prior to executing recipe. |
 | `[confirm('PROMPT')]`<sup>1.23.0</sup> | Require confirmation prior to executing recipe with a custom prompt. |
-| `[doc('COMMENT')]`<sup>master</sup> | Set recipe's [documentation comment](#documentation-comments) to COMMENT. |
+| `[doc('DOC')]`<sup>master</sup> | Set recipe's [documentation comment](#documentation-comments) to `DOC`. |
 | `[group('NAME"']`<sup>master</sup> | Put recipe in [recipe group](#recipe-groups) `NAME`. |
 | `[linux]`<sup>1.8.0</sup> | Enable recipe on Linux. |
 | `[macos]`<sup>1.8.0</sup> | Enable recipe on MacOS. |

--- a/README.md
+++ b/README.md
@@ -1079,13 +1079,11 @@ Available recipes:
     test # test stuff
 ```
 
-You can also add a documentation comment with the `doc` attribute. This suppresses
-a pre-recipe comment from appearing in `just --list`:
+The `[doc]` attribute can be used to set or suppress a recipe's doc comment:
 
 ```just
-
-# This comment won't appear in the list output
-[doc("Build stuff")]
+# This comment won't appear
+[doc('Build stuff')]
 build:
   ./bin/build
 
@@ -1101,7 +1099,6 @@ Available recipes:
     build # Build stuff
     test
 ```
-
 
 ### Variables and Substitution
 
@@ -1646,9 +1643,9 @@ Recipes may be annotated with attributes that change their behavior.
 | Name | Description |
 |------|-------------|
 | `[confirm]`<sup>1.17.0</sup> | Require confirmation prior to executing recipe. |
-| `[confirm('prompt')]`<sup>1.23.0</sup> | Require confirmation prior to executing recipe with a custom prompt. |
-| `[doc('documentation comment')]`<sup>1.27.0</sup> | Add a [documentation comment](#documentation-comments). |
-| `[group('NAME"']`<sup>master</sup> | Put recipe in [recipe group](#recipe-groups) `NAME`.
+| `[confirm('PROMPT')]`<sup>1.23.0</sup> | Require confirmation prior to executing recipe with a custom prompt. |
+| `[doc('COMMENT')]`<sup>master</sup> | Set recipe's [documentation comment](#documentation-comments) to COMMENT. |
+| `[group('NAME"']`<sup>master</sup> | Put recipe in [recipe group](#recipe-groups) `NAME`. |
 | `[linux]`<sup>1.8.0</sup> | Enable recipe on Linux. |
 | `[macos]`<sup>1.8.0</sup> | Enable recipe on MacOS. |
 | `[no-cd]`<sup>1.9.0</sup> | Don't change directory before executing recipe. |

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -10,6 +10,9 @@ use super::*;
 #[strum_discriminants(strum(serialize_all = "kebab-case"))]
 pub(crate) enum Attribute<'src> {
   Confirm(Option<StringLiteral<'src>>),
+  Doc {
+    docstring: Option<StringLiteral<'src>>,
+  },
   Group(StringLiteral<'src>),
   Linux,
   Macos,
@@ -24,7 +27,7 @@ pub(crate) enum Attribute<'src> {
 impl AttributeDiscriminant {
   fn argument_range(self) -> RangeInclusive<usize> {
     match self {
-      Self::Confirm => 0..=1,
+      Self::Confirm | Self::Doc => 0..=1,
       Self::Group => 1..=1,
       Self::Linux
       | Self::Macos
@@ -72,6 +75,9 @@ impl<'src> Attribute<'src> {
 
     Ok(match discriminant {
       Confirm => Self::Confirm(argument),
+      Doc => Self::Doc {
+        docstring: argument,
+      },
       Group => Self::Group(argument.unwrap()),
       Linux => Self::Linux,
       Macos => Self::Macos,
@@ -91,6 +97,7 @@ impl<'src> Attribute<'src> {
   fn argument(&self) -> Option<&StringLiteral> {
     match self {
       Self::Confirm(prompt) => prompt.as_ref(),
+      Self::Doc { docstring } => docstring.as_ref(),
       Self::Group(name) => Some(name),
       Self::Linux
       | Self::Macos
@@ -107,7 +114,6 @@ impl<'src> Attribute<'src> {
 impl<'src> Display for Attribute<'src> {
   fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
     write!(f, "{}", self.name())?;
-
     if let Some(argument) = self.argument() {
       write!(f, "({argument})")?;
     }

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -10,9 +10,7 @@ use super::*;
 #[strum_discriminants(strum(serialize_all = "kebab-case"))]
 pub(crate) enum Attribute<'src> {
   Confirm(Option<StringLiteral<'src>>),
-  Doc {
-    docstring: Option<StringLiteral<'src>>,
-  },
+  Doc(Option<StringLiteral<'src>>),
   Group(StringLiteral<'src>),
   Linux,
   Macos,
@@ -75,9 +73,7 @@ impl<'src> Attribute<'src> {
 
     Ok(match discriminant {
       Confirm => Self::Confirm(argument),
-      Doc => Self::Doc {
-        docstring: argument,
-      },
+      Doc => Self::Doc(argument),
       Group => Self::Group(argument.unwrap()),
       Linux => Self::Linux,
       Macos => Self::Macos,
@@ -97,8 +93,8 @@ impl<'src> Attribute<'src> {
   fn argument(&self) -> Option<&StringLiteral> {
     match self {
       Self::Confirm(prompt) => prompt.as_ref(),
-      Self::Doc { docstring } => docstring.as_ref(),
-      Self::Group(name) => Some(name),
+      Self::Doc(doc) => doc.as_ref(),
+      Self::Group(group) => Some(group),
       Self::Linux
       | Self::Macos
       | Self::NoCd

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -453,8 +453,8 @@ impl<'src, D> Recipe<'src, D> {
 
   pub(crate) fn doc(&self) -> Option<&str> {
     for attribute in &self.attributes {
-      if let Attribute::Doc(comment) = attribute {
-        return comment.as_ref().map(|s| s.cooked.as_ref());
+      if let Attribute::Doc(doc) = attribute {
+        return doc.as_ref().map(|s| s.cooked.as_ref());
       }
     }
     self.doc

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -450,6 +450,15 @@ impl<'src, D> Recipe<'src, D> {
       })
       .collect()
   }
+
+  pub(crate) fn docstring(&self) -> Option<&str> {
+    for attribute in &self.attributes {
+      if let Attribute::Doc { docstring } = attribute {
+        return docstring.as_ref().map(|s| s.cooked.as_ref());
+      }
+    }
+    self.doc
+  }
 }
 
 impl<'src, D: Display> ColorDisplay for Recipe<'src, D> {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -451,10 +451,10 @@ impl<'src, D> Recipe<'src, D> {
       .collect()
   }
 
-  pub(crate) fn docstring(&self) -> Option<&str> {
+  pub(crate) fn doc(&self) -> Option<&str> {
     for attribute in &self.attributes {
-      if let Attribute::Doc { docstring } = attribute {
-        return docstring.as_ref().map(|s| s.cooked.as_ref());
+      if let Attribute::Doc(comment) = attribute {
+        return comment.as_ref().map(|s| s.cooked.as_ref());
       }
     }
     self.doc

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -573,7 +573,7 @@ impl Subcommand {
           );
 
           let doc = if i == 0 {
-            recipe.doc.map(Cow::Borrowed)
+            recipe.docstring().map(Cow::Borrowed)
           } else {
             Some(Cow::Owned(format!("alias for `{}`", recipe.name)))
           };

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -573,7 +573,7 @@ impl Subcommand {
           );
 
           let doc = if i == 0 {
-            recipe.docstring().map(Cow::Borrowed)
+            recipe.doc().map(Cow::Borrowed)
           } else {
             Some(Cow::Owned(format!("alias for `{}`", recipe.name)))
           };

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -129,3 +129,45 @@ fn unexpected_attribute_argument() {
     .status(1)
     .run();
 }
+
+#[test]
+fn doc_attribute() {
+  Test::new()
+    .justfile(
+      "
+    # Non-document comment
+    [doc('The real docstring')]
+    foo:
+      echo foo
+  ",
+    )
+    .args(["--list"])
+    .stdout(
+      "
+    Available recipes:
+        foo # The real docstring
+        ",
+    )
+    .run();
+}
+
+#[test]
+fn suppress_doc_comment() {
+  Test::new()
+    .justfile(
+      "
+    # Non-document comment
+    [doc]
+    foo:
+      echo foo
+  ",
+    )
+    .args(["--list"])
+    .stdout(
+      "
+    Available recipes:
+        foo
+        ",
+    )
+    .run();
+}

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -152,7 +152,7 @@ fn doc_attribute() {
 }
 
 #[test]
-fn suppress_doc_comment() {
+fn doc_attribute_suppress() {
   Test::new()
     .justfile(
       "


### PR DESCRIPTION
cf. https://github.com/casey/just/issues/1955 , it would be convenient if there was a way to specify a recipe documentation string with an attribute. Also this would make possible to provide a docstring that is different from actual comments in the justfile.