### PR TITLE
Some evaluator simplifications

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,7 @@
 use super::*;
 
-pub(crate) struct RecipeContext<'src: 'run, 'run> {
+#[derive(Copy, Clone)]
+pub(crate) struct Context<'src: 'run, 'run> {
   pub(crate) config: &'run Config,
   pub(crate) dotenv: &'run BTreeMap<String, String>,
   pub(crate) module_source: &'run Path,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -16,7 +16,6 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     context: &'run RecipeContext,
     assignments: Option<&'run Table<'src, Assignment<'src>>>,
     scope: Scope<'src, 'run>,
-    search: &'run Search,
   ) -> Self {
     Self {
       assignments,
@@ -24,7 +23,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
       dotenv: context.dotenv,
       module_source: context.module_source,
       scope,
-      search,
+      search: context.search,
       settings: context.settings,
       unsets: context.unexports,
     }
@@ -277,9 +276,8 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     context: &'run RecipeContext<'src, 'run>,
     arguments: &[String],
     parameters: &[Parameter<'src>],
-    search: &'run Search,
   ) -> RunResult<'src, (Scope<'src, 'run>, Vec<String>)> {
-    let mut evaluator = Self::new(context, None, context.scope.child(), search);
+    let mut evaluator = Self::new(context, None, context.scope.child());
     let mut scope = context.scope.child();
 
     let mut positional = Vec::new();
@@ -320,9 +318,8 @@ impl<'src, 'run> Evaluator<'src, 'run> {
   pub(crate) fn recipe_evaluator(
     context: &'run RecipeContext,
     scope: &'run Scope<'src, 'run>,
-    search: &'run Search,
   ) -> Self {
-    Self::new(context, None, Scope::child(scope), search)
+    Self::new(context, None, Scope::child(scope))
   }
 }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -22,7 +22,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
       config,
       dotenv,
       module_source: &module.source,
-      scope: &parent,
+      scope: parent,
       search,
       settings: &module.settings,
       unexports: &module.unexports,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -283,11 +283,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     arguments: &[String],
     parameters: &[Parameter<'src>],
   ) -> RunResult<'src, (Scope<'src, 'run>, Vec<String>)> {
-    let mut evaluator = Self {
-      context: *context,
-      assignments: None,
-      scope: context.scope.child(),
-    };
+    let mut evaluator = Self::new(context, &context.scope);
 
     let mut positional = Vec::new();
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -8,7 +8,7 @@ pub(crate) struct Evaluator<'src: 'run, 'run> {
   pub(crate) scope: Scope<'src, 'run>,
   pub(crate) search: &'run Search,
   pub(crate) settings: &'run Settings<'run>,
-  unsets: &'run HashSet<String>,
+  unexports: &'run HashSet<String>,
 }
 
 impl<'src, 'run> Evaluator<'src, 'run> {
@@ -20,7 +20,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     scope: Scope<'src, 'run>,
     search: &'run Search,
     settings: &'run Settings<'run>,
-    unsets: &'run HashSet<String>,
+    unexports: &'run HashSet<String>,
   ) -> RunResult<'src, Scope<'src, 'run>> {
     let mut evaluator = Self {
       assignments: Some(assignments),
@@ -30,7 +30,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
       scope,
       search,
       settings,
-      unsets,
+      unexports,
     };
 
     for assignment in assignments.values() {
@@ -220,7 +220,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     cmd.arg(command);
     cmd.args(args);
     cmd.current_dir(&self.search.working_directory);
-    cmd.export(self.settings, self.dotenv, &self.scope, self.unsets);
+    cmd.export(self.settings, self.dotenv, &self.scope, self.unexports);
     cmd.stdin(Stdio::inherit());
     cmd.stderr(if self.config.verbosity.quiet() {
       Stdio::null()
@@ -311,7 +311,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
       scope,
       search: context.search,
       settings: context.settings,
-      unsets: context.unexports,
+      unexports: context.unexports,
     }
   }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -318,24 +318,11 @@ impl<'src, 'run> Evaluator<'src, 'run> {
   }
 
   pub(crate) fn recipe_evaluator(
-    config: &'run Config,
-    dotenv: &'run BTreeMap<String, String>,
-    module_source: &'run Path,
+    context: &'run RecipeContext,
     scope: &'run Scope<'src, 'run>,
     search: &'run Search,
-    settings: &'run Settings,
-    unsets: &'run HashSet<String>,
   ) -> Self {
-    Self {
-      assignments: None,
-      config,
-      dotenv,
-      module_source,
-      scope: Scope::child(scope),
-      search,
-      settings,
-      unsets,
-    }
+    Self::new(context, None, Scope::child(scope), search)
   }
 }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -12,23 +12,6 @@ pub(crate) struct Evaluator<'src: 'run, 'run> {
 }
 
 impl<'src, 'run> Evaluator<'src, 'run> {
-  fn new(
-    context: &'run RecipeContext,
-    assignments: Option<&'run Table<'src, Assignment<'src>>>,
-    scope: Scope<'src, 'run>,
-  ) -> Self {
-    Self {
-      assignments,
-      config: context.config,
-      dotenv: context.dotenv,
-      module_source: context.module_source,
-      scope,
-      search: context.search,
-      settings: context.settings,
-      unsets: context.unexports,
-    }
-  }
-
   pub(crate) fn evaluate_assignments(
     assignments: &'run Table<'src, Assignment<'src>>,
     config: &'run Config,
@@ -313,6 +296,23 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     }
 
     Ok((scope, positional))
+  }
+
+  fn new(
+    context: &'run RecipeContext,
+    assignments: Option<&'run Table<'src, Assignment<'src>>>,
+    scope: Scope<'src, 'run>,
+  ) -> Self {
+    Self {
+      assignments,
+      config: context.config,
+      dotenv: context.dotenv,
+      module_source: context.module_source,
+      scope,
+      search: context.search,
+      settings: context.settings,
+      unsets: context.unexports,
+    }
   }
 
   pub(crate) fn recipe_evaluator(

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -283,7 +283,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     arguments: &[String],
     parameters: &[Parameter<'src>],
   ) -> RunResult<'src, (Scope<'src, 'run>, Vec<String>)> {
-    let mut evaluator = Self::new(context, &context.scope);
+    let mut evaluator = Self::new(context, context.scope);
 
     let mut positional = Vec::new();
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -12,6 +12,24 @@ pub(crate) struct Evaluator<'src: 'run, 'run> {
 }
 
 impl<'src, 'run> Evaluator<'src, 'run> {
+  fn new(
+    context: &'run RecipeContext,
+    assignments: Option<&'run Table<'src, Assignment<'src>>>,
+    scope: Scope<'src, 'run>,
+    search: &'run Search,
+  ) -> Self {
+    Self {
+      assignments,
+      config: context.config,
+      dotenv: context.dotenv,
+      module_source: context.module_source,
+      scope,
+      search,
+      settings: context.settings,
+      unsets: context.unexports,
+    }
+  }
+
   pub(crate) fn evaluate_assignments(
     assignments: &'run Table<'src, Assignment<'src>>,
     config: &'run Config,
@@ -256,28 +274,13 @@ impl<'src, 'run> Evaluator<'src, 'run> {
   }
 
   pub(crate) fn evaluate_parameters(
+    context: &'run RecipeContext<'src, 'run>,
     arguments: &[String],
-    config: &'run Config,
-    dotenv: &'run BTreeMap<String, String>,
-    module_source: &'run Path,
     parameters: &[Parameter<'src>],
-    scope: &'run Scope<'src, 'run>,
     search: &'run Search,
-    settings: &'run Settings,
-    unsets: &'run HashSet<String>,
   ) -> RunResult<'src, (Scope<'src, 'run>, Vec<String>)> {
-    let mut evaluator = Self {
-      assignments: None,
-      config,
-      dotenv,
-      module_source,
-      scope: scope.child(),
-      search,
-      settings,
-      unsets,
-    };
-
-    let mut scope = scope.child();
+    let mut evaluator = Self::new(context, None, context.scope.child(), search);
+    let mut scope = context.scope.child();
 
     let mut positional = Vec::new();
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(crate) struct Evaluator<'src: 'run, 'run> {
   pub(crate) assignments: Option<&'run Table<'src, Assignment<'src>>>,
-  pub(crate) context: Context<'src, 'run>,
+  pub(crate) context: ExecutionContext<'src, 'run>,
   pub(crate) scope: Scope<'src, 'run>,
 }
 
@@ -18,7 +18,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
   where
     'src: 'run,
   {
-    let context = Context {
+    let context = ExecutionContext {
       config,
       dotenv,
       module_source: &module.source,
@@ -279,7 +279,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
   }
 
   pub(crate) fn evaluate_parameters(
-    context: &Context<'src, 'run>,
+    context: &ExecutionContext<'src, 'run>,
     arguments: &[String],
     parameters: &[Parameter<'src>],
   ) -> RunResult<'src, (Scope<'src, 'run>, Vec<String>)> {
@@ -326,7 +326,10 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     Ok((evaluator.scope, positional))
   }
 
-  pub(crate) fn new(context: &Context<'src, 'run>, scope: &'run Scope<'src, 'run>) -> Self {
+  pub(crate) fn new(
+    context: &ExecutionContext<'src, 'run>,
+    scope: &'run Scope<'src, 'run>,
+  ) -> Self {
     Self {
       context: *context,
       assignments: None,

--- a/src/execution_context.rs
+++ b/src/execution_context.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[derive(Copy, Clone)]
-pub(crate) struct Context<'src: 'run, 'run> {
+pub(crate) struct ExecutionContext<'src: 'run, 'run> {
   pub(crate) config: &'run Config,
   pub(crate) dotenv: &'run BTreeMap<String, String>,
   pub(crate) module_source: &'run Path,

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -237,7 +237,7 @@ impl<'src> Justfile<'src> {
 
     let mut ran = Ran::default();
     for invocation in invocations {
-      let context = Context {
+      let context = ExecutionContext {
         config,
         dotenv: &dotenv,
         module_source: invocation.module_source,
@@ -382,7 +382,7 @@ impl<'src> Justfile<'src> {
 
   fn run_recipe(
     arguments: &[String],
-    context: &Context<'src, '_>,
+    context: &ExecutionContext<'src, '_>,
     ran: &mut Ran<'src>,
     recipe: &Recipe<'src>,
   ) -> RunResult<'src> {

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -196,11 +196,7 @@ impl<'src> Justfile<'src> {
             });
           }
         } else {
-          let mut width = 0;
-
-          for name in scope.names() {
-            width = cmp::max(name.len(), width);
-          }
+          let width = scope.names().fold(0, |acc, name| cmp::max(name.len(), acc));
 
           for binding in scope.bindings() {
             println!(

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -156,7 +156,7 @@ impl<'src> Justfile<'src> {
             });
           }
         } else {
-          let width = scope.names().fold(0, |max, name| cmp::max(name.len(), max));
+          let width = scope.names().fold(0, |max, name| name.len().max(max));
 
           for binding in scope.bindings() {
             println!(

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -436,15 +436,7 @@ impl<'src> Justfile<'src> {
 
     let scope = outer.child();
 
-    let mut evaluator = Evaluator::recipe_evaluator(
-      context.config,
-      context.dotenv,
-      context.module_source,
-      &scope,
-      search,
-      context.settings,
-      context.unexports,
-    );
+    let mut evaluator = Evaluator::recipe_evaluator(context, &scope, search);
 
     let mut run_dependencies =
       |deps: &mut dyn Iterator<Item = &Dependency<'src>>, ran: &mut Ran<'src>| -> RunResult<'src> {

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -455,32 +455,28 @@ impl<'src> Justfile<'src> {
       context.unexports,
     );
 
-    if !context.config.no_dependencies {
-      for Dependency { recipe, arguments } in recipe.dependencies.iter().take(recipe.priors) {
-        let arguments = arguments
-          .iter()
-          .map(|argument| evaluator.evaluate_expression(argument))
-          .collect::<RunResult<Vec<String>>>()?;
+    let mut run_dependencies =
+      |deps: &mut dyn Iterator<Item = &Dependency<'src>>, ran: &mut Ran<'src>| -> RunResult<'src> {
+        if !context.config.no_dependencies {
+          for Dependency {
+            ref recipe,
+            ref arguments,
+          } in deps
+          {
+            let arguments = arguments
+              .iter()
+              .map(|argument| evaluator.evaluate_expression(argument))
+              .collect::<RunResult<Vec<String>>>()?;
 
-        Self::run_recipe(&arguments, context, ran, recipe, search)?;
-      }
-    }
-
-    recipe.run(context, &scope, &positional)?;
-
-    if !context.config.no_dependencies {
-      let mut ran = Ran::default();
-
-      for Dependency { recipe, arguments } in recipe.dependencies.iter().skip(recipe.priors) {
-        let mut evaluated = Vec::new();
-
-        for argument in arguments {
-          evaluated.push(evaluator.evaluate_expression(argument)?);
+            Self::run_recipe(&arguments, context, ran, recipe, search)?;
+          }
         }
+        Ok(())
+      };
 
-        Self::run_recipe(&evaluated, context, &mut ran, recipe, search)?;
-      }
-    }
+    run_dependencies(&mut recipe.dependencies.iter().take(recipe.priors), ran)?;
+    recipe.run(context, &scope, &positional)?;
+    run_dependencies(&mut recipe.dependencies.iter().skip(recipe.priors), &mut Ran::default())?;
 
     ran.ran(&recipe.namepath, arguments.to_vec());
 

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -297,7 +297,6 @@ impl<'src> Justfile<'src> {
         &context,
         &mut ran,
         invocation.recipe,
-        search,
       )?;
     }
 
@@ -419,7 +418,6 @@ impl<'src> Justfile<'src> {
     context: &RecipeContext<'src, '_>,
     ran: &mut Ran<'src>,
     recipe: &Recipe<'src>,
-    search: &Search,
   ) -> RunResult<'src> {
     if ran.has_run(&recipe.namepath, arguments) {
       return Ok(());
@@ -432,11 +430,11 @@ impl<'src> Justfile<'src> {
     }
 
     let (outer, positional) =
-      Evaluator::evaluate_parameters(context, arguments, &recipe.parameters, search)?;
+      Evaluator::evaluate_parameters(context, arguments, &recipe.parameters)?;
 
     let scope = outer.child();
 
-    let mut evaluator = Evaluator::recipe_evaluator(context, &scope, search);
+    let mut evaluator = Evaluator::recipe_evaluator(context, &scope);
 
     let mut run_dependencies =
       |deps: &mut dyn Iterator<Item = &Dependency<'src>>, ran: &mut Ran<'src>| -> RunResult<'src> {
@@ -448,7 +446,7 @@ impl<'src> Justfile<'src> {
               .map(|argument| evaluator.evaluate_expression(argument))
               .collect::<RunResult<Vec<String>>>()?;
 
-            Self::run_recipe(&arguments, context, ran, &dep.recipe, search)?;
+            Self::run_recipe(&arguments, context, ran, &dep.recipe)?;
           }
         }
         Ok(())

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -156,7 +156,7 @@ impl<'src> Justfile<'src> {
             });
           }
         } else {
-          let width = scope.names().fold(0, |acc, name| cmp::max(name.len(), acc));
+          let width = scope.names().fold(0, |max, name| cmp::max(name.len(), max));
 
           for binding in scope.bindings() {
             println!(

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -431,17 +431,8 @@ impl<'src> Justfile<'src> {
       });
     }
 
-    let (outer, positional) = Evaluator::evaluate_parameters(
-      arguments,
-      context.config,
-      context.dotenv,
-      context.module_source,
-      &recipe.parameters,
-      context.scope,
-      search,
-      context.settings,
-      context.unexports,
-    )?;
+    let (outer, positional) =
+      Evaluator::evaluate_parameters(context, arguments, &recipe.parameters, search)?;
 
     let scope = outer.child();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,19 +20,20 @@ pub(crate) use {
     color::Color, color_display::ColorDisplay, command_ext::CommandExt, compilation::Compilation,
     compile_error::CompileError, compile_error_kind::CompileErrorKind, compiler::Compiler,
     condition::Condition, conditional_operator::ConditionalOperator, config::Config,
-    config_error::ConfigError, constants::constants, context::Context, count::Count,
-    delimiter::Delimiter, dependency::Dependency, dump_format::DumpFormat, enclosure::Enclosure,
-    error::Error, evaluator::Evaluator, expression::Expression, fragment::Fragment,
-    function::Function, interrupt_guard::InterruptGuard, interrupt_handler::InterruptHandler,
-    item::Item, justfile::Justfile, keyed::Keyed, keyword::Keyword, lexer::Lexer, line::Line,
-    list::List, load_dotenv::load_dotenv, loader::Loader, module_path::ModulePath, name::Name,
-    namepath::Namepath, ordinal::Ordinal, output::output, output_error::OutputError,
-    parameter::Parameter, parameter_kind::ParameterKind, parser::Parser, platform::Platform,
-    platform_interface::PlatformInterface, position::Position, positional::Positional, ran::Ran,
-    range_ext::RangeExt, recipe::Recipe, recipe_resolver::RecipeResolver,
-    recipe_signature::RecipeSignature, scope::Scope, search::Search, search_config::SearchConfig,
-    search_error::SearchError, set::Set, setting::Setting, settings::Settings, shebang::Shebang,
-    shell::Shell, show_whitespace::ShowWhitespace, source::Source, string_kind::StringKind,
+    config_error::ConfigError, constants::constants, count::Count, delimiter::Delimiter,
+    dependency::Dependency, dump_format::DumpFormat, enclosure::Enclosure, error::Error,
+    evaluator::Evaluator, execution_context::ExecutionContext, expression::Expression,
+    fragment::Fragment, function::Function, interrupt_guard::InterruptGuard,
+    interrupt_handler::InterruptHandler, item::Item, justfile::Justfile, keyed::Keyed,
+    keyword::Keyword, lexer::Lexer, line::Line, list::List, load_dotenv::load_dotenv,
+    loader::Loader, module_path::ModulePath, name::Name, namepath::Namepath, ordinal::Ordinal,
+    output::output, output_error::OutputError, parameter::Parameter, parameter_kind::ParameterKind,
+    parser::Parser, platform::Platform, platform_interface::PlatformInterface, position::Position,
+    positional::Positional, ran::Ran, range_ext::RangeExt, recipe::Recipe,
+    recipe_resolver::RecipeResolver, recipe_signature::RecipeSignature, scope::Scope,
+    search::Search, search_config::SearchConfig, search_error::SearchError, set::Set,
+    setting::Setting, settings::Settings, shebang::Shebang, shell::Shell,
+    show_whitespace::ShowWhitespace, source::Source, string_kind::StringKind,
     string_literal::StringLiteral, subcommand::Subcommand, suggestion::Suggestion, table::Table,
     thunk::Thunk, token::Token, token_kind::TokenKind, unresolved_dependency::UnresolvedDependency,
     unresolved_recipe::UnresolvedRecipe, use_color::UseColor, variables::Variables,
@@ -131,7 +132,6 @@ mod conditional_operator;
 mod config;
 mod config_error;
 mod constants;
-mod context;
 mod count;
 mod delimiter;
 mod dependency;
@@ -139,6 +139,7 @@ mod dump_format;
 mod enclosure;
 mod error;
 mod evaluator;
+mod execution_context;
 mod expression;
 mod fragment;
 mod function;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,20 +20,19 @@ pub(crate) use {
     color::Color, color_display::ColorDisplay, command_ext::CommandExt, compilation::Compilation,
     compile_error::CompileError, compile_error_kind::CompileErrorKind, compiler::Compiler,
     condition::Condition, conditional_operator::ConditionalOperator, config::Config,
-    config_error::ConfigError, constants::constants, count::Count, delimiter::Delimiter,
-    dependency::Dependency, dump_format::DumpFormat, enclosure::Enclosure, error::Error,
-    evaluator::Evaluator, expression::Expression, fragment::Fragment, function::Function,
-    interrupt_guard::InterruptGuard, interrupt_handler::InterruptHandler, item::Item,
-    justfile::Justfile, keyed::Keyed, keyword::Keyword, lexer::Lexer, line::Line, list::List,
-    load_dotenv::load_dotenv, loader::Loader, module_path::ModulePath, name::Name,
+    config_error::ConfigError, constants::constants, context::Context, count::Count,
+    delimiter::Delimiter, dependency::Dependency, dump_format::DumpFormat, enclosure::Enclosure,
+    error::Error, evaluator::Evaluator, expression::Expression, fragment::Fragment,
+    function::Function, interrupt_guard::InterruptGuard, interrupt_handler::InterruptHandler,
+    item::Item, justfile::Justfile, keyed::Keyed, keyword::Keyword, lexer::Lexer, line::Line,
+    list::List, load_dotenv::load_dotenv, loader::Loader, module_path::ModulePath, name::Name,
     namepath::Namepath, ordinal::Ordinal, output::output, output_error::OutputError,
     parameter::Parameter, parameter_kind::ParameterKind, parser::Parser, platform::Platform,
     platform_interface::PlatformInterface, position::Position, positional::Positional, ran::Ran,
-    range_ext::RangeExt, recipe::Recipe, recipe_context::RecipeContext,
-    recipe_resolver::RecipeResolver, recipe_signature::RecipeSignature, scope::Scope,
-    search::Search, search_config::SearchConfig, search_error::SearchError, set::Set,
-    setting::Setting, settings::Settings, shebang::Shebang, shell::Shell,
-    show_whitespace::ShowWhitespace, source::Source, string_kind::StringKind,
+    range_ext::RangeExt, recipe::Recipe, recipe_resolver::RecipeResolver,
+    recipe_signature::RecipeSignature, scope::Scope, search::Search, search_config::SearchConfig,
+    search_error::SearchError, set::Set, setting::Setting, settings::Settings, shebang::Shebang,
+    shell::Shell, show_whitespace::ShowWhitespace, source::Source, string_kind::StringKind,
     string_literal::StringLiteral, subcommand::Subcommand, suggestion::Suggestion, table::Table,
     thunk::Thunk, token::Token, token_kind::TokenKind, unresolved_dependency::UnresolvedDependency,
     unresolved_recipe::UnresolvedRecipe, use_color::UseColor, variables::Variables,
@@ -132,6 +131,7 @@ mod conditional_operator;
 mod config;
 mod config_error;
 mod constants;
+mod context;
 mod count;
 mod delimiter;
 mod dependency;
@@ -169,7 +169,6 @@ mod positional;
 mod ran;
 mod range_ext;
 mod recipe;
-mod recipe_context;
 mod recipe_resolver;
 mod recipe_signature;
 mod run;

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -162,15 +162,7 @@ impl<'src, D> Recipe<'src, D> {
       );
     }
 
-    let evaluator = Evaluator::recipe_evaluator(
-      context.config,
-      context.dotenv,
-      context.module_source,
-      scope,
-      context.search,
-      context.settings,
-      context.unexports,
-    );
+    let evaluator = Evaluator::recipe_evaluator(context, scope, context.search);
 
     if self.shebang {
       self.run_shebang(context, scope, positional, config, evaluator)

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -146,7 +146,7 @@ impl<'src, D> Recipe<'src, D> {
 
   pub(crate) fn run<'run>(
     &self,
-    context: &Context<'src, 'run>,
+    context: &ExecutionContext<'src, 'run>,
     scope: &Scope<'src, 'run>,
     positional: &[String],
   ) -> RunResult<'src, ()> {
@@ -173,7 +173,7 @@ impl<'src, D> Recipe<'src, D> {
 
   fn run_linewise<'run>(
     &self,
-    context: &Context<'src, 'run>,
+    context: &ExecutionContext<'src, 'run>,
     scope: &Scope<'src, 'run>,
     positional: &[String],
     config: &Config,
@@ -305,7 +305,7 @@ impl<'src, D> Recipe<'src, D> {
 
   pub(crate) fn run_shebang<'run>(
     &self,
-    context: &Context<'src, 'run>,
+    context: &ExecutionContext<'src, 'run>,
     scope: &Scope<'src, 'run>,
     positional: &[String],
     config: &Config,

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -146,7 +146,7 @@ impl<'src, D> Recipe<'src, D> {
 
   pub(crate) fn run<'run>(
     &self,
-    context: &RecipeContext<'src, 'run>,
+    context: &Context<'src, 'run>,
     scope: &Scope<'src, 'run>,
     positional: &[String],
   ) -> RunResult<'src, ()> {
@@ -162,7 +162,7 @@ impl<'src, D> Recipe<'src, D> {
       );
     }
 
-    let evaluator = Evaluator::recipe_evaluator(context, scope);
+    let evaluator = Evaluator::new(context, scope);
 
     if self.shebang {
       self.run_shebang(context, scope, positional, config, evaluator)
@@ -173,7 +173,7 @@ impl<'src, D> Recipe<'src, D> {
 
   fn run_linewise<'run>(
     &self,
-    context: &RecipeContext<'src, 'run>,
+    context: &Context<'src, 'run>,
     scope: &Scope<'src, 'run>,
     positional: &[String],
     config: &Config,
@@ -305,7 +305,7 @@ impl<'src, D> Recipe<'src, D> {
 
   pub(crate) fn run_shebang<'run>(
     &self,
-    context: &RecipeContext<'src, 'run>,
+    context: &Context<'src, 'run>,
     scope: &Scope<'src, 'run>,
     positional: &[String],
     config: &Config,

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -162,7 +162,7 @@ impl<'src, D> Recipe<'src, D> {
       );
     }
 
-    let evaluator = Evaluator::recipe_evaluator(context, scope, context.search);
+    let evaluator = Evaluator::recipe_evaluator(context, scope);
 
     if self.shebang {
       self.run_shebang(context, scope, positional, config, evaluator)


### PR DESCRIPTION
This PR modifies some of the methods on `Evaluator` that accept a large number of arguments to instead accept a `RecipeContext`, which already contains most of those arguments, which allows the call sites to be more concise. 

It also deduplicates some of the code around running recipe dependencies, and replaces a mutable variable update with a fold expression.