### PR TITLE
Deprecate backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2034,6 +2034,8 @@ Use `just --groups --unsorted` to print groups in their justfile order.
 
 ### Command Evaluation Using Backticks
 
+Backticks are an older feature that have largely been obsoleted by the `shell` function (see [External Commands](#external-commands).); we recommend that you use `shell` in new justfiles.
+
 Backticks can be used to store the result of commands:
 
 ```just

--- a/README.md
+++ b/README.md
@@ -2060,8 +2060,8 @@ Backticks may not start with `#!`. This syntax is reserved for a future
 upgrade.
 
 The [`shell(…)` function](#external-commands) provides a more general mechanism
-to invoke external commands, including the ability to execute a variable as a
-command, and to pass arguments.
+to invoke external commands, including the ability to execute the contents of a
+variable as a command, and to pass arguments to a command.
 
 ### Conditional Expressions
 

--- a/README.md
+++ b/README.md
@@ -2034,8 +2034,6 @@ Use `just --groups --unsorted` to print groups in their justfile order.
 
 ### Command Evaluation Using Backticks
 
-Backticks are an older feature that have largely been obsoleted by the `shell` function (see [External Commands](#external-commands).); we recommend that you use `shell` in new justfiles.
-
 Backticks can be used to store the result of commands:
 
 ```just
@@ -2060,6 +2058,8 @@ See the [Strings](#strings) section for details on unindenting.
 
 Backticks may not start with `#!`. This syntax is reserved for a future
 upgrade.
+
+More flexible and powerful command invocations can be acheived with the `shell` function (see [External Commands](#external-commands)).
 
 ### Conditional Expressions
 

--- a/README.md
+++ b/README.md
@@ -2059,7 +2059,9 @@ See the [Strings](#strings) section for details on unindenting.
 Backticks may not start with `#!`. This syntax is reserved for a future
 upgrade.
 
-More flexible and powerful command invocations can be acheived with the `shell` function (see [External Commands](#external-commands)).
+The [`shell(…)` function](#external-commands) provides a more general mechanism
+to invoke external commands, including the ability to execute a variable as a
+command, and to pass arguments.
 
 ### Conditional Expressions
 


### PR DESCRIPTION
Just a sentence suggesting people use `shell` instead of backticks.

Oh look, I just used backticks up there!! :-)