### PR TITLE
Reduce code duplication in suggestion methods

### DIFF
--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -34,8 +34,6 @@ pub(crate) struct Justfile<'src> {
 }
 
 impl<'src> Justfile<'src> {
-  /// Given an input string and a collection of candidate items, find the suggestion
-  /// with the closest edit distance to the input less than three, if it exists.
   fn find_suggestion(
     input: &str,
     candidates: impl Iterator<Item = Suggestion<'src>>,

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -40,16 +40,11 @@ impl<'src> Justfile<'src> {
     input: &str,
     candidates: impl Iterator<Item = Suggestion<'src>>,
   ) -> Option<Suggestion<'src>> {
-    let mut suggestions: Vec<(usize, Suggestion<'src>)> = candidates
+    candidates
       .map(|suggestion| (edit_distance(input, suggestion.name), suggestion))
       .filter(|(distance, _suggestion)| *distance < 3)
-      .collect();
-
-    suggestions.sort_by_key(|(distance, _suggestion)| *distance);
-    suggestions
-      .into_iter()
+      .min_by_key(|(distance, _suggestion)| *distance)
       .map(|(_distance, suggestion)| suggestion)
-      .next()
   }
 
   pub(crate) fn suggest_recipe(&self, input: &str) -> Option<Suggestion<'src>> {

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -48,24 +48,27 @@ impl<'src> Justfile<'src> {
   }
 
   pub(crate) fn suggest_recipe(&self, input: &str) -> Option<Suggestion<'src>> {
-    let recipe_candidates = self
-      .recipes
-      .keys()
-      .map(|name| Suggestion { name, target: None });
-    let alias_candidates = self.aliases.iter().map(|(name, alias)| Suggestion {
-      name,
-      target: Some(alias.target.name.lexeme()),
-    });
-    let candidates = recipe_candidates.chain(alias_candidates);
-    Self::find_suggestion(input, candidates)
+    Self::find_suggestion(
+      input,
+      self
+        .recipes
+        .keys()
+        .map(|name| Suggestion { name, target: None })
+        .chain(self.aliases.iter().map(|(name, alias)| Suggestion {
+          name,
+          target: Some(alias.target.name.lexeme()),
+        })),
+    )
   }
 
   pub(crate) fn suggest_variable(&self, input: &str) -> Option<Suggestion<'src>> {
-    let candidates = self
-      .assignments
-      .keys()
-      .map(|name| Suggestion { name, target: None });
-    Self::find_suggestion(input, candidates)
+    Self::find_suggestion(
+      input,
+      self
+        .assignments
+        .keys()
+        .map(|name| Suggestion { name, target: None }),
+    )
   }
 
   pub(crate) fn run(


### PR DESCRIPTION
The existing `suggest_recipe` and `suggest_variable` methods have a decent chunk of duplicate code. This commit factors that out into a separate method. 