### PR TITLE
Simplify `Subcommand::run`

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -76,16 +76,16 @@ impl Search {
     }
   }
 
-  /// Look for a justfile starting from the parent directory to the current justfile
+  /// find justfile starting from parent directory of current justfile
   pub(crate) fn search_parent_directory(&self) -> SearchResult<Self> {
-    let parent_dir = self
+    let parent = self
       .justfile
       .parent()
-      .and_then(|p| p.parent())
+      .and_then(|path| path.parent())
       .ok_or_else(|| SearchError::JustfileHadNoParent {
         path: self.justfile.clone(),
       })?;
-    Self::find_in_directory(parent_dir)
+    Self::find_in_directory(parent)
   }
 
   /// Find a justfile starting in the given directory and searching upwards in the directory tree

--- a/src/search.rs
+++ b/src/search.rs
@@ -34,7 +34,7 @@ impl Search {
     paths
   }
 
-  /// Attempt to find a justfile given the search configuration and invocation directory
+  /// find justfile given search configuration and invocation directory
   pub(crate) fn find(
     search_config: &SearchConfig,
     invocation_directory: &Path,

--- a/src/search.rs
+++ b/src/search.rs
@@ -34,7 +34,7 @@ impl Search {
     paths
   }
 
-  /// find justfile given search configuration and invocation directory
+  /// Find justfile given search configuration and invocation directory
   pub(crate) fn find(
     search_config: &SearchConfig,
     invocation_directory: &Path,
@@ -76,7 +76,7 @@ impl Search {
     }
   }
 
-  /// find justfile starting from parent directory of current justfile
+  /// Find justfile starting from parent directory of current justfile
   pub(crate) fn search_parent_directory(&self) -> SearchResult<Self> {
     let parent = self
       .justfile
@@ -88,7 +88,7 @@ impl Search {
     Self::find_in_directory(parent)
   }
 
-  /// Find a justfile starting in the given directory and searching upwards in the directory tree
+  /// Find justfile starting in given directory searching upwards in directory tree
   fn find_in_directory(starting_dir: &Path) -> SearchResult<Self> {
     let justfile = Self::justfile(starting_dir)?;
     let working_directory = Self::working_directory_from_justfile(&justfile)?;

--- a/src/search.rs
+++ b/src/search.rs
@@ -34,12 +34,13 @@ impl Search {
     paths
   }
 
+  /// Attempt to find a justfile given the search configuration and invocation directory
   pub(crate) fn find(
     search_config: &SearchConfig,
     invocation_directory: &Path,
   ) -> SearchResult<Self> {
     match search_config {
-      SearchConfig::FromInvocationDirectory => Self::find_next(invocation_directory),
+      SearchConfig::FromInvocationDirectory => Self::find_in_directory(invocation_directory),
       SearchConfig::FromSearchDirectory { search_directory } => {
         let search_directory = Self::clean(invocation_directory, search_directory);
         let justfile = Self::justfile(&search_directory)?;
@@ -75,7 +76,20 @@ impl Search {
     }
   }
 
-  pub(crate) fn find_next(starting_dir: &Path) -> SearchResult<Self> {
+  /// Look for a justfile starting from the parent directory to the current justfile
+  pub(crate) fn search_parent_directory(&self) -> SearchResult<Self> {
+    let parent_dir = self
+      .justfile
+      .parent()
+      .and_then(|p| p.parent())
+      .ok_or_else(|| SearchError::JustfileHadNoParent {
+        path: self.justfile.clone(),
+      })?;
+    Self::find_in_directory(parent_dir)
+  }
+
+  /// Find a justfile starting in the given directory and searching upwards in the directory tree
+  fn find_in_directory(starting_dir: &Path) -> SearchResult<Self> {
     let justfile = Self::justfile(starting_dir)?;
     let working_directory = Self::working_directory_from_justfile(&justfile)?;
     Ok(Self {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -118,9 +118,7 @@ impl Subcommand {
 
       if fallback {
         if let Err(err @ (Error::UnknownRecipe { .. } | Error::UnknownSubmodule { .. })) = result {
-          search = search
-            .search_parent_directory()
-            .map_err(|_search_err| err)?;
+          search = search.search_parent_directory().map_err(|_| err)?;
 
           let new_parent = starting_parent
             .strip_prefix(search.justfile.parent().unwrap())

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -53,10 +53,6 @@ impl Subcommand {
       Completions { shell } => return Self::completions(*shell),
       Init => return Self::init(config),
       Man => return Self::man(),
-      Run {
-        arguments,
-        overrides,
-      } => return Self::run(config, loader, arguments, overrides),
       _ => {}
     }
 
@@ -70,6 +66,10 @@ impl Subcommand {
     let justfile = &compilation.justfile;
 
     match self {
+      Run {
+        arguments,
+        overrides,
+      } => Self::run(config, loader, search, arguments, overrides)?,
       Choose { overrides, chooser } => {
         Self::choose(config, justfile, &search, overrides, chooser.as_deref())?;
       }
@@ -83,7 +83,7 @@ impl Subcommand {
       Show { path } => Self::show(config, justfile, path)?,
       Summary => Self::summary(config, justfile),
       Variables => Self::variables(justfile),
-      Changelog | Completions { .. } | Edit | Init | Man | Run { .. } => unreachable!(),
+      Changelog | Completions { .. } | Edit | Init | Man => unreachable!(),
     }
 
     Ok(())
@@ -99,88 +99,52 @@ impl Subcommand {
   fn run<'src>(
     config: &Config,
     loader: &'src Loader,
+    initial_search: Search,
     arguments: &[String],
     overrides: &BTreeMap<String, String>,
   ) -> RunResult<'src> {
-    if matches!(
-      config.search_config,
-      SearchConfig::FromInvocationDirectory | SearchConfig::FromSearchDirectory { .. }
-    ) {
-      let starting_path = match &config.search_config {
-        SearchConfig::FromInvocationDirectory => config.invocation_directory.clone(),
-        SearchConfig::FromSearchDirectory { search_directory } => config
-          .invocation_directory
-          .join(search_directory)
-          .lexiclean(),
-        _ => unreachable!(),
-      };
+    let starting_path = initial_search
+      .justfile
+      .parent()
+      .as_ref()
+      .unwrap()
+      .lexiclean();
 
-      let mut path = starting_path.clone();
+    let mut search = initial_search;
 
-      let mut unknown_recipes_errors = None;
+    loop {
+      let compilation = Self::compile(config, loader, &search)?;
+      let justfile = &compilation.justfile;
+      let fallback = justfile.settings.fallback
+        && matches!(
+          config.search_config,
+          SearchConfig::FromInvocationDirectory | SearchConfig::FromSearchDirectory { .. }
+        );
+      let run_result = justfile.run(config, &search, overrides, arguments);
 
-      loop {
-        let search = match Search::find_next(&path) {
-          Err(SearchError::NotFound) => match unknown_recipes_errors {
-            Some(err) => return Err(err),
-            None => return Err(SearchError::NotFound.into()),
-          },
-          Err(err) => return Err(err.into()),
-          Ok(search) => {
-            if config.verbosity.loquacious() && path != starting_path {
-              eprintln!(
-                "Trying {}",
-                starting_path
-                  .strip_prefix(path)
-                  .unwrap()
-                  .components()
-                  .map(|_| path::Component::ParentDir)
-                  .collect::<PathBuf>()
-                  .join(search.justfile.file_name().unwrap())
-                  .display()
-              );
-            }
-            search
+      match run_result {
+        Err(err @ (Error::UnknownRecipe { .. } | Error::UnknownSubmodule { .. })) if fallback => {
+          let new_search = search
+            .search_parent_directory()
+            .map_err(|_search_err| err)?;
+          let p = new_search.justfile.parent().unwrap();
+          let new_path = starting_path
+            .strip_prefix(p)
+            .unwrap()
+            .components()
+            .map(|_| path::Component::ParentDir)
+            .collect::<PathBuf>()
+            .join(new_search.justfile.file_name().unwrap());
+
+          search = new_search;
+
+          if config.verbosity.loquacious() {
+            eprintln!("Trying {}", new_path.display());
           }
-        };
-
-        match Self::run_inner(config, loader, arguments, overrides, &search) {
-          Err((err @ (Error::UnknownRecipe { .. } | Error::UnknownSubmodule { .. }), true)) => {
-            match search.justfile.parent().unwrap().parent() {
-              Some(parent) => {
-                unknown_recipes_errors.get_or_insert(err);
-                path = parent.into();
-              }
-              None => return Err(err),
-            }
-          }
-          result => return result.map_err(|(err, _fallback)| err),
         }
+        result => return result,
       }
-    } else {
-      Self::run_inner(
-        config,
-        loader,
-        arguments,
-        overrides,
-        &Search::find(&config.search_config, &config.invocation_directory)?,
-      )
-      .map_err(|(err, _fallback)| err)
     }
-  }
-
-  fn run_inner<'src>(
-    config: &Config,
-    loader: &'src Loader,
-    arguments: &[String],
-    overrides: &BTreeMap<String, String>,
-    search: &Search,
-  ) -> Result<(), (Error<'src>, bool)> {
-    let compilation = Self::compile(config, loader, search).map_err(|err| (err, false))?;
-    let justfile = &compilation.justfile;
-    justfile
-      .run(config, search, overrides, arguments)
-      .map_err(|err| (err, justfile.settings.fallback))
   }
 
   fn compile<'src>(

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -117,19 +117,17 @@ impl Subcommand {
 
       match run_result {
         Err(err @ (Error::UnknownRecipe { .. } | Error::UnknownSubmodule { .. })) if fallback => {
-          let new_search = search
+          search = search
             .search_parent_directory()
             .map_err(|_search_err| err)?;
-          let p = new_search.justfile.parent().unwrap();
+          let p = search.justfile.parent().unwrap();
           let new_path = starting_path
             .strip_prefix(p)
             .unwrap()
             .components()
             .map(|_| path::Component::ParentDir)
             .collect::<PathBuf>()
-            .join(new_search.justfile.file_name().unwrap());
-
-          search = new_search;
+            .join(search.justfile.file_name().unwrap());
 
           if config.verbosity.loquacious() {
             eprintln!("Trying {}", new_path.display());

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -69,7 +69,7 @@ impl Subcommand {
       Run {
         arguments,
         overrides,
-      } => Self::run(config, loader, search, arguments, overrides)?,
+      } => Self::run(config, loader, search, compilation, arguments, overrides)?,
       Choose { overrides, chooser } => {
         Self::choose(config, justfile, &search, overrides, chooser.as_deref())?;
       }
@@ -100,6 +100,7 @@ impl Subcommand {
     config: &Config,
     loader: &'src Loader,
     initial_search: Search,
+    initial_compilation: Compilation<'src>,
     arguments: &[String],
     overrides: &BTreeMap<String, String>,
   ) -> RunResult<'src> {
@@ -111,9 +112,9 @@ impl Subcommand {
       .lexiclean();
 
     let mut search = initial_search;
+    let mut compilation = initial_compilation;
 
     loop {
-      let compilation = Self::compile(config, loader, &search)?;
       let justfile = &compilation.justfile;
       let fallback = justfile.settings.fallback
         && matches!(
@@ -141,6 +142,7 @@ impl Subcommand {
           if config.verbosity.loquacious() {
             eprintln!("Trying {}", new_path.display());
           }
+          compilation = Self::compile(config, loader, &search)?;
         }
         result => return result,
       }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -99,20 +99,12 @@ impl Subcommand {
   fn run<'src>(
     config: &Config,
     loader: &'src Loader,
-    initial_search: Search,
-    initial_compilation: Compilation<'src>,
+    mut search: Search,
+    mut compilation: Compilation<'src>,
     arguments: &[String],
     overrides: &BTreeMap<String, String>,
   ) -> RunResult<'src> {
-    let starting_path = initial_search
-      .justfile
-      .parent()
-      .as_ref()
-      .unwrap()
-      .lexiclean();
-
-    let mut search = initial_search;
-    let mut compilation = initial_compilation;
+    let starting_path = search.justfile.parent().as_ref().unwrap().lexiclean();
 
     loop {
       let justfile = &compilation.justfile;


### PR DESCRIPTION
The `Subcommand::run` function is a bit messy because it needs to handle the case where fallback is enabled and a missing recipe triggers searching for a new justfile further up the directory tree. This commit attempts to simplify the loop within `Subcommand::run` and make the logic generally easier to understand. 