### PR TITLE
Make `install` an optional dependency and add 32-bit arm targets

### DIFF
--- a/www/install.sh
+++ b/www/install.sh
@@ -142,6 +142,8 @@ if [ -z "${target-}" ]; then
 
   case $uname_target in
     aarch64-Linux)     target=aarch64-unknown-linux-musl;;
+    armv7l-Linux)      target=armv7-unknown-linux-musleabihf;;
+    armv6l-Linux)      target=arm-unknown-linux-musleabihf;;
     arm64-Darwin)      target=aarch64-apple-darwin;;
     x86_64-Darwin)     target=x86_64-apple-darwin;;
     x86_64-Linux)      target=x86_64-unknown-linux-musl;;

--- a/www/install.sh
+++ b/www/install.sh
@@ -129,12 +129,12 @@ if [ -z "${target-}" ]; then
   uname_target="$(uname -m)-$kernel"
 
   case $uname_target in
-    aarch64-Linux)     target=aarch64-unknown-linux-musl;;
-    armv7l-Linux)      target=armv7-unknown-linux-musleabihf;;
-    armv6l-Linux)      target=arm-unknown-linux-musleabihf;;
-    arm64-Darwin)      target=aarch64-apple-darwin;;
-    x86_64-Darwin)     target=x86_64-apple-darwin;;
-    x86_64-Linux)      target=x86_64-unknown-linux-musl;;
+    aarch64-Linux) target=aarch64-unknown-linux-musl;;
+    arm64-Darwin) target=aarch64-apple-darwin;;
+    armv6l-Linux) target=arm-unknown-linux-musleabihf;;
+    armv7l-Linux) target=armv7-unknown-linux-musleabihf;;
+    x86_64-Darwin) target=x86_64-apple-darwin;;
+    x86_64-Linux) target=x86_64-unknown-linux-musl;;
     x86_64-MINGW64_NT) target=x86_64-pc-windows-msvc;;
     x86_64-Windows_NT) target=x86_64-pc-windows-msvc;;
     *)
@@ -145,8 +145,8 @@ if [ -z "${target-}" ]; then
 fi
 
 case $target in
-  x86_64-pc-windows-msvc) extension=zip;    need unzip;;
-  *)                      extension=tar.gz; need tar;;
+  x86_64-pc-windows-msvc) extension=zip; need unzip;;
+  *) extension=tar.gz; need tar;;
 esac
 
 archive="$releases/download/$tag/$crate-$tag-$target.$extension"

--- a/www/install.sh
+++ b/www/install.sh
@@ -145,8 +145,8 @@ if [ -z "${target-}" ]; then
 fi
 
 case $target in
-  x86_64-pc-windows-msvc) extension=zip;   need unzip;;
-  *)                      extension=tar.gz need tar;;
+  x86_64-pc-windows-msvc) extension=zip;    need unzip;;
+  *)                      extension=tar.gz; need tar;;
 esac
 
 archive="$releases/download/$tag/$crate-$tag-$target.$extension"

--- a/www/install.sh
+++ b/www/install.sh
@@ -110,7 +110,6 @@ command -v curl > /dev/null 2>&1 ||
 
 need mkdir
 need mktemp
-need tar
 
 if [ -z "${tag-}" ]; then
   need grep
@@ -157,8 +156,8 @@ if [ -z "${target-}" ]; then
 fi
 
 case $target in
-  x86_64-pc-windows-msvc) extension=zip; need unzip;;
-  *)                      extension=tar.gz;;
+  x86_64-pc-windows-msvc) extension=zip;   need unzip;;
+  *)                      extension=tar.gz need tar;;
 esac
 
 archive="$releases/download/$tag/$crate-$tag-$target.$extension"

--- a/www/install.sh
+++ b/www/install.sh
@@ -15,7 +15,7 @@ help() {
 Install a binary release of a just hosted on GitHub
 
 USAGE:
-    install [options]
+    install.sh [options]
 
 FLAGS:
     -h, --help      Display this message

--- a/www/install.sh
+++ b/www/install.sh
@@ -62,6 +62,17 @@ download() {
   fi
 }
 
+install_just() {
+  src="$1"
+  dst="$2"
+  if command -v install > /dev/null; then
+    install -m 755 "$src" "$dest"
+  else
+    cp "$src" "$dst"
+    chmod 755 "$dst"
+  fi
+}
+
 force=false
 while test $# -gt 0; do
   case $1 in
@@ -97,7 +108,6 @@ command -v curl > /dev/null 2>&1 ||
   command -v wget > /dev/null 2>&1 ||
   err "need wget or curl (command not found)"
 
-need install
 need mkdir
 need mktemp
 need tar
@@ -171,7 +181,7 @@ if [ -e "$dest/just" ] && [ "$force" = false ]; then
   err "\`$dest/just\` already exists"
 else
   mkdir -p "$dest"
-  install -m 755 "$td/just" "$dest"
+  install_just "$td/just" "$dest"
 fi
 
 rm -rf "$td"

--- a/www/install.sh
+++ b/www/install.sh
@@ -171,8 +171,8 @@ if [ -e "$dest/just" ] && [ "$force" = false ]; then
   err "\`$dest/just\` already exists"
 else
   mkdir -p "$dest"
-  cp "$td/just" "$dest"
-  chmod 755 "$dest"
+  cp "$td/just" "$dest/just"
+  chmod 755 "$dest/just"
 fi
 
 rm -rf "$td"

--- a/www/install.sh
+++ b/www/install.sh
@@ -62,17 +62,6 @@ download() {
   fi
 }
 
-install_just() {
-  src="$1"
-  dst="$2"
-  if command -v install > /dev/null; then
-    install -m 755 "$src" "$dest"
-  else
-    cp "$src" "$dst"
-    chmod 755 "$dst"
-  fi
-}
-
 force=false
 while test $# -gt 0; do
   case $1 in
@@ -182,7 +171,8 @@ if [ -e "$dest/just" ] && [ "$force" = false ]; then
   err "\`$dest/just\` already exists"
 else
   mkdir -p "$dest"
-  install_just "$td/just" "$dest"
+  cp "$td/just" "$dest"
+  chmod 755 "$dest"
 fi
 
 rm -rf "$td"


### PR DESCRIPTION
Resolves #1284 

Believe it or not, some Linux embedded device will not have `install` installed. This is not uncommon when they have a custom distribution build with Buildroot or Yocto, such devices typically have `cp` and `chmod` though, so when `install` is not available, there's now a fall back to cp and chmod. 

Then I added 32-bit arm targets, that includes old Raspberry Pi models but also various embedded linux devices such as Xilinx Zynq family.