### PR TITLE
Slight refactors in subcommand and search modules

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -125,7 +125,7 @@ impl Search {
     }
   }
 
-  pub(crate) fn justfile(directory: &Path) -> SearchResult<PathBuf> {
+  fn justfile(directory: &Path) -> SearchResult<PathBuf> {
     for directory in directory.ancestors() {
       let mut candidates = BTreeSet::new();
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -122,6 +122,8 @@ impl Search {
     })
   }
 
+  /// Starting from a directory, search upwards in the directory tree until a file
+  /// whose name matches a `JUSTFILE_NAMES` entry is found
   fn justfile(directory: &Path) -> SearchResult<PathBuf> {
     for directory in directory.ancestors() {
       let mut candidates = BTreeSet::new();
@@ -172,6 +174,8 @@ impl Search {
     clean.into_iter().collect()
   }
 
+  /// Starting from a subdirectory, attempt to find the root directory of a software project, as determined by the presence
+  /// of one of the version-control-system dotfiles specified in `PROJECT_ROOT_CHILDREN`
   fn project_root(directory: &Path) -> SearchResult<PathBuf> {
     for directory in directory.ancestors() {
       let entries = fs::read_dir(directory).map_err(|io_error| SearchError::Io {

--- a/src/search.rs
+++ b/src/search.rs
@@ -120,8 +120,8 @@ impl Search {
         justfile,
         working_directory,
       } => Ok(Self {
-        justfile: Self::clean(invocation_directory, working_directory),
-        working_directory: Self::clean(invocation_directory, justfile),
+        justfile: Self::clean(invocation_directory, justfile),
+        working_directory: Self::clean(invocation_directory, working_directory),
       }),
     }
   }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -399,9 +399,11 @@ impl Subcommand {
         io_error,
       });
     }
+
     if config.verbosity.loud() {
       eprintln!("Wrote justfile to `{}`", search.justfile.display());
     }
+
     Ok(())
   }
 

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -388,20 +388,21 @@ impl Subcommand {
     let search = Search::init(&config.search_config, &config.invocation_directory)?;
 
     if search.justfile.is_file() {
-      Err(Error::InitExists {
+      return Err(Error::InitExists {
         justfile: search.justfile,
-      })
-    } else if let Err(io_error) = fs::write(&search.justfile, INIT_JUSTFILE) {
-      Err(Error::WriteJustfile {
+      });
+    }
+
+    if let Err(io_error) = fs::write(&search.justfile, INIT_JUSTFILE) {
+      return Err(Error::WriteJustfile {
         justfile: search.justfile,
         io_error,
-      })
-    } else {
-      if config.verbosity.loud() {
-        eprintln!("Wrote justfile to `{}`", search.justfile.display());
-      }
-      Ok(())
+      });
     }
+    if config.verbosity.loud() {
+      eprintln!("Wrote justfile to `{}`", search.justfile.display());
+    }
+    Ok(())
   }
 
   fn man() -> RunResult<'static> {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -71,10 +71,10 @@ impl Subcommand {
 
     match self {
       Choose { overrides, chooser } => {
-        Self::choose(config, justfile, &search, overrides, chooser.as_deref())?
+        Self::choose(config, justfile, &search, overrides, chooser.as_deref())?;
       }
       Command { overrides, .. } | Evaluate { overrides, .. } => {
-        justfile.run(config, &search, overrides, &[])?
+        justfile.run(config, &search, overrides, &[])?;
       }
       Dump => Self::dump(config, compilation)?,
       Format => Self::format(config, &search, compilation)?,


### PR DESCRIPTION
* adds some documentation comments for various methods on `Search`
* passes `Compilation` into several `Subcommand` handler methods to reduce cluttering up the outer scope of `Subcommand::execute`
* makes some code slightly more concise in a few areas