### PR TITLE
Tidy up error message of interrupt signal for default 'fzf' chooser

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -154,7 +154,7 @@ pub(crate) enum Error<'src> {
     recipe: &'src str,
   },
   Signal {
-    recipe: &'src str,
+    recipe: Option<&'src str>,
     line_number: Option<usize>,
     signal: i32,
   },
@@ -436,10 +436,14 @@ impl<'src> ColorDisplay for Error<'src> {
         }
       }
       Signal { recipe, line_number, signal } => {
-        if let Some(n) = line_number {
-          write!(f, "Recipe `{recipe}` was terminated on line {n} by signal {signal}")?;
+        if let Some(recipe) = recipe {
+          if let Some(n) = line_number {
+            write!(f, "Recipe `{recipe}` was terminated on line {n} by signal {signal}")?;
+          } else {
+            write!(f, "Recipe `{recipe}` was terminated by signal {signal}")?;
+          }
         } else {
-          write!(f, "Recipe `{recipe}` was terminated by signal {signal}")?;
+          write!(f, "Command was terminated by signal {signal}")?;
         }
       }
       StdoutIo { io_error } => {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -5,7 +5,7 @@ use super::*;
 fn error_from_signal(recipe: &str, line_number: Option<usize>, exit_status: ExitStatus) -> Error {
   match Platform::signal_from_exit_status(exit_status) {
     Some(signal) => Error::Signal {
-      recipe,
+      recipe: Some(recipe),
       line_number,
       signal,
     },


### PR DESCRIPTION
Hello :wave: 

I'm kind of just starting to use `just` & I think I like it. While I was just trying things out I see that this tool can do a "chooser" mode where the user is guided from interactive CLI, which I think is kind of nice

I have an improvement idea regarding some error message thrown during `chooser` mode that uses the default `fzf` command. Basically right now when I do this:

```justfile
default:
    just --choose

ping:
    echo pong
```

It'll take me to the expected CLI menu
![image](https://github.com/user-attachments/assets/415219e8-8130-4c1e-b737-03c6b0260ae8)


But when I ^C or ^D it it'll throw some (unexpected) error

```shell
just --choose
error: Chooser `fzf --multi --preview 'just --unstable --color always --justfile "/some/path/justfile" --show {}'` failed: exit status: 130
error: Recipe `default` failed on line 2 with exit code 130
```

I think since it is expected that exit code 130 to be [`ExitInterrupt`](https://github.com/junegunn/fzf/blob/30a8ef28cdc1d23cf6956f57ca05bd28db515014/src/constants.go#L74), we can just use it to have better error message

The new error message would be

```shell
just --choose
error: Command was terminated by signal 130
error: Recipe `default` failed on line 2 with exit code 1
```

IMO better error message would be something along the line of just `Command was interrupted` without any signal code, since that signal is `fzf`-specific, but current ones convey the meaning just fine too