### PR TITLE
Don't allow shell-expanded strings in dependency arguments

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -610,6 +610,8 @@ impl<'run, 'src> Parser<'run, 'src> {
   fn parse_string_literal_token(
     &mut self,
   ) -> CompileResult<'src, (Token<'src>, StringLiteral<'src>)> {
+    // todo: if next is identifier, expect that it is keyword x
+
     let expand = self.accepted_keyword(Keyword::X)?;
 
     let token = self.expect(StringToken)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -568,12 +568,8 @@ impl<'run, 'src> Parser<'run, 'src> {
 
     tokens
       .next()
-      .map(|token| token.kind == Identifier && token.lexeme() == "x")
-      .unwrap_or_default()
-      && tokens
-        .next()
-        .map(|token| token.kind == StringToken)
-        .unwrap_or_default()
+      .is_some_and(|token| token.kind == Identifier && token.lexeme() == "x")
+      && tokens.next().is_some_and(|token| token.kind == StringToken)
   }
 
   /// Parse a value, e.g. `(bar)`

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -11,3 +11,17 @@ fn dont_run_duplicate_recipes() {
     )
     .run();
 }
+
+#[test]
+fn bugfix_parameters() {
+  Test::new()
+    .justfile(
+      "
+        foo a b c:
+          echo {{a}} {{b}} {{c}}
+        bar a b: (foo a b 'c')
+      ",
+    )
+    .args(["bar", "A", "B"])
+    .run();
+}

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -11,16 +11,3 @@ fn dont_run_duplicate_recipes() {
     )
     .run();
 }
-
-#[test]
-fn bugfix_parameters() {
-  Test::new()
-    .justfile(
-      "
-        foo a b:
-        bar a b: (foo a 'c')
-      ",
-    )
-    .args(["bar", "A", "B"])
-    .run();
-}

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -17,9 +17,8 @@ fn bugfix_parameters() {
   Test::new()
     .justfile(
       "
-        foo a b c:
-          echo {{a}} {{b}} {{c}}
-        bar a b: (foo a b 'c')
+        foo a b:
+        bar a b: (foo a 'c')
       ",
     )
     .args(["bar", "A", "B"])


### PR DESCRIPTION
Fixes, in horrible fashion, #2074.