### PR TITLE
Improve error message on bad working directory

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -127,6 +127,11 @@ pub(crate) enum Error<'src> {
   MissingModuleFile {
     module: Name<'src>,
   },
+  WorkingDirectoryIo {
+    recipe: &'src str,
+    working_directory: PathBuf,
+    io_error: io::Error,
+  },
   NoChoosableRecipes,
   NoDefaultRecipe,
   NoRecipes,
@@ -470,6 +475,12 @@ impl<'src> ColorDisplay for Error<'src> {
       UnstableFeature { unstable_feature } => {
         write!(f, "{unstable_feature} Invoke `just` with `--unstable`, set the `JUST_UNSTABLE` environment variable, or add `set unstable` to your `justfile` to enable unstable features.")?;
       }
+      WorkingDirectoryIo { recipe, working_directory, io_error } => {
+        match io_error.kind() {
+          io::ErrorKind::NotFound => write!(f, "Recipe `{recipe}` could not be run because just could not find working directory `{}`: {io_error}", working_directory.to_string_lossy()),
+          _ => write!(f, "Recipe `{recipe}` could not be run because just could not set working directory to `{}`: {io_error}", working_directory.to_string_lossy()),
+        }?;
+      },
       WriteJustfile { justfile, io_error } => {
         let justfile = justfile.display();
         write!(f, "Failed to write justfile to `{justfile}`: {io_error}")?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -116,6 +116,9 @@ pub(crate) enum Error<'src> {
   Io {
     recipe: &'src str,
     io_error: io::Error,
+    shell: String,
+    working_directory_io_error: Option<io::Error>,
+    working_directory: Option<PathBuf>,
   },
   Load {
     path: PathBuf,
@@ -184,11 +187,6 @@ pub(crate) enum Error<'src> {
   },
   WriteJustfile {
     justfile: PathBuf,
-    io_error: io::Error,
-  },
-  WorkingDirectoryIo {
-    recipe: &'src str,
-    working_directory: PathBuf,
     io_error: io::Error,
   },
 }
@@ -401,12 +399,15 @@ impl<'src> ColorDisplay for Error<'src> {
         write!(f, "Internal runtime error, this may indicate a bug in just: {message} \
                    consider filing an issue: https://github.com/casey/just/issues/new")?;
       }
-      Io { recipe, io_error } => {
-        match io_error.kind() {
-          io::ErrorKind::NotFound => write!(f, "Recipe `{recipe}` could not be run because just could not find the shell: {io_error}"),
-          io::ErrorKind::PermissionDenied => write!(f, "Recipe `{recipe}` could not be run because just could not run the shell: {io_error}"),
-          _ => write!(f, "Recipe `{recipe}` could not be run because of an IO error while launching the shell: {io_error}"),
-        }?;
+      Io { recipe, io_error, shell, working_directory_io_error, working_directory } => {
+        write!(f, "Failed to run recipe `{recipe}`:\n  Failed to run shell `{shell}`:\n    {io_error}", )?;
+        if let Some(working_directory_io_error) = working_directory_io_error {
+          let working_directory = working_directory.as_ref().expect("is Some when error is Some").display();
+          write!(f, "\n  Failed to set working directory to `{working_directory}`")?;
+          if working_directory_io_error.to_string() != io_error.to_string() {
+            write!(f, ":\n    {working_directory_io_error}")?;
+          }
+        }
       }
       Load { io_error, path } => {
         write!(f, "Failed to read justfile at `{}`: {io_error}", path.display())?;
@@ -475,9 +476,6 @@ impl<'src> ColorDisplay for Error<'src> {
       UnstableFeature { unstable_feature } => {
         write!(f, "{unstable_feature} Invoke `just` with `--unstable`, set the `JUST_UNSTABLE` environment variable, or add `set unstable` to your `justfile` to enable unstable features.")?;
       }
-      WorkingDirectoryIo { recipe, working_directory, io_error } => {
-        write!(f, "Recipe `{recipe}` could not be run because just could not set working directory to `{}`: {io_error}", working_directory.display())?;
-      },
       WriteJustfile { justfile, io_error } => {
         let justfile = justfile.display();
         write!(f, "Failed to write justfile to `{justfile}`: {io_error}")?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -127,11 +127,6 @@ pub(crate) enum Error<'src> {
   MissingModuleFile {
     module: Name<'src>,
   },
-  WorkingDirectoryIo {
-    recipe: &'src str,
-    working_directory: PathBuf,
-    io_error: io::Error,
-  },
   NoChoosableRecipes,
   NoDefaultRecipe,
   NoRecipes,
@@ -189,6 +184,11 @@ pub(crate) enum Error<'src> {
   },
   WriteJustfile {
     justfile: PathBuf,
+    io_error: io::Error,
+  },
+  WorkingDirectoryIo {
+    recipe: &'src str,
+    working_directory: PathBuf,
     io_error: io::Error,
   },
 }
@@ -476,10 +476,7 @@ impl<'src> ColorDisplay for Error<'src> {
         write!(f, "{unstable_feature} Invoke `just` with `--unstable`, set the `JUST_UNSTABLE` environment variable, or add `set unstable` to your `justfile` to enable unstable features.")?;
       }
       WorkingDirectoryIo { recipe, working_directory, io_error } => {
-        match io_error.kind() {
-          io::ErrorKind::NotFound => write!(f, "Recipe `{recipe}` could not be run because just could not find working directory `{}`: {io_error}", working_directory.to_string_lossy()),
-          _ => write!(f, "Recipe `{recipe}` could not be run because just could not set working directory to `{}`: {io_error}", working_directory.to_string_lossy()),
-        }?;
+        write!(f, "Recipe `{recipe}` could not be run because just could not set working directory to `{}`: {io_error}", working_directory.display())?;
       },
       WriteJustfile { justfile, io_error } => {
         let justfile = justfile.display();

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -306,7 +306,7 @@ impl<'src, D> Recipe<'src, D> {
         Err(io_error) => {
           let working_directory = self.working_directory(context);
           let working_directory_io_error = match &working_directory {
-            Some(working_directory) => match fs::read_dir(&working_directory) {
+            Some(working_directory) => match fs::read_dir(working_directory) {
               Ok(_) => None,
               Err(io_error) => Some(io_error),
             },

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -304,6 +304,15 @@ impl<'src, D> Recipe<'src, D> {
           }
         }
         Err(io_error) => {
+          if let Some(working_directory) = self.working_directory(context) {
+            if let Err(io_error) = fs::read_dir(working_directory.clone()) {
+              return Err(Error::WorkingDirectoryIo {
+                recipe: self.name(),
+                working_directory,
+                io_error,
+              });
+            }
+          }
           return Err(Error::Io {
             recipe: self.name(),
             io_error,

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -305,7 +305,7 @@ impl<'src, D> Recipe<'src, D> {
         }
         Err(io_error) => {
           if let Some(working_directory) = self.working_directory(context) {
-            if let Err(io_error) = fs::read_dir(working_directory.clone()) {
+            if let Err(io_error) = fs::read_dir(&working_directory) {
               return Err(Error::WorkingDirectoryIo {
                 recipe: self.name(),
                 working_directory,

--- a/tests/shell.rs
+++ b/tests/shell.rs
@@ -164,7 +164,7 @@ fn recipe_shell_not_found_error_message() {
     .shell(false)
     .args(["--shell", "NOT_A_REAL_SHELL"])
     .stderr_regex(
-      "error: Recipe `foo` could not be run because just could not find the shell: .*\n",
+      ".*Failed to run recipe `foo`:\n  Failed to run shell `NOT_A_REAL_SHELL`:\n    .*",
     )
     .status(1)
     .run();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,4 @@
-use {super::*, pretty_assertions::assert_eq};
+use {super::*, fs::Permissions, pretty_assertions::assert_eq};
 
 macro_rules! test {
   {
@@ -96,6 +96,11 @@ impl Test {
 
   pub(crate) fn create_dir(self, path: impl AsRef<Path>) -> Self {
     fs::create_dir_all(self.tempdir.path().join(path.as_ref())).unwrap();
+    self
+  }
+
+  pub(crate) fn chmod(self, path: impl AsRef<Path>, perm: Permissions) -> Self {
+    fs::set_permissions(self.tempdir.path().join(path.as_ref()), perm).unwrap();
     self
   }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -99,6 +99,7 @@ impl Test {
     self
   }
 
+  #[cfg(unix)]
   pub(crate) fn chmod(self, path: impl AsRef<Path>, perm: Permissions) -> Self {
     fs::set_permissions(self.tempdir.path().join(path.as_ref()), perm).unwrap();
     self

--- a/tests/working_directory.rs
+++ b/tests/working_directory.rs
@@ -1,4 +1,4 @@
-use {super::*, fs::Permissions, std::os::unix::fs::PermissionsExt};
+use super::*;
 
 const JUSTFILE: &str = r#"
 foo := `cat data`
@@ -344,13 +344,15 @@ fn missing_working_directory_produces_clear_message() {
     )
     .status(1)
     .stderr_regex(
-      ".*Recipe `default` could not be run because just could not find working directory `.*/missing`.*",
+      ".*Recipe `default` could not be run because just could not set working directory to `.*/missing`.*",
     )
     .run();
 }
 
 #[test]
+#[cfg(unix)]
 fn unusable_working_directory_produces_clear_message() {
+  use {fs::Permissions, std::os::unix::fs::PermissionsExt};
   Test::new()
   .justfile(
     "


### PR DESCRIPTION
Handles two cases:

- working directory doesn't exist.
- working directory cannot be changed into due to on of the following:
    - The process lacks permissions to view the contents.
    - The path points at a non-directory file.

Addresses: #2295