### PR TITLE
Remove Config::run

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -748,11 +748,6 @@ impl Config {
       Err(Error::UnstableFeature { unstable_feature })
     }
   }
-
-  pub(crate) fn run(self, loader: &Loader) -> RunResult {
-    InterruptHandler::install(self.verbosity).ok();
-    self.subcommand.execute(&self, loader)
-  }
 }
 
 #[cfg(test)]

--- a/src/run.rs
+++ b/src/run.rs
@@ -23,7 +23,10 @@ pub fn run(args: impl Iterator<Item = impl Into<OsString> + Clone>) -> Result<()
   let loader = Loader::new();
 
   config
-    .and_then(|config| config.run(&loader))
+    .and_then(|config| {
+      InterruptHandler::install(config.verbosity).ok();
+      config.subcommand.execute(&config, &loader)
+    })
     .map_err(|error| {
       if !verbosity.quiet() && error.print_message() {
         eprintln!("{}", error.color_display(color.stderr()));


### PR DESCRIPTION
Minor refactor that removes a layer of indirection and one function named `run`. Arguably partially addresses https://github.com/casey/just/issues/610 , although I'm not sure if this issue is still relevant anyway. 