### PR TITLE
Release 1.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+[1.29.1](https://github.com/casey/just/releases/tag/1.29.1) - 2024-06-14
+------------------------------------------------------------------------
+
+### Fixed
+- Fix unexport syntax conflicts ([#2158](https://github.com/casey/just/pull/2158))
+
 [1.29.0](https://github.com/casey/just/releases/tag/1.29.0) - 2024-06-13
 ------------------------------------------------------------------------
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "just"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "ansi_term",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "just"
-version = "1.29.0"
+version = "1.29.1"
 authors = ["Casey Rodarmor <casey@rodarmor.com>"]
 autotests = false
 categories = ["command-line-utilities", "development-tools"]


### PR DESCRIPTION
- Bump version: 1.29.0 → 1.29.1
- Update changelog
- Update changelog contributor credits