### PR TITLE
Use string-specific pretty_assertions displayer in tests

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,7 @@
-use {super::*, pretty_assertions::assert_eq};
+use {
+  super::*,
+  pretty_assertions::{assert_eq, StrComparison},
+};
 
 macro_rules! test {
   {
@@ -205,6 +208,14 @@ impl Test {
       equal
     }
 
+    fn compare_string(name: &str, have: &str, want: &str) -> bool {
+      let equal = have == want;
+      if !equal {
+        eprintln!("Bad {name}: {}", StrComparison::new(&have, &want));
+      }
+      equal
+    }
+
     if let Some(justfile) = &self.justfile {
       let justfile = unindent(justfile);
       fs::write(self.justfile_path(), justfile).unwrap();
@@ -266,8 +277,8 @@ impl Test {
     }
 
     if !compare("status", output.status.code(), Some(self.status))
-      | (self.stdout_regex.is_none() && !compare("stdout", output_stdout, &stdout))
-      | (self.stderr_regex.is_none() && !compare("stderr", output_stderr, &stderr))
+      | (self.stdout_regex.is_none() && !compare_string("stdout", output_stdout, &stdout))
+      | (self.stderr_regex.is_none() && !compare_string("stderr", output_stderr, &stderr))
     {
       panic!("Output mismatch.");
     }


### PR DESCRIPTION
The `pretty_assertions` crate that the test harness is already using has a string-specific comparison implementation that can properly display ANSI escapes, which are pretty frequent in `just` tests.

When running e.g. `cargo test unicode_escape_invalid_character`:

Before:
```
failures:

---- string::unicode_escape_invalid_character stdout ----
Bad stderr: Diff < left / right > :
<"\u{1b}[31merror:\u{1b}[0m unicode escape sequence value `BadBad` greater than maximum valid code point `10FFFF`\n   \u{1b}[38;5;246m╭\u{1b}[0m\u{1b}[38;5;246m─\u{1b}[0m\u{1b}[38;5;246m[\u{1b}[0mjustfile:1:6\u{1b}[38;5;246m]\u{1b}[0m\n   \u{1b}[38;5;246m│\u{1b}[0m\n \u{1b}[38;5;246m1 │\u{1b}[0m \u{1b}[38;5;249mx\u{1b}[0m\u{1b}[38;5;249m \u{1b}[0m\u{1b}[38;5;249m:\u{1b}[0m\u{1b}[38;5;249m=\u{1b}[0m\u{1b}[38;5;249m \u{1b}[0m\"\\u{BadBad}\"\n\u{1b}[38;5;246m───╯\u{1b}[0m\n"
>"error: unicode escape sequence value `BadBad` greater than maximum valid code point `10FFFF`\n ——▶ justfile:1:6\n  │\n1 │ x := \"\\u{BadBad}\"\n  │      ^^^^^^^^^^^^\n"

thread 'string::unicode_escape_invalid_character' panicked at tests/string.rs:509:6:
Output mismatch.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:
```
failures:

---- string::unicode_escape_invalid_character stdout ----
Bad stderr: Diff < left / right > :
<error: unicode escape sequence value `BadBad` greater than maximum valid code point `10FFFF`
<   ╭─[justfile:1:6]
<   │
< 1 │ x := "\u{BadBad}"
<───╯
>error: unicode escape sequence value `BadBad` greater than maximum valid code point `10FFFF`
> ——▶ justfile:1:6
>  │
>1 │ x := "\u{BadBad}"
>  │      ^^^^^^^^^^^^


thread 'string::unicode_escape_invalid_character' panicked at tests/string.rs:509:6:
Output mismatch.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


This should help with the test conversion that needs to happen in https://github.com/casey/just/pull/2426