### PR TITLE
Remove AliasShadowsRecipe compilation error

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -323,14 +323,6 @@ impl<'src> Analyzer<'src> {
     recipes: &Table<'src, Rc<Recipe<'src>>>,
     alias: Alias<'src, Name<'src>>,
   ) -> CompileResult<'src, Alias<'src>> {
-    // Make sure the alias doesn't conflict with any recipe
-    if let Some(recipe) = recipes.get(alias.name.lexeme()) {
-      return Err(alias.name.token.error(AliasShadowsRecipe {
-        alias: alias.name.lexeme(),
-        recipe_line: recipe.line_number(),
-      }));
-    }
-
     // Make sure the target recipe exists
     match recipes.get(alias.target.lexeme()) {
       Some(target) => Ok(alias.resolve(Rc::clone(target))),

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -32,12 +32,6 @@ impl Display for CompileError<'_> {
     use CompileErrorKind::*;
 
     match &*self.kind {
-      AliasShadowsRecipe { alias, recipe_line } => write!(
-        f,
-        "Alias `{alias}` defined on line {} shadows recipe `{alias}` defined on line {}",
-        self.token.line.ordinal(),
-        recipe_line.ordinal(),
-      ),
       AttributeArgumentCountMismatch {
         attribute,
         found,

--- a/src/compile_error_kind.rs
+++ b/src/compile_error_kind.rs
@@ -2,10 +2,6 @@ use super::*;
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum CompileErrorKind<'src> {
-  AliasShadowsRecipe {
-    alias: &'src str,
-    recipe_line: usize,
-  },
   AttributeArgumentCountMismatch {
     attribute: &'src str,
     found: usize,


### PR DESCRIPTION
`AliasShadowsRecipe` doesn't actually ever get created, because the check for redefinitions that emits the more-general `Redefinition` compiler error catches cases where an alias has the same name as an existing recipe instead. So it is redundant and can be removed.