### PR TITLE
Invertible attributes

### DIFF
--- a/src/attribute_set.rs
+++ b/src/attribute_set.rs
@@ -12,6 +12,17 @@ impl<'src> AttributeSet<'src> {
     self.0.iter().any(|attr| attr.discriminant() == target)
   }
 
+  pub(crate) fn contains_invertible(&self, target: AttributeDiscriminant) -> Option<bool> {
+    self.get(target).map(|attr| match attr {
+      Attribute::Linux { enabled }
+      | Attribute::Macos { enabled }
+      | Attribute::Openbsd { enabled }
+      | Attribute::Unix { enabled }
+      | Attribute::Windows { enabled } => *enabled,
+      _ => panic!("contains_invertible called with non-invertible attribute"),
+    })
+  }
+
   pub(crate) fn get(&self, discriminant: AttributeDiscriminant) -> Option<&Attribute<'src>> {
     self
       .0

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -187,6 +187,9 @@ impl Display for CompileError<'_> {
           _ => character.escape_default().collect(),
         }
       ),
+      InvalidInvertedAttribute { attr_name } => {
+        write!(f, "{attr_name} cannot be inverted with `not()`")
+      }
       MismatchedClosingDelimiter {
         open,
         open_line,

--- a/src/compile_error_kind.rs
+++ b/src/compile_error_kind.rs
@@ -76,6 +76,9 @@ pub(crate) enum CompileErrorKind<'src> {
   InvalidEscapeSequence {
     character: char,
   },
+  InvalidInvertedAttribute {
+    attr_name: &'src str,
+  },
   MismatchedClosingDelimiter {
     close: Delimiter,
     open: Delimiter,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1191,7 +1191,17 @@ impl<'run, 'src> Parser<'run, 'src> {
       token.get_or_insert(bracket);
 
       loop {
-        let name = self.parse_name()?;
+        let (name, inverted) = {
+          let name = self.parse_name()?;
+          if name.lexeme() == "not" {
+            self.expect(ParenL)?;
+            let name = self.parse_name()?;
+            self.expect(ParenR)?;
+            (name, true)
+          } else {
+            (name, false)
+          }
+        };
 
         let mut arguments = Vec::new();
 
@@ -1208,7 +1218,7 @@ impl<'run, 'src> Parser<'run, 'src> {
           self.expect(ParenR)?;
         }
 
-        let attribute = Attribute::new(name, arguments)?;
+        let attribute = Attribute::new(name, arguments, !inverted)?;
 
         let first = attributes.get(&attribute).or_else(|| {
           if attribute.repeatable() {
@@ -2747,6 +2757,17 @@ mod tests {
     column: 1,
     width:  7,
     kind:   UnknownAttribute { attribute: "unknown" },
+  }
+
+  error! {
+    name:   invalid_invertable_attribute,
+    input:  "[not(private)]\nsome_recipe:\n @exit 3",
+    offset: 5,
+    line:   0,
+    column: 5,
+    width:  7,
+    kind:   InvalidInvertedAttribute { attr_name: "private" },
+
   }
 
   error! {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -31,6 +31,7 @@ enum System {
   MacOS,
   OpenBSD,
   Unix,
+  Unrecognized,
   Windows,
 }
 
@@ -52,7 +53,7 @@ impl System {
     if cfg!(unix) {
       return Unix;
     }
-    panic!("No recognized system");
+    Unrecognized
   }
 
   fn enabled(self, enabled: SystemMap, disabled: SystemMap) -> bool {
@@ -82,6 +83,7 @@ impl System {
           && (enabled.unix
             || !(enabled.windows || enabled.macos || enabled.linux || enabled.openbsd))
       }
+      System::Unrecognized => true,
     }
   }
 }


### PR DESCRIPTION
This PR implements a `not()` syntax for certain OS-target attributes.

Resolves https://github.com/casey/just/issues/1895