### PR TITLE
Ignore errors from env_logger init.

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -11,7 +11,8 @@ pub fn run() -> Result<(), i32> {
       .filter("JUST_LOG")
       .write_style("JUST_LOG_STYLE"),
   )
-  .init();
+  .try_init()
+  .ok();
 
   let app = Config::app();
 


### PR DESCRIPTION
I want to use `just` as a rust library from my existing rust application, which already uses env_logger:

```
use env_logger::Env;

fn main() {
    env_logger::init_from_env(
        Env::default()
            .filter_or("LOG_LEVEL", "warn")
            .write_style_or("LOG_STYLE", "always"),
    );
    set_env_default("DATABASE_URL");

    // This fails with env_logger double initialization error:
    if let Err(code) = just::run() {
        std::process::exit(code);
    }
}
```

If I run `just::run()` after I have already initialized `env_logger`, I get this error:

```
Builder::init should not be called after logger initialized: SetLoggerError(())
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

It looks like the correct fix is to use env_logger's [try_init](https://docs.rs/env_logger/latest/env_logger/fn.try_init.html#) instead, and so that's what I've done, which fixes the above code to have no more errors.