### PR TITLE
Generate .sha256sum files for release artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,7 +99,9 @@ jobs:
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       with:
         draft: false
-        files: ${{ steps.package.outputs.archive }}
+        files: |
+          ${{ steps.package.outputs.archive }}
+          ${{ steps.package.outputs.archive-checksum }}
         prerelease: ${{ steps.ref-type.outputs.value != 'release' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,7 @@ jobs:
         draft: false
         files: |
           ${{ steps.package.outputs.archive }}
-          ${{ steps.package.outputs.archive-checksum }}
+          ${{ steps.package.outputs.archive }}.sha256sum
         prerelease: ${{ steps.ref-type.outputs.value != 'release' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/package
+++ b/bin/package
@@ -45,13 +45,12 @@ case $OS in
     ARCHIVE=$DIST/just-$VERSION-$TARGET.tar.gz
     tar czf $ARCHIVE *
     echo "archive=$ARCHIVE" >> $GITHUB_OUTPUT
+    shasum -a 256 $ARCHIVE > $ARCHIVE.sha256sum
     ;;
   windows-latest)
     ARCHIVE=$DIST/just-$VERSION-$TARGET.zip
     7z a $ARCHIVE *
     echo "archive=`pwd -W`/just-$VERSION-$TARGET.zip" >> $GITHUB_OUTPUT
+    certutil -hashfile $ARCHIVE SHA256 > $ARCHIVE.sha256sum
     ;;
 esac
-
-echo "Creating release .sha256sum..."
-shasum -a 256 $ARCHIVE > $ARCHIVE.sha256sum

--- a/bin/package
+++ b/bin/package
@@ -45,12 +45,13 @@ case $OS in
     ARCHIVE=$DIST/just-$VERSION-$TARGET.tar.gz
     tar czf $ARCHIVE *
     echo "archive=$ARCHIVE" >> $GITHUB_OUTPUT
-    sha256sum $ARCHIVE > $ARCHIVE.sha256sum
     ;;
   windows-latest)
     ARCHIVE=$DIST/just-$VERSION-$TARGET.zip
     7z a $ARCHIVE *
     echo "archive=`pwd -W`/just-$VERSION-$TARGET.zip" >> $GITHUB_OUTPUT
-    sha256sum $ARCHIVE > $ARCHIVE.sha256sum
     ;;
 esac
+
+echo "Creating release .sha256sum..."
+shasum -a 256 $ARCHIVE > $ARCHIVE.sha256sum

--- a/bin/package
+++ b/bin/package
@@ -46,13 +46,11 @@ case $OS in
     tar czf $ARCHIVE *
     echo "archive=$ARCHIVE" >> $GITHUB_OUTPUT
     sha256sum $ARCHIVE > $ARCHIVE.sha256sum
-    echo "archive-checksum=$ARCHIVE.sha256sum" >> $GITHUB_OUTPUT
     ;;
   windows-latest)
     ARCHIVE=$DIST/just-$VERSION-$TARGET.zip
     7z a $ARCHIVE *
     echo "archive=`pwd -W`/just-$VERSION-$TARGET.zip" >> $GITHUB_OUTPUT
     sha256sum $ARCHIVE > $ARCHIVE.sha256sum
-    echo "archive-checksum=`pwd -W`/just-$VERSION-$TARGET.zip.sha256sum" >> $GITHUB_OUTPUT
     ;;
 esac

--- a/bin/package
+++ b/bin/package
@@ -45,10 +45,14 @@ case $OS in
     ARCHIVE=$DIST/just-$VERSION-$TARGET.tar.gz
     tar czf $ARCHIVE *
     echo "archive=$ARCHIVE" >> $GITHUB_OUTPUT
+    sha256sum $ARCHIVE > $ARCHIVE.sha256sum
+    echo "archive-checksum=$ARCHIVE.sha256sum" >> $GITHUB_OUTPUT
     ;;
   windows-latest)
     ARCHIVE=$DIST/just-$VERSION-$TARGET.zip
     7z a $ARCHIVE *
     echo "archive=`pwd -W`/just-$VERSION-$TARGET.zip" >> $GITHUB_OUTPUT
+    sha256sum $ARCHIVE > $ARCHIVE.sha256sum
+    echo "archive-checksum=`pwd -W`/just-$VERSION-$TARGET.zip.sha256sum" >> $GITHUB_OUTPUT
     ;;
 esac

--- a/bin/package
+++ b/bin/package
@@ -51,6 +51,6 @@ case $OS in
     ARCHIVE=$DIST/just-$VERSION-$TARGET.zip
     7z a $ARCHIVE *
     echo "archive=`pwd -W`/just-$VERSION-$TARGET.zip" >> $GITHUB_OUTPUT
-    certutil -hashfile $ARCHIVE SHA256 > $ARCHIVE.sha256sum
+    sha256sum $ARCHIVE > $ARCHIVE.sha256sum
     ;;
 esac


### PR DESCRIPTION
I am *very much* not confident that `sha256sum` is available on the Windows runner images, so unsure that this will work in its current form (hence the draft status).

If `sha256sum` is not available, I could easily do the work in Python, which [I see](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) is available on the runners.

Another possibility: rather than uploading the artifacts one-by-one to the release (which allows partial failure), I could restructure the build to temporarily [store the artifacts](https://github.com/twisted/twisted/blob/d0db2ee5592bff64f5c8f23a1265180eae022d38/.github/workflows/test.yaml#L314-L319) and then [download them all](https://github.com/twisted/twisted/blob/d0db2ee5592bff64f5c8f23a1265180eae022d38/.github/workflows/test.yaml#L346-L351) before generating the release. That'd happen in a Linux environment where `sha256sum` is available.

Please let me know your preference!
