### PR TITLE
note that you can override dotenv-path at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,7 +905,7 @@ are set, `just` will try to load environment variables from a file.
 If `dotenv-path` is set, `just` will look for a file at the given path, which
 may be absolute, or relative to the working directory.
 
-The command line option `--dotenv-path`, short form `-E`, can be used to set or
+The command-line option `--dotenv-path`, short form `-E`, can be used to set or
 override `dotenv-path` at runtime.
 
 If `dotenv-filename` is set `just` will look for a file at the given path,

--- a/README.md
+++ b/README.md
@@ -903,8 +903,10 @@ If any of `dotenv-load`, `dotenv-filename`, `dotenv-path`, or `dotenv-required`
 are set, `just` will try to load environment variables from a file.
 
 If `dotenv-path` is set, `just` will look for a file at the given path, which
-may be absolute, or relative to the working directory. Passing `-E different_path`
-or `--dotenv-path different_path` overrides `dotenv-path` at runtime.
+may be absolute, or relative to the working directory.
+
+The command line option `--dotenv-path`, short form `-E`, can be used to set or
+override `dotenv-path` at runtime.
 
 If `dotenv-filename` is set `just` will look for a file at the given path,
 relative to the working directory and each of its ancestors.

--- a/README.md
+++ b/README.md
@@ -903,7 +903,8 @@ If any of `dotenv-load`, `dotenv-filename`, `dotenv-path`, or `dotenv-required`
 are set, `just` will try to load environment variables from a file.
 
 If `dotenv-path` is set, `just` will look for a file at the given path, which
-may be absolute, or relative to the working directory.
+may be absolute, or relative to the working directory. Passing `-E different_path`
+or `--dotenv-path different_path` overrides `dotenv-path` at runtime.
 
 If `dotenv-filename` is set `just` will look for a file at the given path,
 relative to the working directory and each of its ancestors.


### PR DESCRIPTION
Being able to override `-E/--dotenv-path` at runtime is super useful and should be part of documentation.