### PR TITLE
Enhance Fish Shell Completions for Optional --justfile Argument

### DIFF
--- a/src/completions.rs
+++ b/src/completions.rs
@@ -94,7 +94,7 @@ export extern "just" [
 ]"#;
 
 const FISH_RECIPE_COMPLETIONS: &str = r#"function __fish_just_complete_recipes
-        if string match -rq '(-f|--justfile)\s*=?(?<justfile>[^\s]+)' -- (commandline -pc)
+        if string match -rq '(-f|--justfile)\s*=?(?<justfile>[^\s]+)' -- (string split -- ' -- ' (commandline -pc))[1]
           set -fx JUST_JUSTFILE "$justfile"
         end
         just --list 2> /dev/null | tail -n +2 | awk '{

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -94,6 +94,9 @@ export extern "just" [
 ]"#;
 
 const FISH_RECIPE_COMPLETIONS: &str = r#"function __fish_just_complete_recipes
+        if string match -rq '(-f|--justfile)\s*=?(?<justfile>[^\s]+)' -- (commandline -pc)
+          set -fx JUST_JUSTFILE "$justfile"
+        end
         just --list 2> /dev/null | tail -n +2 | awk '{
         command = $1;
         args = $0;


### PR DESCRIPTION
This pull request introduces a minor enhancement to the Fish shell completion script.

**Changes:**
- Added logic to dynamically set the `JUST_JUSTFILE` environment variable when the `-f` or `--justfile` argument is provided in the command line.

**Motivation for the Change:**

Currently, users specifying a custom justfile with `-f` or `--justfile` do not have this reflected in their completions within the Fish shell. This can lead to inconsistencies and an unintuitive user experience. By setting the `JUST_JUSTFILE` environment variable, the change is as minimal as it could be and completions will be more accurate by reflecting the correct justfile being used.

**Further Notes:**

- This change adds only three lines of code to enhance the existing Fish shell completions.
- It retains backward compatibility and only enhances the functionality for those who use a custom justfile.

**Testing:**

- Tested manually with various `just` commands in Fish shell, both with and without the `-f`/`--justfile` options, to ensure appropriate behavior.

I hope these enhancements provide a more seamless experience for `just` users leveraging Fish shell completions.

Thank you for considering this improvement!
