### PR TITLE
Allow interchangable recipe redefinitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3321,6 +3321,8 @@ import? 'foo/bar.just'
 
 Missing source files for optional imports do not produce an error.
 
+Importing the same source file multiple times is not an error.
+
 ### Modules<sup>1.19.0</sup>
 
 A `justfile` can declare modules using `mod` statements.

--- a/README.md
+++ b/README.md
@@ -3319,9 +3319,33 @@ Imports may be made optional by putting a `?` after the `import` keyword:
 import? 'foo/bar.just'
 ```
 
-Missing source files for optional imports do not produce an error.
+Importing the same source file multiple times is not an error<sup>master</sup>.
+This allows importing multiple justfiles, for example `foo.just` and
+`bar.just`, which both import a third justfile containing shared recipes, for
+example `baz.just`, without the duplicate import of `baz.just` being an error:
 
-Importing the same source file multiple times is not an error.
+```just
+# justfile
+import 'foo.just'
+import 'bar.just'
+```
+
+```just
+# foo.just
+import 'baz.just'
+foo: baz
+```
+
+```just
+# bar.just
+import 'baz.just'
+bar: baz
+```
+
+```just
+# baz
+baz:
+```
 
 ### Modules<sup>1.19.0</sup>
 

--- a/README.md
+++ b/README.md
@@ -3324,19 +3324,19 @@ This allows importing multiple justfiles, for example `foo.just` and
 `bar.just`, which both import a third justfile containing shared recipes, for
 example `baz.just`, without the duplicate import of `baz.just` being an error:
 
-```just
+```mf
 # justfile
 import 'foo.just'
 import 'bar.just'
 ```
 
-```just
+```mf
 # foo.just
 import 'baz.just'
 foo: baz
 ```
 
-```just
+```mf
 # bar.just
 import 'baz.just'
 bar: baz

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -141,6 +141,15 @@ impl<'run, 'src> Analyzer<'run, 'src> {
 
     let mut deduplicated_recipes = Table::<'src, UnresolvedRecipe<'src>>::default();
     for recipe in self.recipes {
+      // compare name tokens, which include file path and source location, so
+      // will only return true for the same recipe imported from the same file
+      if deduplicated_recipes
+        .values()
+        .any(|previous| recipe.name == previous.name)
+      {
+        continue;
+      }
+
       Self::define(
         &mut definitions,
         recipe.name,

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -35,12 +35,11 @@ impl<'run, 'src> Analyzer<'run, 'src> {
     root: &Path,
   ) -> CompileResult<'src, Justfile<'src>> {
     let mut definitions = HashMap::new();
+    let mut imports = HashSet::new();
 
     let mut stack = Vec::new();
     let ast = asts.get(root).unwrap();
     stack.push(ast);
-
-    let mut imported = HashSet::new();
 
     while let Some(ast) = stack.pop() {
       for item in &ast.items {
@@ -56,7 +55,7 @@ impl<'run, 'src> Analyzer<'run, 'src> {
           Item::Comment(_) => (),
           Item::Import { absolute, .. } => {
             if let Some(absolute) = absolute {
-              if imported.insert(absolute) {
+              if imports.insert(absolute) {
                 stack.push(asts.get(absolute).unwrap());
               }
             }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -21,7 +21,6 @@ impl Compiler {
       let tokens = Lexer::lex(relative, src)?;
       let mut ast = Parser::parse(
         current.file_depth,
-        &current.path,
         &current.import_offsets,
         &current.namepath,
         &tokens,
@@ -214,14 +213,7 @@ impl Compiler {
   #[cfg(test)]
   pub(crate) fn test_compile(src: &str) -> CompileResult<Justfile> {
     let tokens = Lexer::test_lex(src)?;
-    let ast = Parser::parse(
-      0,
-      &PathBuf::new(),
-      &[],
-      &Namepath::default(),
-      &tokens,
-      &PathBuf::new(),
-    )?;
+    let ast = Parser::parse(0, &[], &Namepath::default(), &tokens, &PathBuf::new())?;
     let root = PathBuf::from("justfile");
     let mut asts: HashMap<PathBuf, Ast> = HashMap::new();
     asts.insert(root.clone(), ast);

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -26,8 +26,6 @@ pub(crate) struct Recipe<'src, D = Dependency<'src>> {
   #[serde(skip)]
   pub(crate) file_depth: u32,
   #[serde(skip)]
-  pub(crate) file_path: PathBuf,
-  #[serde(skip)]
   pub(crate) import_offsets: Vec<usize>,
   pub(crate) name: Name<'src>,
   pub(crate) namepath: Namepath<'src>,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -59,15 +59,8 @@ pub(crate) fn analysis_error(
 ) {
   let tokens = Lexer::test_lex(src).expect("Lexing failed in parse test...");
 
-  let ast = Parser::parse(
-    0,
-    &PathBuf::new(),
-    &[],
-    &Namepath::default(),
-    &tokens,
-    &PathBuf::new(),
-  )
-  .expect("Parsing failed in analysis test...");
+  let ast = Parser::parse(0, &[], &Namepath::default(), &tokens, &PathBuf::new())
+    .expect("Parsing failed in analysis test...");
 
   let root = PathBuf::from("justfile");
   let mut asts: HashMap<PathBuf, Ast> = HashMap::new();

--- a/src/unresolved_recipe.rs
+++ b/src/unresolved_recipe.rs
@@ -50,7 +50,6 @@ impl<'src> UnresolvedRecipe<'src> {
       dependencies,
       doc: self.doc,
       file_depth: self.file_depth,
-      file_path: self.file_path,
       import_offsets: self.import_offsets,
       name: self.name,
       namepath: self.namepath,

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -360,3 +360,34 @@ fn reused_import_are_allowed() {
     })
     .run();
 }
+
+#[test]
+fn multiply_imported_recipes_do_not_conflict() {
+  Test::new()
+    .justfile(
+      "
+      import 'a.just'
+      import 'a.just'
+      foo: bar
+    ",
+    )
+    .write("a.just", "bar:")
+    .run();
+}
+
+#[test]
+fn multiply_imported_recipes_in_nested_imports_do_not_conflict() {
+  Test::new()
+    .justfile(
+      "
+      import 'a.just'
+      import 'b.just'
+      foo: bar
+    ",
+    )
+    .write("a.just", "import 'c.just'")
+    .write("b.just", "import 'c.just'")
+    .write("c.just", "@bar:\n echo 'hello'")
+    .stdout("hello\n")
+    .run();
+}

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -362,7 +362,7 @@ fn reused_import_are_allowed() {
 }
 
 #[test]
-fn multiply_imported_recipes_do_not_conflict() {
+fn multiply_imported_items_do_not_conflict() {
   Test::new()
     .justfile(
       "
@@ -371,12 +371,21 @@ fn multiply_imported_recipes_do_not_conflict() {
       foo: bar
     ",
     )
-    .write("a.just", "bar:")
+    .write(
+      "a.just",
+      "
+x := 'y'
+
+@bar:
+  echo hello
+",
+    )
+    .stdout("hello\n")
     .run();
 }
 
 #[test]
-fn multiply_imported_recipes_in_nested_imports_do_not_conflict() {
+fn nested_multiply_imported_items_do_not_conflict() {
   Test::new()
     .justfile(
       "
@@ -387,7 +396,15 @@ fn multiply_imported_recipes_in_nested_imports_do_not_conflict() {
     )
     .write("a.just", "import 'c.just'")
     .write("b.just", "import 'c.just'")
-    .write("c.just", "@bar:\n echo 'hello'")
+    .write(
+      "c.just",
+      "
+x := 'y'
+
+@bar:
+  echo hello
+",
+    )
     .stdout("hello\n")
     .run();
 }


### PR DESCRIPTION
Fixes #2436.

@neunenak Does this seem reasonable to you? See the original issue, but basically, if you have the same recipe imported in multiple places in the same module, you'll get an error. This seems safe to allow, since they're exactly the same recipe. Allowing it is kind of like automatically wrapping recipes in C-style include guards.

This is a bit hacky, since it only works for recipes. The less hacky way to do it would be to just ignore an import if it's a file that's already been imported into this module, which would work for everything.