### PR TITLE
Release 1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,63 @@
 Changelog
 =========
 
+[1.27.0](https://github.com/casey/just/releases/tag/1.27.0) - 2024-05-25
+------------------------------------------------------------------------
+
+### Changed
+- Use cache dir for temporary files ([#2067](https://github.com/casey/just/pull/2067))
+
+### Added
+- Add `[doc]` attribute to set and suppress documentation comments ([#2050](https://github.com/casey/just/pull/2050) by [neunenak](https://github.com/neunenak))
+- Add source_file() and source_directory() functions ([#2088](https://github.com/casey/just/pull/2088))
+- Add recipe groups ([#1842](https://github.com/casey/just/pull/1842) by [neunenak](https://github.com/neunenak))
+- Add shell() function for running external commands ([#2047](https://github.com/casey/just/pull/2047) by [gyreas](https://github.com/gyreas))
+- Add `--global-justfile` flag ([#1846](https://github.com/casey/just/pull/1846) by [neunenak](https://github.com/neunenak))
+- Add shell-expanded strings ([#2055](https://github.com/casey/just/pull/2055))
+- Add `encode_uri_component` function ([#2052](https://github.com/casey/just/pull/2052) by [laniakea64](https://github.com/laniakea64))
+- Add `choose` function for generating random strings ([#2049](https://github.com/casey/just/pull/2049) by [laniakea64](https://github.com/laniakea64))
+- Add predefined constants ([#2054](https://github.com/casey/just/pull/2054))
+- Allow setting some command-line options with environment variables ([#2044](https://github.com/casey/just/pull/2044) by [neunenak](https://github.com/neunenak))
+- Add prepend() function ([#2045](https://github.com/casey/just/pull/2045) by [gyreas](https://github.com/gyreas))
+- Add append() function ([#2046](https://github.com/casey/just/pull/2046) by [gyreas](https://github.com/gyreas))
+- Add --man subcommand ([#2041](https://github.com/casey/just/pull/2041))
+- Make `dotenv-path` relative to working directory ([#2040](https://github.com/casey/just/pull/2040))
+- Add `assert` expression ([#1845](https://github.com/casey/just/pull/1845) by [de1iza](https://github.com/de1iza))
+- Add 'allow-duplicate-variables' setting ([#1922](https://github.com/casey/just/pull/1922) by [Mijago](https://github.com/Mijago))
+
+### Fixed
+- List modules in source order with `--unsorted` ([#2085](https://github.com/casey/just/pull/2085))
+- Show submodule recipes in --choose ([#2069](https://github.com/casey/just/pull/2069))
+- Allow multiple imports of the same file in different modules ([#2065](https://github.com/casey/just/pull/2065))
+- Fix submodule recipe listing indentation ([#2063](https://github.com/casey/just/pull/2063))
+- Pass command as first argument to `shell` ([#2061](https://github.com/casey/just/pull/2061))
+- Allow shell expanded strings in mod and import paths ([#2059](https://github.com/casey/just/pull/2059))
+- Run imported recipes in root justfile with correct working directory ([#2056](https://github.com/casey/just/pull/2056))
+- Fix output `\r\n` stripping ([#2035](https://github.com/casey/just/pull/2035))
+
+### Misc
+- Forbid whitespace in shell-expanded string prefixes ([#2083](https://github.com/casey/just/pull/2083))
+- Add Debian and Ubuntu install instructions to readme ([#2072](https://github.com/casey/just/pull/2072))
+- Remove snap installation instructions from readme ([#2070](https://github.com/casey/just/pull/2070))
+- Fallback to wget in install script if curl isn't available([#1913](https://github.com/casey/just/pull/1913) by [tgross35](https://github.com/tgross35))
+- Use std::io::IsTerminal instead of atty crate ([#2066](https://github.com/casey/just/pull/2066))
+- Improve `shell()` documentation ([#2060](https://github.com/casey/just/pull/2060) by [laniakea64](https://github.com/laniakea64))
+- Add bash completion for snap ([#2058](https://github.com/casey/just/pull/2058) by [albertodonato](https://github.com/albertodonato))
+- Refactor list subcommand ([#2062](https://github.com/casey/just/pull/2062))
+- Document working directory ([#2053](https://github.com/casey/just/pull/2053))
+- Replace FunctionContext with Evaluator ([#2048](https://github.com/casey/just/pull/2048))
+- Update clap to version 4 ([#1924](https://github.com/casey/just/pull/1924) by [poliorcetics](https://github.com/poliorcetics))
+- Cleanup ([#2026](https://github.com/casey/just/pull/2026) by [adamnemecek](https://github.com/adamnemecek))
+- Increase --list maximum alignable width from 30 to 50 ([#2039](https://github.com/casey/just/pull/2039))
+- Document using `env -S` ([#2038](https://github.com/casey/just/pull/2038))
+- Update line continuation documentation ([#1998](https://github.com/casey/just/pull/1998) by [laniakea64](https://github.com/laniakea64))
+- Add example using GNU parallel to run tasks in concurrently ([#1915](https://github.com/casey/just/pull/1915) by [amarao](https://github.com/amarao))
+- Placate clippy: use `clone_into` ([#2037](https://github.com/casey/just/pull/2037))
+- Use --command-color when printing shebang recipe commands ([#1911](https://github.com/casey/just/pull/1911) by [avi-cenna](https://github.com/avi-cenna))
+- Document how to use watchexec to re-run recipes when files change ([#2036](https://github.com/casey/just/pull/2036))
+- Update VS Code extensions in readme ([#2034](https://github.com/casey/just/pull/2034))
+- Add rust:just repology package table to readme ([#2032](https://github.com/casey/just/pull/2032))
+
 [1.26.0](https://github.com/casey/just/releases/tag/1.26.0) - 2024-05-13
 ------------------------------------------------------------------------
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 
 [[package]]
 name = "cfg-if"
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -514,7 +514,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "just"
-version = "1.26.0"
+version = "1.27.0"
 dependencies = [
  "ansi_term",
  "blake3",
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
 dependencies = [
  "unicode-ident",
 ]
@@ -883,7 +883,7 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -929,23 +929,23 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75976f4748ab44f6e5332102be424e7c2dc18daeaf7e725f2040c3ebb133512e"
+checksum = "418b8136fec49956eba89be7da2847ec1909df92a9ae4178b5ff0ff092c8d95e"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b19911debfb8c2fb1107bc6cb2d61868aaf53a988449213959bb1b5b1ed95f"
+checksum = "1a4812a669da00d17d8266a0439eddcacbc88b17f732f927e52eeb9d196f7fb5"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1003,7 +1003,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.64"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1091,7 +1091,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "just"
-version = "1.26.0"
+version = "1.27.0"
 authors = ["Casey Rodarmor <casey@rodarmor.com>"]
 autotests = false
 categories = ["command-line-utilities", "development-tools"]

--- a/README.md
+++ b/README.md
@@ -1261,7 +1261,7 @@ sequence processing takes place after unindentation. The unindentation
 algorithm does not take escape-sequence produced whitespace or newlines into
 account.
 
-Strings prefixed with `x` are shell expanded<sup>master</sup>:
+Strings prefixed with `x` are shell expanded<sup>1.27.0</sup>:
 
 ```justfile
 foobar := x'~/$FOO/${BAR}'
@@ -1336,7 +1336,7 @@ file.
 
 #### External Commands
 
-- `shell(command, args...)`<sup>master</sup> returns the standard output of shell script
+- `shell(command, args...)`<sup>1.27.0</sup> returns the standard output of shell script
   `command` with zero or more positional arguments `args`. The shell used to
   interpret `command` is the same shell that is used to evaluate recipe lines,
   and can be changed with `set shell := […]`.
@@ -1443,9 +1443,9 @@ script:
 
 #### Source and Source Directory
 
-- `source()`<sup>master</sup> - Retrieves the path of the current source file.
+- `source()`<sup>1.27.0</sup> - Retrieves the path of the current source file.
 
-- `source_directory()`<sup>master</sup> - Retrieves the path of the parent directory of the
+- `source_directory()`<sup>1.27.0</sup> - Retrieves the path of the parent directory of the
   current source file.
 
 `source()` and `source_directory()` behave the same as `justfile()` and
@@ -1487,12 +1487,12 @@ The process ID is: 420
 
 #### String Manipulation
 
-- `append(suffix, s)`<sup>master</sup> Append `suffix` to whitespace-separated
+- `append(suffix, s)`<sup>1.27.0</sup> Append `suffix` to whitespace-separated
   strings in `s`. `append('/src', 'foo bar baz')` → `'foo/src bar/src baz/src'`
-- `prepend(prefix, s)`<sup>master</sup> Prepend `prefix` to
+- `prepend(prefix, s)`<sup>1.27.0</sup> Prepend `prefix` to
   whitespace-separated strings in `s`. `prepend('src/', 'foo bar baz')` →
   `'src/foo src/bar src/baz'`
-- `encode_uri_component(s)`<sup>master</sup> - Percent-encode characters in `s`
+- `encode_uri_component(s)`<sup>1.27.0</sup> - Percent-encode characters in `s`
   except `[A-Za-z0-9_.!~*'()-]`, matching the behavior of the
   [JavaScript `encodeURIComponent` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
 - `quote(s)` - Replace all single quotes with `'\''` and prepend and append
@@ -1587,7 +1587,7 @@ which will halt execution.
 
 #### Random
 
-- `choose(n, alphabet)`<sup>master</sup> - Generate a string of `n` randomly
+- `choose(n, alphabet)`<sup>1.27.0</sup> - Generate a string of `n` randomly
   selected characters from `alphabet`, which may not contain repeated
   characters. For example, `choose('64', HEX)` will generate a random
   64-character lowercase hex string.
@@ -1622,9 +1622,9 @@ A number of constants are predefined:
 
 | Name | Value |
 |------|-------------|
-| `HEX`<sup>master</sup> | `"0123456789abcdef"` |
-| `HEXLOWER`<sup>master</sup> | `"0123456789abcdef"` |
-| `HEXUPPER`<sup>master</sup> | `"0123456789ABCDEF"` |
+| `HEX`<sup>1.27.0</sup> | `"0123456789abcdef"` |
+| `HEXLOWER`<sup>1.27.0</sup> | `"0123456789abcdef"` |
+| `HEXUPPER`<sup>1.27.0</sup> | `"0123456789ABCDEF"` |
 
 ```just
 @foo:
@@ -1644,8 +1644,8 @@ Recipes may be annotated with attributes that change their behavior.
 |------|-------------|
 | `[confirm]`<sup>1.17.0</sup> | Require confirmation prior to executing recipe. |
 | `[confirm('PROMPT')]`<sup>1.23.0</sup> | Require confirmation prior to executing recipe with a custom prompt. |
-| `[doc('DOC')]`<sup>master</sup> | Set recipe's [documentation comment](#documentation-comments) to `DOC`. |
-| `[group('NAME"']`<sup>master</sup> | Put recipe in [recipe group](#recipe-groups) `NAME`. |
+| `[doc('DOC')]`<sup>1.27.0</sup> | Set recipe's [documentation comment](#documentation-comments) to `DOC`. |
+| `[group('NAME"']`<sup>1.27.0</sup> | Put recipe in [recipe group](#recipe-groups) `NAME`. |
 | `[linux]`<sup>1.8.0</sup> | Enable recipe on Linux. |
 | `[macos]`<sup>1.8.0</sup> | Enable recipe on MacOS. |
 | `[no-cd]`<sup>1.9.0</sup> | Don't change directory before executing recipe. |

--- a/man/just.1
+++ b/man/just.1
@@ -1,10 +1,10 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH just 1  "just 1.26.0" 
+.TH just 1  "just 1.27.0" 
 .SH NAME
 just \- 🤖 Just a command runner \- https://github.com/casey/just
 .SH SYNOPSIS
-\fBjust\fR [\fB\-\-check\fR] [\fB\-\-chooser\fR] [\fB\-\-color\fR] [\fB\-\-command\-color\fR] [\fB\-\-yes\fR] [\fB\-n\fR|\fB\-\-dry\-run\fR] [\fB\-\-dump\-format\fR] [\fB\-\-highlight\fR] [\fB\-\-list\-heading\fR] [\fB\-\-list\-prefix\fR] [\fB\-\-no\-aliases\fR] [\fB\-\-no\-deps\fR] [\fB\-\-no\-dotenv\fR] [\fB\-\-no\-highlight\fR] [\fB\-f\fR|\fB\-\-justfile\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-\-set\fR] [\fB\-\-shell\fR] [\fB\-\-shell\-arg\fR] [\fB\-\-shell\-command\fR] [\fB\-\-clear\-shell\-args\fR] [\fB\-u\fR|\fB\-\-unsorted\fR] [\fB\-\-unstable\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-d\fR|\fB\-\-working\-directory\fR] [\fB\-\-changelog\fR] [\fB\-\-choose\fR] [\fB\-c\fR|\fB\-\-command\fR] [\fB\-\-completions\fR] [\fB\-\-dump\fR] [\fB\-e\fR|\fB\-\-edit\fR] [\fB\-\-evaluate\fR] [\fB\-\-fmt\fR] [\fB\-\-init\fR] [\fB\-l\fR|\fB\-\-list\fR] [\fB\-\-man\fR] [\fB\-s\fR|\fB\-\-show\fR] [\fB\-\-summary\fR] [\fB\-\-variables\fR] [\fB\-\-dotenv\-filename\fR] [\fB\-E\fR|\fB\-\-dotenv\-path\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIARGUMENTS\fR] 
+\fBjust\fR [\fB\-\-check\fR] [\fB\-\-chooser\fR] [\fB\-\-color\fR] [\fB\-\-command\-color\fR] [\fB\-\-yes\fR] [\fB\-n\fR|\fB\-\-dry\-run\fR] [\fB\-\-dump\-format\fR] [\fB\-\-highlight\fR] [\fB\-\-list\-heading\fR] [\fB\-\-list\-prefix\fR] [\fB\-\-no\-aliases\fR] [\fB\-\-no\-deps\fR] [\fB\-\-no\-dotenv\fR] [\fB\-\-no\-highlight\fR] [\fB\-f\fR|\fB\-\-justfile\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-\-set\fR] [\fB\-\-shell\fR] [\fB\-\-shell\-arg\fR] [\fB\-\-shell\-command\fR] [\fB\-\-clear\-shell\-args\fR] [\fB\-u\fR|\fB\-\-unsorted\fR] [\fB\-\-unstable\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-d\fR|\fB\-\-working\-directory\fR] [\fB\-\-changelog\fR] [\fB\-\-choose\fR] [\fB\-c\fR|\fB\-\-command\fR] [\fB\-\-completions\fR] [\fB\-\-dump\fR] [\fB\-e\fR|\fB\-\-edit\fR] [\fB\-\-evaluate\fR] [\fB\-\-fmt\fR] [\fB\-\-init\fR] [\fB\-l\fR|\fB\-\-list\fR] [\fB\-\-groups\fR] [\fB\-\-man\fR] [\fB\-s\fR|\fB\-\-show\fR] [\fB\-\-summary\fR] [\fB\-\-variables\fR] [\fB\-\-dotenv\-filename\fR] [\fB\-E\fR|\fB\-\-dotenv\-path\fR] [\fB\-g\fR|\fB\-\-global\-justfile\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIARGUMENTS\fR] 
 .SH DESCRIPTION
 🤖 Just a command runner \- https://github.com/casey/just
 .SH OPTIONS
@@ -24,6 +24,9 @@ Print colorful output
 
 .br
 [\fIpossible values: \fRauto, always, never]
+.RS
+May also be specified with the \fBJUST_COLOR\fR environment variable. 
+.RE
 .TP
 \fB\-\-command\-color\fR
 Echo recipe lines in <COMMAND\-COLOR>
@@ -31,12 +34,18 @@ Echo recipe lines in <COMMAND\-COLOR>
 
 .br
 [\fIpossible values: \fRblack, blue, cyan, green, purple, red, yellow]
+.RS
+May also be specified with the \fBJUST_COMMAND_COLOR\fR environment variable. 
+.RE
 .TP
 \fB\-\-yes\fR
 Automatically confirm all recipes.
 .TP
 \fB\-n\fR, \fB\-\-dry\-run\fR
 Print what just would do without doing it
+.RS
+May also be specified with the \fBJUST_DRY_RUN\fR environment variable. 
+.RE
 .TP
 \fB\-\-dump\-format\fR=\fIFORMAT\fR [default: just]
 Dump justfile as <FORMAT>
@@ -68,9 +77,15 @@ Don\*(Aqt highlight echoed recipe lines in bold
 .TP
 \fB\-f\fR, \fB\-\-justfile\fR
 Use <JUSTFILE> as justfile
+.RS
+May also be specified with the \fBJUST_JUSTFILE\fR environment variable. 
+.RE
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Suppress all output
+.RS
+May also be specified with the \fBJUST_QUIET\fR environment variable. 
+.RE
 .TP
 \fB\-\-set\fR=\fIVARIABLE VALUE\fR
 Override <VARIABLE> with <VALUE>
@@ -98,9 +113,15 @@ May also be specified with the \fBJUST_UNSTABLE\fR environment variable.
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
 Use verbose output
+.RS
+May also be specified with the \fBJUST_VERBOSE\fR environment variable. 
+.RE
 .TP
 \fB\-d\fR, \fB\-\-working\-directory\fR
 Use <WORKING\-DIRECTORY> as working directory. \-\-justfile must also be set
+.RS
+May also be specified with the \fBJUST_WORKING_DIRECTORY\fR environment variable. 
+.RE
 .TP
 \fB\-\-changelog\fR
 Print changelog
@@ -136,6 +157,9 @@ Initialize new justfile in project root
 \fB\-l\fR, \fB\-\-list\fR
 List available recipes and their arguments
 .TP
+\fB\-\-groups\fR
+List recipe groups
+.TP
 \fB\-\-man\fR
 Print man page
 .TP
@@ -154,6 +178,9 @@ Search for environment file named <DOTENV\-FILENAME> instead of `.env`
 \fB\-E\fR, \fB\-\-dotenv\-path\fR
 Load <DOTENV\-PATH> as environment file instead of searching for one
 .TP
+\fB\-g\fR, \fB\-\-global\-justfile\fR
+Use global justfile
+.TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .TP
@@ -163,6 +190,6 @@ Print version
 [\fIARGUMENTS\fR]
 Overrides and recipe(s) to run, defaulting to the first recipe in the justfile
 .SH VERSION
-v1.26.0
+v1.27.0
 .SH AUTHORS
 Casey Rodarmor <casey@rodarmor.com>


### PR DESCRIPTION
- Bump version: 1.26.0 → 1.27.0
- Update changelog
- Update changelog contributor credits
- Update dependencies
- Update man page
- Update version references in readme