### PR TITLE
Added Windows aarch64 binary to releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
         - armv7-unknown-linux-musleabihf
         - x86_64-apple-darwin
         - x86_64-pc-windows-msvc
+        - aarch64-pc-windows-msvc
         - x86_64-unknown-linux-musl
         include:
         - target: aarch64-apple-darwin
@@ -38,6 +39,8 @@ jobs:
           os: macos-latest
           target_rustflags: ''
         - target: x86_64-pc-windows-msvc
+          os: windows-latest
+        - target: aarch64-pc-windows-msvc
           os: windows-latest
           target_rustflags: ''
         - target: x86_64-unknown-linux-musl
@@ -60,6 +63,11 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install gcc-arm-linux-gnueabihf
+
+    - name: Install AArch64 Toolchain (Windows)
+      if: ${{ matrix.target == 'aarch64-pc-windows-msvc' }}
+      run: |
+        rustup target add aarch64-pc-windows-msvc
 
     - name: Ref Type
       id: ref-type


### PR DESCRIPTION
This PR adds the binary for Windows on ARM to GitHub releases via cross compilation