### PR TITLE
Fix bug in redefinition compile error reporting

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -383,7 +383,7 @@ mod tests {
     line: 2,
     column: 6,
     width: 3,
-    kind: Redefinition { first_type: "alias", second_type: "recipe", name: "foo", first: 0 },
+    kind: Redefinition { first_type: "recipe", second_type: "alias", name: "foo", first: 0 },
   }
 
   analysis_error! {

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -52,10 +52,10 @@ impl<'src> Analyzer<'src> {
      -> CompileResult<'src> {
       if let Some((first_type, original)) = definitions.get(name.lexeme()) {
         if !(*first_type == second_type && duplicates_allowed) {
-          let (original, redefinition) = if name.line < original.line {
-            (name, *original)
+          let ((first_type, second_type), (original, redefinition)) = if name.line < original.line {
+            ((second_type, *first_type), (name, *original))
           } else {
-            (*original, name)
+            ((*first_type, second_type), (*original, name))
           };
 
           return Err(redefinition.token.error(Redefinition {

--- a/tests/error_messages.rs
+++ b/tests/error_messages.rs
@@ -116,7 +116,7 @@ fn redefinition_errors_properly_swap_types() {
     .write("foo.just", "foo:")
     .justfile("foo:\n echo foo\n\nmod foo 'foo.just'")
     .status(EXIT_FAILURE)
-    .stderr(format!(
+    .stderr(
       "
 error: Recipe `foo` defined on line 1 is redefined as a module on line 4
  ——▶ justfile:4:5
@@ -124,6 +124,6 @@ error: Recipe `foo` defined on line 1 is redefined as a module on line 4
 4 │ mod foo 'foo.just'
   │     ^^^
 ",
-    ))
+    )
     .run();
 }

--- a/tests/error_messages.rs
+++ b/tests/error_messages.rs
@@ -109,3 +109,21 @@ fn file_paths_not_in_subdir_are_absolute() {
     )
     .run();
 }
+
+#[test]
+fn redefinition_errors_properly_swap_types() {
+  Test::new()
+    .write("foo.just", "foo:")
+    .justfile("foo:\n echo foo\n\nmod foo 'foo.just'")
+    .status(EXIT_FAILURE)
+    .stderr(format!(
+      "
+error: Recipe `foo` defined on line 1 is redefined as a module on line 4
+ ——▶ justfile:4:5
+  │
+4 │ mod foo 'foo.just'
+  │     ^^^
+",
+    ))
+    .run();
+}


### PR DESCRIPTION
This fixes a bug that caused the error reporting for redefinition compile errors to be reported "backwards" when the original and redefinition were differing types.

See #2350 for additional information.