### PR TITLE
Add [attribute: value] shorthand

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -42,7 +42,7 @@ impl AttributeDiscriminant {
 impl<'src> Attribute<'src> {
   pub(crate) fn new(
     name: Name<'src>,
-    mut arguments: Vec<StringLiteral<'src>>,
+    argument: Option<StringLiteral<'src>>,
   ) -> CompileResult<'src, Self> {
     use AttributeDiscriminant::*;
 
@@ -56,7 +56,7 @@ impl<'src> Attribute<'src> {
         })
       })?;
 
-    let found = arguments.len();
+    let found = argument.as_ref().iter().count();
     let range = discriminant.argument_range();
 
     if !range.contains(&found) {
@@ -71,9 +71,9 @@ impl<'src> Attribute<'src> {
     }
 
     Ok(match discriminant {
-      Confirm => Self::Confirm(arguments.pop()),
-      Doc => Self::Doc(arguments.pop()),
-      Group => Self::Group(arguments.pop().unwrap()),
+      Confirm => Self::Confirm(argument),
+      Doc => Self::Doc(argument),
+      Group => Self::Group(argument.unwrap()),
       Linux => Self::Linux,
       Macos => Self::Macos,
       NoCd => Self::NoCd,

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -58,7 +58,6 @@ impl<'src> Attribute<'src> {
 
     let found = argument.as_ref().iter().count();
     let range = discriminant.argument_range();
-
     if !range.contains(&found) {
       return Err(
         name.error(CompileErrorKind::AttributeArgumentCountMismatch {

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -42,7 +42,7 @@ impl AttributeDiscriminant {
 impl<'src> Attribute<'src> {
   pub(crate) fn new(
     name: Name<'src>,
-    argument: Option<StringLiteral<'src>>,
+    mut arguments: Vec<StringLiteral<'src>>,
   ) -> CompileResult<'src, Self> {
     use AttributeDiscriminant::*;
 
@@ -56,8 +56,7 @@ impl<'src> Attribute<'src> {
         })
       })?;
 
-    let found = argument.as_ref().iter().count();
-
+    let found = arguments.len();
     let range = discriminant.argument_range();
 
     if !range.contains(&found) {
@@ -72,9 +71,9 @@ impl<'src> Attribute<'src> {
     }
 
     Ok(match discriminant {
-      Confirm => Self::Confirm(argument),
-      Doc => Self::Doc(argument),
-      Group => Self::Group(argument.unwrap()),
+      Confirm => Self::Confirm(arguments.pop()),
+      Doc => Self::Doc(arguments.pop()),
+      Group => Self::Group(arguments.pop().unwrap()),
       Linux => Self::Linux,
       Macos => Self::Macos,
       NoCd => Self::NoCd,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -987,12 +987,10 @@ impl<'run, 'src> Parser<'run, 'src> {
       loop {
         let name = self.parse_name()?;
 
-        let maybe_argument = if self.next_is(Colon) {
-          self.presume(Colon)?;
+        let maybe_argument = if self.accepted(Colon)? {
           let arg = self.parse_string_literal()?;
           Some(arg)
-        } else if self.next_is(ParenL) {
-          self.presume(ParenL)?;
+        } else if self.accepted(ParenL)? {
           let arg = self.parse_string_literal()?;
           self.expect(ParenR)?;
           Some(arg)

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -72,7 +72,7 @@ fn multiple_attributes_one_line_error_message() {
     )
     .stderr(
       "
-        error: Expected ']', ',', or '(', but found identifier
+        error: Expected ']', ':', ',', or '(', but found identifier
          ——▶ justfile:1:17
           │
         1 │ [macos, windows linux]

--- a/tests/confirm.rs
+++ b/tests/confirm.rs
@@ -130,7 +130,7 @@ fn confirm_recipe_with_prompt_too_many_args() {
             echo confirmed
         ",
     )
-    .stderr("error: Expected ')', but found ','\n ——▶ justfile:1:64\n  │\n1 │ [confirm(\"This is dangerous - are you sure you want to run it?\",\"this second argument is not supported\")]\n  │                                                                ^\n")
+    .stderr("error: Attribute `confirm` got 2 arguments but takes at most 1 argument\n ——▶ justfile:1:2\n  │\n1 │ [confirm(\"This is dangerous - are you sure you want to run it?\",\"this second argument is not supported\")]\n  │  ^^^^^^^\n")
     .stdout("")
     .status(1)
     .run();

--- a/tests/confirm.rs
+++ b/tests/confirm.rs
@@ -130,7 +130,7 @@ fn confirm_recipe_with_prompt_too_many_args() {
             echo confirmed
         ",
     )
-    .stderr("error: Attribute `confirm` got 2 arguments but takes at most 1 argument\n ——▶ justfile:1:2\n  │\n1 │ [confirm(\"This is dangerous - are you sure you want to run it?\",\"this second argument is not supported\")]\n  │  ^^^^^^^\n")
+    .stderr("error: Expected ')', but found ','\n ——▶ justfile:1:64\n  │\n1 │ [confirm(\"This is dangerous - are you sure you want to run it?\",\"this second argument is not supported\")]\n  │                                                                ^\n")
     .stdout("")
     .status(1)
     .run();

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -126,11 +126,10 @@ fn list_groups_with_custom_prefix() {
   Test::new()
     .justfile(
       "
-        [group('B')]
+        [group: 'B']
         foo:
 
-        [group('A')]
-        [group('B')]
+        [group: 'A', group: 'B']
         bar:
       ",
     )

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -126,6 +126,30 @@ fn list_groups_with_custom_prefix() {
   Test::new()
     .justfile(
       "
+        [group('B')]
+        foo:
+
+        [group('A')]
+        [group('B')]
+        bar:
+      ",
+    )
+    .args(["--groups", "--list-prefix", "..."])
+    .stdout(
+      "
+      Recipe groups:
+      ...A
+      ...B
+      ",
+    )
+    .run();
+}
+
+#[test]
+fn list_groups_with_shorthand_syntax() {
+  Test::new()
+    .justfile(
+      "
         [group: 'B']
         foo:
 


### PR DESCRIPTION
https://github.com/casey/just/issues/2086

Adds a shorthand syntax `[attribute: value]` for attributes with a single argument, that is equivalent to `[attribute(value)]`.