### PR TITLE
Analyzer changes

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -139,7 +139,7 @@ impl<'run, 'src> Analyzer<'run, 'src> {
 
     AssignmentResolver::resolve_assignments(&assignments)?;
 
-    let mut recipe_table: Table<'src, UnresolvedRecipe<'src>> = Table::default();
+    let mut deduplicated_recipes = Table::<'src, UnresolvedRecipe<'src>>::default();
     for recipe in self.recipes {
       Self::define(
         &mut definitions,
@@ -148,15 +148,15 @@ impl<'run, 'src> Analyzer<'run, 'src> {
         settings.allow_duplicate_recipes,
       )?;
 
-      if recipe_table
+      if deduplicated_recipes
         .get(recipe.name.lexeme())
         .map_or(true, |original| recipe.file_depth <= original.file_depth)
       {
-        recipe_table.insert(recipe.clone());
+        deduplicated_recipes.insert(recipe.clone());
       }
     }
 
-    let recipes = RecipeResolver::resolve_recipes(&assignments, &settings, recipe_table)?;
+    let recipes = RecipeResolver::resolve_recipes(&assignments, &settings, deduplicated_recipes)?;
 
     let mut aliases = Table::new();
     while let Some(alias) = self.aliases.pop() {

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -100,7 +100,7 @@ impl<'run, 'src> Analyzer<'run, 'src> {
             }
           }
           Item::Set(set) => {
-            Self::analyze_set(&self.sets, set)?;
+            self.analyze_set(set)?;
             self.sets.insert(set.clone());
           }
           Item::Unexport { name } => {
@@ -312,8 +312,8 @@ impl<'run, 'src> Analyzer<'run, 'src> {
     Ok(())
   }
 
-  fn analyze_set(sets: &Table<'src, Set<'src>>, set: &Set<'src>) -> CompileResult<'src> {
-    if let Some(original) = sets.get(set.name.lexeme()) {
+  fn analyze_set(&self, set: &Set<'src>) -> CompileResult<'src> {
+    if let Some(original) = self.sets.get(set.name.lexeme()) {
       return Err(set.name.error(DuplicateSet {
         setting: original.name.lexeme(),
         first: original.name.line,

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -118,15 +118,6 @@ impl<'run, 'src> Analyzer<'run, 'src> {
 
     let settings = Settings::from_table(self.sets);
 
-    for recipe in &self.recipes {
-      Self::define(
-        &mut definitions,
-        recipe.name,
-        "recipe",
-        settings.allow_duplicate_recipes,
-      )?;
-    }
-
     let mut assignments: Table<'src, Assignment<'src>> = Table::default();
     for assignment in self.assignments {
       let variable = assignment.name.lexeme();
@@ -150,6 +141,13 @@ impl<'run, 'src> Analyzer<'run, 'src> {
 
     let mut recipe_table: Table<'src, UnresolvedRecipe<'src>> = Table::default();
     for recipe in self.recipes {
+      Self::define(
+        &mut definitions,
+        recipe.name,
+        "recipe",
+        settings.allow_duplicate_recipes,
+      )?;
+
       if recipe_table
         .get(recipe.name.lexeme())
         .map_or(true, |original| recipe.file_depth <= original.file_depth)

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1,11 +1,11 @@
 use {super::*, CompileErrorKind::*};
 
 #[derive(Default)]
-pub(crate) struct Analyzer<'local, 'src> {
+pub(crate) struct Analyzer<'run, 'src> {
   aliases: Table<'src, Alias<'src, Name<'src>>>,
-  assignments: Vec<&'local Binding<'src, Expression<'src>>>,
+  assignments: Vec<&'run Binding<'src, Expression<'src>>>,
   modules: Table<'src, Justfile<'src>>,
-  recipes: Vec<&'local Recipe<'src, UnresolvedDependency<'src>>>,
+  recipes: Vec<&'run Recipe<'src, UnresolvedDependency<'src>>>,
   sets: Table<'src, Set<'src>>,
   unexports: HashSet<String>,
   warnings: Vec<Warning>,
@@ -44,7 +44,7 @@ impl<'src> Definitions<'src> {
   }
 }
 
-impl<'local, 'src> Analyzer<'local, 'src> {
+impl<'run, 'src> Analyzer<'run, 'src> {
   pub(crate) fn analyze(
     asts: &HashMap<PathBuf, Ast<'src>>,
     doc: Option<String>,

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -106,11 +106,7 @@ impl<'run, 'src> Analyzer<'run, 'src> {
 
     let settings = Settings::from_table(sets);
 
-    let recipe_names: Vec<Name<'src>> = analyzer
-      .recipes
-      .iter()
-      .map(|recipe| recipe.name.clone())
-      .collect();
+    let recipe_names: Vec<Name<'src>> = analyzer.recipes.iter().map(|recipe| recipe.name).collect();
     for name in recipe_names {
       analyzer.define(name, "recipe", settings.allow_duplicate_recipes)?;
     }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -21,8 +21,7 @@ impl<'run, 'src> Analyzer<'run, 'src> {
     paths: &HashMap<PathBuf, PathBuf>,
     root: &Path,
   ) -> CompileResult<'src, Justfile<'src>> {
-    let analyzer = Analyzer::default();
-    analyzer.justfile(asts, doc, groups, loaded, name, paths, root)
+    Self::default().justfile(asts, doc, groups, loaded, name, paths, root)
   }
 
   fn justfile(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -29,11 +29,11 @@ pub(crate) struct Settings<'src> {
 }
 
 impl<'src> Settings<'src> {
-  pub(crate) fn from_setting_iter(iter: impl Iterator<Item = Setting<'src>>) -> Self {
+  pub(crate) fn from_table(sets: Table<'src, Set<'src>>) -> Self {
     let mut settings = Self::default();
 
-    for set in iter {
-      match set {
+    for (_name, set) in sets {
+      match set.value {
         Setting::AllowDuplicateRecipes(allow_duplicate_recipes) => {
           settings.allow_duplicate_recipes = allow_duplicate_recipes;
         }


### PR DESCRIPTION
This is a refactoring commit to the analyzer code that hopefully makes it easier to understand what the analyzer is doing.

`Analyzer::analyze()` now instantiates an `Analyzer`, and all of the data structures containing items have been moved to being members of that`Analyzer` struct, rather than some being on the struct and accessed through `self` and others being bare variables in the function scope.

The `definitions` HashMap is moved to being a field on the `Analyzer` struct, rather than using a closure defined in function scope.

`analyze_set` is moved to being an associated function so it works the same way as the other `analyze_*` functions.