### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1785,7 +1785,7 @@ js-lint:
 [group('rust recipes')]
 [group('lint')]
 rust-lint:
-    echo 'Runninng Rust linter…'
+    echo 'Running Rust linter…'
 
 [group('lint')]
 cpp-lint:


### PR DESCRIPTION
Finding a typo when reading the doc about the new `Recipe Groups` feature.

Create this pull request to fix it.