### PR TITLE
Add percent encoding function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,7 @@ dependencies = [
  "libc",
  "log",
  "num_cpus",
+ "percent-encoding",
  "pretty_assertions",
  "regex",
  "semver",
@@ -636,6 +637,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pretty_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ lexiclean = "0.0.1"
 libc = "0.2.0"
 log = "0.4.4"
 num_cpus = "1.15.0"
+percent-encoding = "2.3.1"
 regex = "1.10.4"
 semver = "1.0.20"
 serde = { version = "1.0.130", features = ["derive", "rc"] }

--- a/README.md
+++ b/README.md
@@ -1402,6 +1402,7 @@ The process ID is: 420
 - `prepend(prefix, s)`<sup>master</sup> Prepend `prefix` to
   whitespace-separated strings in `s`. `prepend('src/', 'foo bar baz')` →
   `'src/foo src/bar src/baz'`
+- `percent_encode(s)`<sup>master</sup> - Percent-encode characters in `s` that are non-ASCII or that might have meaning in a URL.
 - `quote(s)` - Replace all single quotes with `'\''` and prepend and append
   single quotes to `s`. This is sufficient to escape special characters for
   many shells, including most Bourne shell descendants.

--- a/README.md
+++ b/README.md
@@ -1427,7 +1427,9 @@ The process ID is: 420
 - `prepend(prefix, s)`<sup>master</sup> Prepend `prefix` to
   whitespace-separated strings in `s`. `prepend('src/', 'foo bar baz')` →
   `'src/foo src/bar src/baz'`
-- `percent_encode(s)`<sup>master</sup> - Percent-encode characters in `s` that are non-ASCII or that might have meaning in a URL, matching the behavior of the [JavaScript `encodeURIComponent` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
+- `encode_uri_component(s)`<sup>master</sup> - Percent-encode characters in `s`
+  except `[A-Za-z0-9_.!~*'()-]`, matching the behavior of the
+  [JavaScript `encodeURIComponent` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
 - `quote(s)` - Replace all single quotes with `'\''` and prepend and append
   single quotes to `s`. This is sufficient to escape special characters for
   many shells, including most Bourne shell descendants.

--- a/README.md
+++ b/README.md
@@ -1427,7 +1427,7 @@ The process ID is: 420
 - `prepend(prefix, s)`<sup>master</sup> Prepend `prefix` to
   whitespace-separated strings in `s`. `prepend('src/', 'foo bar baz')` →
   `'src/foo src/bar src/baz'`
-- `percent_encode(s)`<sup>master</sup> - Percent-encode characters in `s` that are non-ASCII or that might have meaning in a URL.
+- `percent_encode(s)`<sup>master</sup> - Percent-encode characters in `s` that are non-ASCII or that might have meaning in a URL, matching the behavior of the [JavaScript `encodeURIComponent` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
 - `quote(s)` - Replace all single quotes with `'\''` and prepend and append
   single quotes to `s`. This is sufficient to escape special characters for
   many shells, including most Bourne shell descendants.

--- a/src/function.rs
+++ b/src/function.rs
@@ -405,7 +405,12 @@ fn percent_encode(_evaluator: &Evaluator, s: &str) -> Result<String, String> {
     .remove(b'-')
     .remove(b'_')
     .remove(b'.')
-    .remove(b'~');
+    .remove(b'!')
+    .remove(b'~')
+    .remove(b'*')
+    .remove(b'\'')
+    .remove(b'(')
+    .remove(b')');
   Ok(percent_encoding::utf8_percent_encode(s, &ASCII_SET).to_string())
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -56,6 +56,7 @@ pub(crate) fn get(name: &str) -> Option<Function> {
     "os_family" => Nullary(os_family),
     "parent_directory" => Unary(parent_directory),
     "path_exists" => Unary(path_exists),
+    "percent_encode" => Unary(percent_encode),
     "prepend" => Binary(prepend),
     "quote" => Unary(quote),
     "replace" => Ternary(replace),
@@ -370,6 +371,17 @@ fn path_exists(evaluator: &Evaluator, path: &str) -> Result<String, String> {
       .exists()
       .to_string(),
   )
+}
+
+// This has to be 'static
+static PERCENT_ENCODE_ASCII: percent_encoding::AsciiSet = percent_encoding::NON_ALPHANUMERIC
+  .remove(b'-')
+  .remove(b'_')
+  .remove(b'.')
+  .remove(b'~');
+
+fn percent_encode(_evaluator: &Evaluator, s: &str) -> Result<String, String> {
+  Ok(percent_encoding::utf8_percent_encode(s, &PERCENT_ENCODE_ASCII).to_string())
 }
 
 fn quote(_evaluator: &Evaluator, s: &str) -> Result<String, String> {

--- a/src/function.rs
+++ b/src/function.rs
@@ -35,6 +35,7 @@ pub(crate) fn get(name: &str) -> Option<Function> {
     "config_local_directory" => Nullary(|_| dir("local config", dirs::config_local_dir)),
     "data_directory" => Nullary(|_| dir("data", dirs::data_dir)),
     "data_local_directory" => Nullary(|_| dir("local data", dirs::data_local_dir)),
+    "encode_uri_component" => Unary(encode_uri_component),
     "env" => UnaryOpt(env),
     "env_var" => Unary(env_var),
     "env_var_or_default" => Binary(env_var_or_default),
@@ -59,7 +60,6 @@ pub(crate) fn get(name: &str) -> Option<Function> {
     "os_family" => Nullary(os_family),
     "parent_directory" => Unary(parent_directory),
     "path_exists" => Unary(path_exists),
-    "percent_encode" => Unary(percent_encode),
     "prepend" => Binary(prepend),
     "quote" => Unary(quote),
     "replace" => Ternary(replace),
@@ -203,6 +203,20 @@ fn dir(name: &'static str, f: fn() -> Option<PathBuf>) -> Result<String, String>
       }),
     None => Err(format!("{name} directory not found")),
   }
+}
+
+fn encode_uri_component(_evaluator: &Evaluator, s: &str) -> Result<String, String> {
+  static PERCENT_ENCODE: percent_encoding::AsciiSet = percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'!')
+    .remove(b'~')
+    .remove(b'*')
+    .remove(b'\'')
+    .remove(b'(')
+    .remove(b')');
+  Ok(percent_encoding::utf8_percent_encode(s, &PERCENT_ENCODE).to_string())
 }
 
 fn env_var(evaluator: &Evaluator, key: &str) -> Result<String, String> {
@@ -398,20 +412,6 @@ fn path_exists(evaluator: &Evaluator, path: &str) -> Result<String, String> {
       .exists()
       .to_string(),
   )
-}
-
-fn percent_encode(_evaluator: &Evaluator, s: &str) -> Result<String, String> {
-  static ASCII_SET: percent_encoding::AsciiSet = percent_encoding::NON_ALPHANUMERIC
-    .remove(b'-')
-    .remove(b'_')
-    .remove(b'.')
-    .remove(b'!')
-    .remove(b'~')
-    .remove(b'*')
-    .remove(b'\'')
-    .remove(b'(')
-    .remove(b')');
-  Ok(percent_encoding::utf8_percent_encode(s, &ASCII_SET).to_string())
 }
 
 fn quote(_evaluator: &Evaluator, s: &str) -> Result<String, String> {

--- a/src/function.rs
+++ b/src/function.rs
@@ -400,15 +400,13 @@ fn path_exists(evaluator: &Evaluator, path: &str) -> Result<String, String> {
   )
 }
 
-// This has to be 'static
-static PERCENT_ENCODE_ASCII: percent_encoding::AsciiSet = percent_encoding::NON_ALPHANUMERIC
-  .remove(b'-')
-  .remove(b'_')
-  .remove(b'.')
-  .remove(b'~');
-
 fn percent_encode(_evaluator: &Evaluator, s: &str) -> Result<String, String> {
-  Ok(percent_encoding::utf8_percent_encode(s, &PERCENT_ENCODE_ASCII).to_string())
+  static ASCII_SET: percent_encoding::AsciiSet = percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+  Ok(percent_encoding::utf8_percent_encode(s, &ASCII_SET).to_string())
 }
 
 fn quote(_evaluator: &Evaluator, s: &str) -> Result<String, String> {

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -795,9 +795,9 @@ fn canonicalize() {
 }
 
 #[test]
-fn percent_encode() {
+fn encode_uri_component() {
   Test::new()
-    .justfile("x := percent_encode(\"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\\\"#$%&'()*+,-./:;<=>?@[\\\\]^_`{|}~ \\t\\r\\n🌐\")")
+    .justfile("x := encode_uri_component(\"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\\\"#$%&'()*+,-./:;<=>?@[\\\\]^_`{|}~ \\t\\r\\n🌐\")")
     .args(["--evaluate", "x"])
     .stdout("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!%22%23%24%25%26'()*%2B%2C-.%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~%20%09%0D%0A%F0%9F%8C%90")
     .run();

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -799,6 +799,6 @@ fn percent_encode() {
   Test::new()
     .justfile("x := percent_encode(\"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\\\"#$%&'()*+,-./:;<=>?@[\\\\]^_`{|}~ \\t\\r\\n🌐\")")
     .args(["--evaluate", "x"])
-    .stdout("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~%20%09%0D%0A%F0%9F%8C%90")
+    .stdout("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!%22%23%24%25%26'()*%2B%2C-.%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~%20%09%0D%0A%F0%9F%8C%90")
     .run();
 }

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -739,3 +739,12 @@ fn canonicalize() {
     .stdout_regex(".*/justfile")
     .run();
 }
+
+#[test]
+fn percent_encode() {
+  Test::new()
+    .justfile("x := percent_encode(\"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\\\"#$%&'()*+,-./:;<=>?@[\\\\]^_`{|}~ \\t\\r\\n🌐\")")
+    .args(["--evaluate", "x"])
+    .stdout("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~%20%09%0D%0A%F0%9F%8C%90")
+    .run();
+}


### PR DESCRIPTION
https://github.com/casey/just/issues/1982

This function encodes more characters than [Javascript `encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) because the Examples section of that page mentions some cases that require additional percent-encoding, and in my experience extra percent-encoding like this doesn't hurt anything.

Not happy about the `static` in light of https://github.com/casey/just/pull/2049#discussion_r1605682328 but don't know any way around it :frowning_face: 