### PR TITLE
Adds `just::run_with_args` to provide arguments from Rust code

### DIFF
--- a/examples/run-with-args.rs
+++ b/examples/run-with-args.rs
@@ -1,0 +1,8 @@
+// Example showing how to run just commands from Rust code:
+
+fn main() {
+  let args = vec!["-f", "kitchen-sink.just", "foo"];
+  if let Err(code) = just::run_with_args(args) {
+    std::process::exit(code);
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub(crate) use {
 pub(crate) use crate::{node::Node, tree::Tree};
 
 pub use crate::run::run;
+pub use crate::run::run_with_args;
 
 // Used in integration tests.
 #[doc(hidden)]

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,8 +1,34 @@
 use super::*;
 
-/// Main entry point into just binary.
-#[allow(clippy::missing_errors_doc)]
+/// ArgSource controls where the program arguments are received from.
+enum ArgSource {
+  OS,
+  Is(Vec<String>),
+}
+
+/// Main entry point into just binary, taking arguments provided by the OS.
 pub fn run() -> Result<(), i32> {
+  run_with_arg_source(ArgSource::OS)
+}
+
+/// Main entry point into just library, taking arguments provided by Vec<&str>
+pub fn run_with_args(args: Vec<&str>) -> Result<(), i32> {
+  let args: Vec<String> = Vec::from_iter(
+    vec!["just".to_string()].into_iter().chain(
+      args
+        .iter()
+        .map(|&s| s.into())
+        .collect::<Vec<String>>()
+        .iter()
+        .cloned(),
+    ),
+  );
+  run_with_arg_source(ArgSource::Is(args))
+}
+
+/// Main entry point which takes arguments from a configurable source.
+#[allow(clippy::missing_errors_doc)]
+fn run_with_arg_source(arg_source: ArgSource) -> Result<(), i32> {
   #[cfg(windows)]
   ansi_term::enable_ansi_support().ok();
 
@@ -17,7 +43,10 @@ pub fn run() -> Result<(), i32> {
   let app = Config::app();
 
   info!("Parsing command line arguments…");
-  let matches = app.get_matches();
+  let matches = match arg_source {
+    ArgSource::OS => app.get_matches(),
+    ArgSource::Is(value) => app.get_matches_from(value),
+  };
 
   let config = Config::from_matches(&matches).map_err(Error::from);
 


### PR DESCRIPTION
This adds a new method to run just commands passed from a Vec<&str>.

I found [this blog post](https://www.kirillvasiltsov.com/writing/optional-arguments-in-rust/) where I copied this pattern for optional arguments, I didn't want to mess with the original arity of the run() method, so I made a second method for passing args, and a third to consolidate the common logic, but maybe there's a better way?

This example runs the `foo` target:

```
cargo run --example run-with-args
 ## (stdout): bar
```

I don't quite know how to test this yet either, because I'm not forking the process, I don't think I can capture stdout like the other tests do.