### PR TITLE
Use clap ValueParser for command-line configuration parsing

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -135,9 +135,9 @@ impl Color {
 }
 
 impl From<UseColor> for Color {
-  fn from(value: UseColor) -> Self {
+  fn from(use_color: UseColor) -> Self {
     Self {
-      use_color: value,
+      use_color,
       ..Default::default()
     }
   }

--- a/src/color.rs
+++ b/src/color.rs
@@ -38,6 +38,7 @@ impl Color {
     }
   }
 
+  #[cfg(test)]
   pub(crate) fn always() -> Self {
     Self {
       use_color: UseColor::Always,
@@ -130,6 +131,15 @@ impl Color {
 
   pub(crate) fn suffix(&self) -> Suffix {
     self.effective_style().suffix()
+  }
+}
+
+impl From<UseColor> for Color {
+  fn from(value: UseColor) -> Self {
+    Self {
+      use_color: value,
+      ..Default::default()
+    }
   }
 }
 

--- a/src/command_color.rs
+++ b/src/command_color.rs
@@ -11,16 +11,16 @@ pub(crate) enum CommandColor {
   Yellow,
 }
 
-impl Into<ansi_term::Color> for CommandColor {
-  fn into(self) -> ansi_term::Color {
-    match self {
-      Self::Black => ansi_term::Color::Black,
-      Self::Blue => ansi_term::Color::Blue,
-      Self::Cyan => ansi_term::Color::Cyan,
-      Self::Green => ansi_term::Color::Green,
-      Self::Purple => ansi_term::Color::Purple,
-      Self::Red => ansi_term::Color::Red,
-      Self::Yellow => ansi_term::Color::Yellow,
+impl From<CommandColor> for ansi_term::Color {
+  fn from(command_color: CommandColor) -> Self {
+    match command_color {
+      CommandColor::Black => Self::Black,
+      CommandColor::Blue => Self::Blue,
+      CommandColor::Cyan => Self::Cyan,
+      CommandColor::Green => Self::Green,
+      CommandColor::Purple => Self::Purple,
+      CommandColor::Red => Self::Red,
+      CommandColor::Yellow => Self::Yellow,
     }
   }
 }

--- a/src/command_color.rs
+++ b/src/command_color.rs
@@ -1,0 +1,26 @@
+use super::*;
+
+#[derive(Copy, Clone, ValueEnum)]
+pub(crate) enum CommandColor {
+  Black,
+  Blue,
+  Cyan,
+  Green,
+  Purple,
+  Red,
+  Yellow,
+}
+
+impl Into<ansi_term::Color> for CommandColor {
+  fn into(self) -> ansi_term::Color {
+    match self {
+      Self::Black => ansi_term::Color::Black,
+      Self::Blue => ansi_term::Color::Blue,
+      Self::Cyan => ansi_term::Color::Cyan,
+      Self::Green => ansi_term::Color::Green,
+      Self::Purple => ansi_term::Color::Purple,
+      Self::Red => ansi_term::Color::Red,
+      Self::Yellow => ansi_term::Color::Yellow,
+    }
+  }
+}

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,4 +1,4 @@
-use {super::*, clap::ValueEnum};
+use super::*;
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq)]
 pub(crate) enum Shell {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,7 @@
 use {
   super::*,
   clap::{
-    builder::{
-      styling::AnsiColor, FalseyValueParser, PossibleValuesParser, Styles, TypedValueParser,
-    },
+    builder::{styling::AnsiColor, FalseyValueParser, Styles},
     parser::ValuesRef,
     value_parser, Arg, ArgAction, ArgGroup, ArgMatches, Command,
   },
@@ -110,23 +108,6 @@ mod arg {
   pub(crate) const VERBOSE: &str = "VERBOSE";
   pub(crate) const WORKING_DIRECTORY: &str = "WORKING-DIRECTORY";
   pub(crate) const YES: &str = "YES";
-
-  pub(crate) const COMMAND_COLOR_BLACK: &str = "black";
-  pub(crate) const COMMAND_COLOR_BLUE: &str = "blue";
-  pub(crate) const COMMAND_COLOR_CYAN: &str = "cyan";
-  pub(crate) const COMMAND_COLOR_GREEN: &str = "green";
-  pub(crate) const COMMAND_COLOR_PURPLE: &str = "purple";
-  pub(crate) const COMMAND_COLOR_RED: &str = "red";
-  pub(crate) const COMMAND_COLOR_YELLOW: &str = "yellow";
-  pub(crate) const COMMAND_COLOR_VALUES: &[&str] = &[
-    COMMAND_COLOR_BLACK,
-    COMMAND_COLOR_BLUE,
-    COMMAND_COLOR_CYAN,
-    COMMAND_COLOR_GREEN,
-    COMMAND_COLOR_PURPLE,
-    COMMAND_COLOR_RED,
-    COMMAND_COLOR_YELLOW,
-  ];
 }
 
 impl Config {
@@ -186,22 +167,7 @@ impl Config {
           .long("command-color")
           .env("JUST_COMMAND_COLOR")
           .action(ArgAction::Set)
-          .value_parser(
-            PossibleValuesParser::new(arg::COMMAND_COLOR_VALUES).try_map(|value| {
-              match value.as_str() {
-                arg::COMMAND_COLOR_BLACK => Ok(ansi_term::Color::Black),
-                arg::COMMAND_COLOR_BLUE => Ok(ansi_term::Color::Blue),
-                arg::COMMAND_COLOR_CYAN => Ok(ansi_term::Color::Cyan),
-                arg::COMMAND_COLOR_GREEN => Ok(ansi_term::Color::Green),
-                arg::COMMAND_COLOR_PURPLE => Ok(ansi_term::Color::Purple),
-                arg::COMMAND_COLOR_RED => Ok(ansi_term::Color::Red),
-                arg::COMMAND_COLOR_YELLOW => Ok(ansi_term::Color::Yellow),
-                value => Err(ConfigError::Internal {
-                  message: format!("Invalid argument `{value}` to --command-color."),
-                }),
-              }
-            }),
-          )
+          .value_parser(clap::value_parser!(CommandColor))
           .help("Echo recipe lines in <COMMAND-COLOR>"),
       )
       .arg(
@@ -705,8 +671,9 @@ impl Config {
       check: matches.get_flag(arg::CHECK),
       color: (*matches.get_one::<UseColor>(arg::COLOR).unwrap()).into(),
       command_color: matches
-        .get_one::<ansi_term::Color>(arg::COMMAND_COLOR)
-        .copied(),
+        .get_one::<CommandColor>(arg::COMMAND_COLOR)
+        .copied()
+        .map(|command_color| command_color.into()),
       dotenv_filename: matches
         .get_one::<String>(arg::DOTENV_FILENAME)
         .map(Into::into),

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,8 +111,6 @@ mod arg {
   pub(crate) const WORKING_DIRECTORY: &str = "WORKING-DIRECTORY";
   pub(crate) const YES: &str = "YES";
 
-  pub(crate) const COLOR_AUTO: &str = "auto";
-
   pub(crate) const COMMAND_COLOR_BLACK: &str = "black";
   pub(crate) const COMMAND_COLOR_BLUE: &str = "blue";
   pub(crate) const COMMAND_COLOR_CYAN: &str = "cyan";
@@ -129,8 +127,6 @@ mod arg {
     COMMAND_COLOR_RED,
     COMMAND_COLOR_YELLOW,
   ];
-
-  pub(crate) const DUMP_FORMAT_JUST: &str = "just";
 }
 
 impl Config {
@@ -182,7 +178,7 @@ impl Config {
           .env("JUST_COLOR")
           .action(ArgAction::Set)
           .value_parser(clap::value_parser!(UseColor))
-          .default_value(arg::COLOR_AUTO)
+          .default_value("auto")
           .help("Print colorful output"),
       )
       .arg(
@@ -238,7 +234,7 @@ impl Config {
           .env("JUST_DUMP_FORMAT")
           .action(ArgAction::Set)
           .value_parser(clap::value_parser!(DumpFormat))
-          .default_value(arg::DUMP_FORMAT_JUST)
+          .default_value("just")
           .value_name("FORMAT")
           .help("Dump justfile as <FORMAT>"),
       )

--- a/src/config.rs
+++ b/src/config.rs
@@ -673,7 +673,7 @@ impl Config {
       command_color: matches
         .get_one::<CommandColor>(arg::COMMAND_COLOR)
         .copied()
-        .map(|command_color| command_color.into()),
+        .map(CommandColor::into),
       dotenv_filename: matches
         .get_one::<String>(arg::DOTENV_FILENAME)
         .map(Into::into),

--- a/src/dump_format.rs
+++ b/src/dump_format.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, clap::ValueEnum)]
 pub(crate) enum DumpFormat {
   Json,
   Just,

--- a/src/dump_format.rs
+++ b/src/dump_format.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, PartialEq, Clone, clap::ValueEnum)]
+use super::*;
+
+#[derive(Debug, PartialEq, Clone, ValueEnum)]
 pub(crate) enum DumpFormat {
   Json,
   Just,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub(crate) use {
     verbosity::Verbosity, warning::Warning,
   },
   camino::Utf8Path,
+  clap::ValueEnum,
   derivative::Derivative,
   edit_distance::edit_distance,
   lexiclean::Lexiclean,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,23 +23,23 @@ pub(crate) use {
   crate::{
     alias::Alias, analyzer::Analyzer, argument_parser::ArgumentParser, assignment::Assignment,
     assignment_resolver::AssignmentResolver, ast::Ast, attribute::Attribute, binding::Binding,
-    color::Color, color_display::ColorDisplay, command_ext::CommandExt, compilation::Compilation,
-    compile_error::CompileError, compile_error_kind::CompileErrorKind, compiler::Compiler,
-    condition::Condition, conditional_operator::ConditionalOperator, config::Config,
-    config_error::ConfigError, constants::constants, count::Count, delimiter::Delimiter,
-    dependency::Dependency, dump_format::DumpFormat, enclosure::Enclosure, error::Error,
-    evaluator::Evaluator, execution_context::ExecutionContext, expression::Expression,
-    fragment::Fragment, function::Function, interrupt_guard::InterruptGuard,
-    interrupt_handler::InterruptHandler, item::Item, justfile::Justfile, keyed::Keyed,
-    keyword::Keyword, lexer::Lexer, line::Line, list::List, load_dotenv::load_dotenv,
-    loader::Loader, module_path::ModulePath, name::Name, namepath::Namepath, ordinal::Ordinal,
-    output::output, output_error::OutputError, parameter::Parameter, parameter_kind::ParameterKind,
-    parser::Parser, platform::Platform, platform_interface::PlatformInterface, position::Position,
-    positional::Positional, ran::Ran, range_ext::RangeExt, recipe::Recipe,
-    recipe_resolver::RecipeResolver, recipe_signature::RecipeSignature, scope::Scope,
-    search::Search, search_config::SearchConfig, search_error::SearchError, set::Set,
-    setting::Setting, settings::Settings, shebang::Shebang, shell::Shell,
-    show_whitespace::ShowWhitespace, source::Source, string_kind::StringKind,
+    color::Color, color_display::ColorDisplay, command_color::CommandColor,
+    command_ext::CommandExt, compilation::Compilation, compile_error::CompileError,
+    compile_error_kind::CompileErrorKind, compiler::Compiler, condition::Condition,
+    conditional_operator::ConditionalOperator, config::Config, config_error::ConfigError,
+    constants::constants, count::Count, delimiter::Delimiter, dependency::Dependency,
+    dump_format::DumpFormat, enclosure::Enclosure, error::Error, evaluator::Evaluator,
+    execution_context::ExecutionContext, expression::Expression, fragment::Fragment,
+    function::Function, interrupt_guard::InterruptGuard, interrupt_handler::InterruptHandler,
+    item::Item, justfile::Justfile, keyed::Keyed, keyword::Keyword, lexer::Lexer, line::Line,
+    list::List, load_dotenv::load_dotenv, loader::Loader, module_path::ModulePath, name::Name,
+    namepath::Namepath, ordinal::Ordinal, output::output, output_error::OutputError,
+    parameter::Parameter, parameter_kind::ParameterKind, parser::Parser, platform::Platform,
+    platform_interface::PlatformInterface, position::Position, positional::Positional, ran::Ran,
+    range_ext::RangeExt, recipe::Recipe, recipe_resolver::RecipeResolver,
+    recipe_signature::RecipeSignature, scope::Scope, search::Search, search_config::SearchConfig,
+    search_error::SearchError, set::Set, setting::Setting, settings::Settings, shebang::Shebang,
+    shell::Shell, show_whitespace::ShowWhitespace, source::Source, string_kind::StringKind,
     string_literal::StringLiteral, subcommand::Subcommand, suggestion::Suggestion, table::Table,
     thunk::Thunk, token::Token, token_kind::TokenKind, unresolved_dependency::UnresolvedDependency,
     unresolved_recipe::UnresolvedRecipe, use_color::UseColor, variables::Variables,
@@ -129,6 +129,7 @@ mod attribute;
 mod binding;
 mod color;
 mod color_display;
+mod command_color;
 mod command_ext;
 mod compilation;
 mod compile_error;

--- a/src/use_color.rs
+++ b/src/use_color.rs
@@ -1,4 +1,6 @@
-#[derive(Copy, Clone, Debug, PartialEq, clap::ValueEnum)]
+use super::*;
+
+#[derive(Copy, Clone, Debug, PartialEq, ValueEnum)]
 pub(crate) enum UseColor {
   Auto,
   Always,

--- a/src/use_color.rs
+++ b/src/use_color.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, clap::ValueEnum)]
 pub(crate) enum UseColor {
   Auto,
   Always,


### PR DESCRIPTION
Some of the configuration currently done with explicit function calls could be done more concisely with clap ValueParser