### PR TITLE
Remove dependency on cradle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,15 +307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cradle"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7096122c1023d53de7298f322590170540ad3eba46bbc2750b495f098c27c09a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,7 +600,6 @@ dependencies = [
  "clap 4.5.7",
  "clap_complete",
  "clap_mangen",
- "cradle",
  "ctrlc",
  "derivative",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ unicode-width = "0.1.0"
 uuid = { version = "1.0.0", features = ["v4"] }
 
 [dev-dependencies]
-cradle = "0.2.0"
 executable-path = "1.0.0"
 pretty_assertions = "1.0.0"
 temptree = "0.2.0"

--- a/tests/choose.rs
+++ b/tests/choose.rs
@@ -185,7 +185,13 @@ fn status_error() {
     "exit-2": "#!/usr/bin/env bash\nexit 2\n",
   };
 
-  ("chmod", "+x", &tmp.path().join("exit-2")).run();
+  let output = Command::new("chmod")
+    .arg("+x")
+    .arg(tmp.path().join("exit-2"))
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
 
   let path = env::join_paths(
     iter::once(tmp.path().to_owned()).chain(env::split_paths(&env::var_os("PATH").unwrap())),

--- a/tests/choose.rs
+++ b/tests/choose.rs
@@ -185,7 +185,7 @@ fn status_error() {
     "exit-2": "#!/usr/bin/env bash\nexit 2\n",
   };
 
-  ("chmod", "+x", tmp.path().join("exit-2")).run();
+  ("chmod", "+x", &tmp.path().join("exit-2")).run();
 
   let path = env::join_paths(
     iter::once(tmp.path().to_owned()).chain(env::split_paths(&env::var_os("PATH").unwrap())),

--- a/tests/edit.rs
+++ b/tests/edit.rs
@@ -64,7 +64,13 @@ fn status_error() {
     "exit-2": "#!/usr/bin/env bash\nexit 2\n",
   };
 
-  ("chmod", "+x", &tmp.path().join("exit-2")).run();
+  let output = Command::new("chmod")
+    .arg("+x")
+    .arg(tmp.path().join("exit-2"))
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
 
   let path = env::join_paths(
     iter::once(tmp.path().to_owned()).chain(env::split_paths(&env::var_os("PATH").unwrap())),

--- a/tests/edit.rs
+++ b/tests/edit.rs
@@ -64,7 +64,7 @@ fn status_error() {
     "exit-2": "#!/usr/bin/env bash\nexit 2\n",
   };
 
-  ("chmod", "+x", tmp.path().join("exit-2")).run();
+  ("chmod", "+x", &tmp.path().join("exit-2")).run();
 
   let path = env::join_paths(
     iter::once(tmp.path().to_owned()).chain(env::split_paths(&env::var_os("PATH").unwrap())),

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -126,7 +126,13 @@ fn write_error() {
 
   let justfile_path = test.justfile_path();
 
-  ("chmod", "400", &justfile_path).run();
+  let output = Command::new("chmod")
+    .arg("400")
+    .arg(&justfile_path)
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
 
   let _tempdir = test.run();
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,7 +5,6 @@ pub(crate) use {
     tempdir::tempdir,
     test::{assert_eval_eq, Output, Test},
   },
-  cradle::input::Input,
   executable_path::executable_path,
   just::unindent,
   libc::{EXIT_FAILURE, EXIT_SUCCESS},
@@ -126,5 +125,19 @@ fn path_for_regex(s: &str) -> String {
     s.replace('/', "\\\\")
   } else {
     s.into()
+  }
+}
+
+trait JustRun {
+  fn run(&self);
+}
+
+impl JustRun for (&str, &str, &PathBuf) {
+  fn run(&self) {
+    Command::new(self.0)
+      .arg(self.1)
+      .arg(self.2)
+      .output()
+      .unwrap();
   }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -127,17 +127,3 @@ fn path_for_regex(s: &str) -> String {
     s.into()
   }
 }
-
-trait JustRun {
-  fn run(&self);
-}
-
-impl JustRun for (&str, &str, &PathBuf) {
-  fn run(&self) {
-    Command::new(self.0)
-      .arg(self.1)
-      .arg(self.2)
-      .output()
-      .unwrap();
-  }
-}


### PR DESCRIPTION
...as an effort of minimizing dependencies in Debian. Since the tests are meant to pass, I just `unwrap()`'d it.

`JustRun` is just an improvised name, as well as its placement. Do advice if you just don't like that.