### PR TITLE
Lexiclean search directory so `..` does not check the current directory

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -4,6 +4,7 @@ const DEFAULT_JUSTFILE_NAME: &str = JUSTFILE_NAMES[0];
 pub(crate) const JUSTFILE_NAMES: [&str; 2] = ["justfile", ".justfile"];
 const PROJECT_ROOT_CHILDREN: &[&str] = &[".bzr", ".git", ".hg", ".svn", "_darcs"];
 
+#[derive(Debug)]
 pub(crate) struct Search {
   pub(crate) justfile: PathBuf,
   pub(crate) working_directory: PathBuf,

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -110,9 +110,10 @@ impl Subcommand {
     ) {
       let starting_path = match &config.search_config {
         SearchConfig::FromInvocationDirectory => config.invocation_directory.clone(),
-        SearchConfig::FromSearchDirectory { search_directory } => {
-          env::current_dir().unwrap().join(search_directory)
-        }
+        SearchConfig::FromSearchDirectory { search_directory } => config
+          .invocation_directory
+          .join(search_directory)
+          .lexiclean(),
         _ => unreachable!(),
       };
 

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -144,6 +144,22 @@ fn single_upwards() {
 }
 
 #[test]
+fn double_upwards() {
+  let tmp = temptree! {
+    justfile: "default:\n\techo ok",
+    foo: {
+      bar: {
+        justfile: "default:\n\techo foo",
+      },
+    },
+  };
+
+  let path = tmp.path().join("foo/bar");
+
+  search_test(path, &["../default"]);
+}
+
+#[test]
 fn find_dot_justfile() {
   Test::new()
     .justfile(


### PR DESCRIPTION
If the search directory was `..`, for example in the invocation `just ../foo`, we would wind up checking the justfile in the current directory since we did `INVOCATION_DIRECTORY/..`.ancestors(), which would first return `INVOCATION_DIRECTORY`.

Instead, lexiclean the result of joining th invocation directory with the search directory, so `..` is removed, and `ancestors()` doesn't return the invocation directory.