### PR TITLE
Dump individual recipes by name

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -10,6 +10,15 @@ pub(crate) struct Ast<'src> {
   pub(crate) working_directory: PathBuf,
 }
 
+impl<'src> Ast<'src> {
+  pub(crate) fn get_recipe_item(&self, name: &str) -> Option<&Item<'src>> {
+    self
+      .items
+      .iter()
+      .find(|item| matches!(item, Item::Recipe(recipe) if recipe.name.lexeme() == name))
+  }
+}
+
 impl<'src> Display for Ast<'src> {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
     let mut iter = self.items.iter().peekable();

--- a/src/config.rs
+++ b/src/config.rs
@@ -637,9 +637,13 @@ impl Config {
       }
     } else if let Some(&shell) = matches.get_one::<completions::Shell>(cmd::COMPLETIONS) {
       Subcommand::Completions { shell }
-    } else if let Some(mut recipe) = matches.get_many::<String>(cmd::DUMP) {
+    } else if let Some(recipe) = matches.get_many::<String>(cmd::DUMP) {
       Subcommand::Dump {
-        recipe: recipe.next().cloned(),
+        recipe: if recipe.len() == 0 {
+          None
+        } else {
+          Some(Self::parse_module_path(recipe)?)
+        },
       }
     } else if matches.get_flag(cmd::EDIT) {
       Subcommand::Edit

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,6 +83,9 @@ pub(crate) enum Error<'src> {
   DumpJson {
     serde_json_error: serde_json::Error,
   },
+  DumpRecipeMissing {
+    recipe_name: String,
+  },
   EditorInvoke {
     editor: OsString,
     io_error: io::Error,
@@ -359,6 +362,7 @@ impl<'src> ColorDisplay for Error<'src> {
       DumpJson { serde_json_error } => {
         write!(f, "Failed to dump JSON to stdout: {serde_json_error}")?;
       }
+      DumpRecipeMissing { recipe_name } => write!(f, "Recipe missing: {recipe_name}")?,
       EditorInvoke { editor, io_error } => {
         let editor = editor.to_string_lossy();
         write!(f, "Editor `{editor}` invocation failed: {io_error}")?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,9 +83,6 @@ pub(crate) enum Error<'src> {
   DumpJson {
     serde_json_error: serde_json::Error,
   },
-  DumpRecipeMissing {
-    recipe_name: String,
-  },
   EditorInvoke {
     editor: OsString,
     io_error: io::Error,
@@ -362,7 +359,6 @@ impl<'src> ColorDisplay for Error<'src> {
       DumpJson { serde_json_error } => {
         write!(f, "Failed to dump JSON to stdout: {serde_json_error}")?;
       }
-      DumpRecipeMissing { recipe_name } => write!(f, "Recipe missing: {recipe_name}")?,
       EditorInvoke { editor, io_error } => {
         let editor = editor.to_string_lossy();
         write!(f, "Editor `{editor}` invocation failed: {io_error}")?;

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -385,6 +385,24 @@ impl<'src> Justfile<'src> {
     modules
   }
 
+  pub(crate) fn lookup_module_and_item<'a, 'b>(
+    &'a self,
+    path: &'b ModulePath,
+  ) -> RunResult<'src, (&'a Justfile<'src>, String)> {
+    let mut module: &'a Justfile = self;
+    for name in &path.path[0..path.path.len() - 1] {
+      module = module
+        .modules
+        .get(name)
+        .ok_or_else(|| Error::UnknownSubmodule {
+          path: path.to_string(),
+        })?;
+    }
+
+    let name = path.path.last().unwrap();
+    Ok((module, name.to_owned()))
+  }
+
   pub(crate) fn public_recipes(&self, config: &Config) -> Vec<&Recipe> {
     let mut recipes = self
       .recipes

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -18,7 +18,7 @@ pub(crate) enum Subcommand {
     shell: completions::Shell,
   },
   Dump {
-    recipe: Option<String>,
+    recipe: Option<ModulePath>,
   },
   Edit,
   Evaluate {
@@ -309,14 +309,15 @@ impl Subcommand {
     config: &Config,
     ast: &Ast,
     justfile: &Justfile,
-    recipe: Option<&String>,
+    recipe: Option<&ModulePath>,
   ) -> RunResult<'static> {
     match config.dump_format {
       DumpFormat::Json => {
         if let Some(recipe_name) = recipe {
+          let recipe_name = recipe_name.to_string();
           let recipe = justfile
             .recipes
-            .get(recipe_name)
+            .get(&recipe_name)
             .ok_or(Error::DumpRecipeMissing {
               recipe_name: recipe_name.to_owned(),
             })?;
@@ -330,8 +331,9 @@ impl Subcommand {
       }
       DumpFormat::Just => {
         if let Some(recipe_name) = recipe {
+          let recipe_name = recipe_name.to_string();
           let recipe = ast
-            .get_recipe_item(recipe_name)
+            .get_recipe_item(&recipe_name)
             .ok_or(Error::DumpRecipeMissing {
               recipe_name: recipe_name.to_owned(),
             })?;

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1375,3 +1375,33 @@ fn module_group() {
     ))
     .run();
 }
+
+#[test]
+fn dump_single_recipe() {
+  Test::new()
+    .justfile(
+      "
+      foo:
+        echo 'FOO'
+    ",
+    )
+    .args(["--dump", "foo", "--dump-format", "json"])
+    .stdout(format!(
+      "{}\n",
+      serde_json::to_string(&json!({
+          "attributes": [],
+          "body": [["echo 'FOO'"]],
+          "dependencies": [],
+          "doc": null,
+          "name": "foo",
+          "namepath": "foo",
+          "parameters": [],
+          "priors": 0,
+          "private": false,
+          "quiet": false,
+          "shebang": false,
+      }))
+      .unwrap()
+    ))
+    .run();
+}


### PR DESCRIPTION
This commit modifies the `--dump` option to optionally take the name of a recipe as an argument, and only dump the contents of that single recipe. Resolves https://github.com/casey/just/issues/737