### PR TITLE
feat: allow groups on submodules

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -96,7 +96,7 @@ impl Compiler {
       asts.insert(current.path, ast.clone());
     }
 
-    let justfile = Analyzer::analyze(&asts, None, &loaded, None, &paths, root)?;
+    let justfile = Analyzer::analyze(&asts, None, &[], &loaded, None, &paths, root)?;
 
     Ok(Compilation {
       asts,
@@ -229,7 +229,7 @@ impl Compiler {
     asts.insert(root.clone(), ast);
     let mut paths: HashMap<PathBuf, PathBuf> = HashMap::new();
     paths.insert(root.clone(), root.clone());
-    Analyzer::analyze(&asts, None, &[], None, &paths, &root)
+    Analyzer::analyze(&asts, None, &[], &[], None, &paths, &root)
   }
 }
 

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -413,7 +413,6 @@ impl<'src> Justfile<'src> {
 
     for submodule in self.modules.values() {
       for group in submodule.groups() {
-        // submodule.name.unwrap() is safe here because any non-root justfile will have a name set
         groups.push((&[], submodule.name.unwrap().offset, group.to_string()));
       }
     }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -553,24 +553,23 @@ impl Subcommand {
       groups
     };
 
-    // ordered contains groups from both recipes and submodules by calling .public_groups()
-    let mut ordered = module
+    let mut ordered_groups = module
       .public_groups(config)
       .into_iter()
       .map(Some)
       .collect::<Vec<Option<String>>>();
 
     if recipe_groups.contains_key(&None) || submodule_groups.contains_key(&None) {
-      ordered.insert(0, None);
+      ordered_groups.insert(0, None);
     }
 
-    let no_groups = ordered.len() == 1 && ordered.first() == Some(&None);
+    let no_groups = ordered_groups.len() == 1 && ordered_groups.first() == Some(&None);
     let mut groups_count = 0;
     if !no_groups {
-      groups_count = ordered.len();
+      groups_count = ordered_groups.len();
     }
 
-    for (i, group) in ordered.into_iter().enumerate() {
+    for (i, group) in ordered_groups.into_iter().enumerate() {
       if i > 0 {
         println!();
       }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -77,7 +77,7 @@ pub(crate) fn analysis_error(
   let mut paths: HashMap<PathBuf, PathBuf> = HashMap::new();
   paths.insert("justfile".into(), "justfile".into());
 
-  match Analyzer::analyze(&asts, None, &[], None, &paths, &root) {
+  match Analyzer::analyze(&asts, None, &[], &[], None, &paths, &root) {
     Ok(_) => panic!("Analysis unexpectedly succeeded"),
     Err(have) => {
       let want = CompileError {

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -27,6 +27,7 @@ fn alias() {
         }
       },
       "assignments": {},
+      "groups": [],
       "modules": {},
       "recipes": {
         "foo": {
@@ -84,6 +85,7 @@ fn assignment() {
       },
       "first": null,
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {},
       "settings": {
@@ -123,6 +125,7 @@ fn body() {
       "assignments": {},
       "first": "foo",
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {
         "foo": {
@@ -178,6 +181,7 @@ fn dependencies() {
       "assignments": {},
       "first": "foo",
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {
         "bar": {
@@ -266,6 +270,7 @@ fn dependency_argument() {
           "depth": 0,
         },
       },
+      "groups": [],
       "modules": {},
       "recipes": {
         "bar": {
@@ -361,6 +366,7 @@ fn duplicate_recipes() {
         }
       },
       "assignments": {},
+      "groups": [],
       "modules": {},
       "recipes": {
         "foo": {
@@ -428,6 +434,7 @@ fn duplicate_variables() {
       },
       "first": null,
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {},
       "settings": {
@@ -463,6 +470,7 @@ fn doc_comment() {
       "first": "foo",
       "doc": null,
       "assignments": {},
+      "groups": [],
       "modules": {},
       "recipes": {
         "foo": {
@@ -512,6 +520,7 @@ fn empty_justfile() {
       "assignments": {},
       "first": null,
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {},
       "settings": {
@@ -554,6 +563,7 @@ fn parameters() {
       "first": "a",
       "doc": null,
       "assignments": {},
+      "groups": [],
       "modules": {},
       "recipes": {
         "a": {
@@ -707,6 +717,7 @@ fn priors() {
       "assignments": {},
       "first": "a",
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {
         "a": {
@@ -792,6 +803,7 @@ fn private() {
       "assignments": {},
       "first": "_foo",
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {
         "_foo": {
@@ -841,6 +853,7 @@ fn quiet() {
       "assignments": {},
       "first": "foo",
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {
         "foo": {
@@ -902,6 +915,7 @@ fn settings() {
       "assignments": {},
       "first": "foo",
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {
         "foo": {
@@ -957,6 +971,7 @@ fn shebang() {
       "assignments": {},
       "first": "foo",
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {
         "foo": {
@@ -1006,6 +1021,7 @@ fn simple() {
       "assignments": {},
       "first": "foo",
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {
         "foo": {
@@ -1058,6 +1074,7 @@ fn attribute() {
       "assignments": {},
       "first": "foo",
       "doc": null,
+      "groups": [],
       "modules": {},
       "recipes": {
         "foo": {
@@ -1118,12 +1135,107 @@ fn module() {
         "assignments": {},
         "first": null,
         "doc": null,
+        "groups": [],
         "modules": {
           "foo": {
             "aliases": {},
             "assignments": {},
             "first": "bar",
             "doc": "hello",
+            "groups": [],
+            "modules": {},
+            "recipes": {
+              "bar": {
+                "attributes": [],
+                "body": [],
+                "dependencies": [],
+                "doc": null,
+                "name": "bar",
+                "namepath": "foo::bar",
+                "parameters": [],
+                "priors": 0,
+                "private": false,
+                "quiet": false,
+                "shebang": false,
+              }
+            },
+            "settings": {
+              "allow_duplicate_recipes": false,
+              "allow_duplicate_variables": false,
+              "dotenv_filename": null,
+              "dotenv_load": false,
+              "dotenv_path": null,
+              "dotenv_required": false,
+              "export": false,
+              "fallback": false,
+              "positional_arguments": false,
+              "quiet": false,
+              "shell": null,
+              "tempdir" : null,
+              "unstable": false,
+              "ignore_comments": false,
+              "windows_powershell": false,
+              "windows_shell": null,
+            },
+            "unexports": [],
+            "warnings": [],
+          },
+        },
+        "recipes": {},
+        "settings": {
+          "allow_duplicate_recipes": false,
+          "allow_duplicate_variables": false,
+          "dotenv_filename": null,
+          "dotenv_load": false,
+          "dotenv_path": null,
+          "dotenv_required": false,
+          "export": false,
+          "fallback": false,
+          "positional_arguments": false,
+          "quiet": false,
+          "shell": null,
+          "tempdir" : null,
+          "unstable": false,
+          "ignore_comments": false,
+          "windows_powershell": false,
+          "windows_shell": null,
+        },
+        "unexports": [],
+        "warnings": [],
+      }))
+      .unwrap()
+    ))
+    .run();
+}
+
+#[test]
+fn module_group() {
+  Test::new()
+    .justfile(
+      "
+      [group('alpha')]
+      mod foo
+    ",
+    )
+    .tree(tree! {
+      "foo.just": "bar:",
+    })
+    .args(["--dump", "--dump-format", "json"])
+    .stdout(format!(
+      "{}\n",
+      serde_json::to_string(&json!({
+        "aliases": {},
+        "assignments": {},
+        "first": null,
+        "doc": null,
+        "groups": [],
+        "modules": {
+          "foo": {
+            "aliases": {},
+            "assignments": {},
+            "first": "bar",
+            "doc": null,
+            "groups": ["alpha"],
             "modules": {},
             "recipes": {
               "bar": {

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -236,12 +236,13 @@ fn list_with_groups_in_modules() {
     .stdout(
       "
         Available recipes:
-            [FOO]
-            foo
-
+            (no group)
             bar:
                 [BAZ]
                 baz
+
+            [FOO]
+            foo
       ",
     )
     .run();
@@ -396,7 +397,7 @@ fn module_doc_aligned() {
 }
 
 #[test]
-fn space_before_submodules_following_groups() {
+fn submodules_without_groups() {
   Test::new()
     .write("foo.just", "")
     .justfile(
@@ -411,10 +412,11 @@ fn space_before_submodules_following_groups() {
     .stdout(
       "
         Available recipes:
+            (no group)
+            foo ...
+
             [baz]
             bar
-
-            foo ...
       ",
     )
     .run();

--- a/tests/modules.rs
+++ b/tests/modules.rs
@@ -772,6 +772,204 @@ fn doc_attribute_on_module() {
 }
 
 #[test]
+fn group_attribute_on_module() {
+  Test::new()
+    .write("foo.just", "")
+    .write("bar.just", "")
+    .write("zee.just", "")
+    .justfile(
+      r#"
+        [group('alpha')]
+        mod zee
+
+        [group('alpha')]
+        mod foo
+
+        [group('alpha')]
+        a:
+
+        [group('beta')]
+        b:
+
+        [group('beta')]
+        mod bar
+
+        c:
+      "#,
+    )
+    .test_round_trip(false)
+    .arg("--list")
+    .stdout(
+      "
+        Available recipes:
+            (no group)
+            c
+
+            [alpha]
+            a
+            foo ...
+            zee ...
+            
+            [beta]
+            b
+            bar ...
+      ",
+    )
+    .run();
+}
+
+#[test]
+fn group_attribute_on_module_unsorted() {
+  Test::new()
+    .write("foo.just", "")
+    .write("bar.just", "")
+    .write("zee.just", "")
+    .justfile(
+      r#"
+        [group('alpha')]
+        mod zee
+
+        [group('alpha')]
+        mod foo
+
+        [group('alpha')]
+        a:
+
+        [group('beta')]
+        b:
+
+        [group('beta')]
+        mod bar
+
+        c:
+      "#,
+    )
+    .test_round_trip(false)
+    .arg("--list")
+    .arg("--unsorted")
+    .stdout(
+      "
+        Available recipes:
+            (no group)
+            c
+
+            [alpha]
+            a
+            zee ...
+            foo ...
+            
+            [beta]
+            b
+            bar ...
+      ",
+    )
+    .run();
+}
+
+#[test]
+fn group_attribute_on_module_list_submodule() {
+  Test::new()
+    .write("foo.just", "d:")
+    .write("bar.just", "e:")
+    .write("zee.just", "f:")
+    .justfile(
+      r#"
+        [group('alpha')]
+        mod zee
+
+        [group('alpha')]
+        mod foo
+
+        [group('alpha')]
+        a:
+
+        [group('beta')]
+        b:
+
+        [group('beta')]
+        mod bar
+
+        c:
+      "#,
+    )
+    .test_round_trip(false)
+    .arg("--list")
+    .arg("--list-submodules")
+    .stdout(
+      "
+        Available recipes:
+            (no group)
+            c
+
+            [alpha]
+            a
+            foo:
+                d
+            zee:
+                f
+
+            [beta]
+            b
+            bar:
+                e
+      ",
+    )
+    .run();
+}
+
+#[test]
+fn group_attribute_on_module_list_submodule_unsorted() {
+  Test::new()
+    .write("foo.just", "d:")
+    .write("bar.just", "e:")
+    .write("zee.just", "f:")
+    .justfile(
+      r#"
+        [group('alpha')]
+        mod zee
+
+        [group('alpha')]
+        mod foo
+
+        [group('alpha')]
+        a:
+
+        [group('beta')]
+        b:
+
+        [group('beta')]
+        mod bar
+
+        c:
+      "#,
+    )
+    .test_round_trip(false)
+    .arg("--list")
+    .arg("--list-submodules")
+    .arg("--unsorted")
+    .stdout(
+      "
+        Available recipes:
+            (no group)
+            c
+
+            [alpha]
+            a
+            zee:
+                f
+            foo:
+                d
+
+            [beta]
+            b
+            bar:
+                e
+      ",
+    )
+    .run();
+}
+
+#[test]
 fn bad_module_attribute_fails() {
   Test::new()
     .write("foo.just", "")


### PR DESCRIPTION
Hello! I've been working on a fix for https://github.com/casey/just/issues/2243.

I added the whole `attributes` object instead of just passing around the group like how the `doc` is. My rationale for this was to make it easier to have access to anything stored in the `attributes` in the future, let me know if that is the wrong path though.

This is my first time contributing to `just`, I'm open to any feedback!