### PR TITLE
Use spaced-separated recipe paths in `--choose`

### DIFF
--- a/src/namepath.rs
+++ b/src/namepath.rs
@@ -7,6 +7,13 @@ impl<'src> Namepath<'src> {
   pub(crate) fn join(&self, name: Name<'src>) -> Self {
     Self(self.0.iter().copied().chain(iter::once(name)).collect())
   }
+
+  pub(crate) fn spaced(&self) -> ModulePath {
+    ModulePath {
+      path: self.0.iter().map(|name| name.lexeme().into()).collect(),
+      spaced: true,
+    }
+  }
 }
 
 impl<'src> Display for Namepath<'src> {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -261,14 +261,15 @@ impl Subcommand {
     };
 
     for recipe in recipes {
-      if let Err(io_error) = child
-        .stdin
-        .as_mut()
-        .expect("Child was created with piped stdio")
-        .write_all(format!("{}\n", recipe.namepath).as_bytes())
-      {
-        return Err(Error::ChooserWrite { io_error, chooser });
-      }
+      write!(
+        child.stdin.as_mut().unwrap(),
+        "{}\n",
+        recipe.namepath.spaced()
+      )
+      .map_err(|io_error| Error::ChooserWrite {
+        io_error,
+        chooser: chooser.clone(),
+      })?;
     }
 
     let output = match child.wait_with_output() {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -261,9 +261,9 @@ impl Subcommand {
     };
 
     for recipe in recipes {
-      write!(
+      writeln!(
         child.stdin.as_mut().unwrap(),
-        "{}\n",
+        "{}",
         recipe.namepath.spaced()
       )
       .map_err(|io_error| Error::ChooserWrite {


### PR DESCRIPTION
Use space-separated recipe paths in `--choose`, since they are the preferred external notation over `::`-separated paths.