### PR TITLE
Remove (no group) before recipes not in a group

### DIFF
--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -575,11 +575,8 @@ impl Subcommand {
       }
 
       if !no_groups {
-        print!("{list_prefix}");
         if let Some(group) = &group {
-          println!("[{group}]");
-        } else {
-          println!("(no group)");
+          println!("{list_prefix}[{group}]");
         }
       }
 

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -25,7 +25,6 @@ fn list_with_groups() {
     .stdout(
       "
         Available recipes:
-            (no group)
             c
 
             [alpha]
@@ -76,7 +75,6 @@ fn list_with_groups_unsorted() {
     .stdout(
       "
         Available recipes:
-            (no group)
             c
 
             [alpha]
@@ -118,7 +116,6 @@ fn list_with_groups_unsorted_group_order() {
     .stdout(
       "
         Available recipes:
-            (no group)
             c
 
             [x]

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -236,7 +236,6 @@ fn list_with_groups_in_modules() {
     .stdout(
       "
         Available recipes:
-            (no group)
             bar:
                 [BAZ]
                 baz
@@ -412,7 +411,6 @@ fn submodules_without_groups() {
     .stdout(
       "
         Available recipes:
-            (no group)
             foo ...
 
             [baz]

--- a/tests/modules.rs
+++ b/tests/modules.rs
@@ -802,14 +802,13 @@ fn group_attribute_on_module() {
     .stdout(
       "
         Available recipes:
-            (no group)
             c
 
             [alpha]
             a
             foo ...
             zee ...
-            
+
             [beta]
             b
             bar ...
@@ -850,14 +849,13 @@ fn group_attribute_on_module_unsorted() {
     .stdout(
       "
         Available recipes:
-            (no group)
             c
 
             [alpha]
             a
             zee ...
             foo ...
-            
+
             [beta]
             b
             bar ...
@@ -898,7 +896,6 @@ fn group_attribute_on_module_list_submodule() {
     .stdout(
       "
         Available recipes:
-            (no group)
             c
 
             [alpha]
@@ -950,7 +947,6 @@ fn group_attribute_on_module_list_submodule_unsorted() {
     .stdout(
       "
         Available recipes:
-            (no group)
             c
 
             [alpha]


### PR DESCRIPTION
I think it's probably fine to just print them first with no header