### PR TITLE
Replace `derivative` with `derive-where`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
@@ -329,14 +329,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
+name = "derive-where"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -531,7 +531,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "ctrlc",
- "derivative",
+ "derive-where",
  "dirs",
  "dotenvy",
  "edit-distance",
@@ -861,7 +861,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
@@ -930,7 +930,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
@@ -958,18 +958,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]
@@ -1038,7 +1027,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
@@ -1142,7 +1131,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1164,7 +1153,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1396,5 +1385,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ clap = { version = "4.0.0", features = ["derive", "env", "wrap_help"] }
 clap_complete = "4.0.0"
 clap_mangen = "0.2.20"
 ctrlc = { version = "3.1.1", features = ["termination"] }
-derivative = "2.0.0"
+derive-where = "1.2.7"
 dirs = "5.0.1"
 dotenvy = "0.15"
 edit-distance = "2.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@ pub(crate) use {
   },
   camino::Utf8Path,
   clap::ValueEnum,
-  derivative::Derivative,
   edit_distance::edit_distance,
   lexiclean::Lexiclean,
   libc::EXIT_FAILURE,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub(crate) use {
   },
   camino::Utf8Path,
   clap::ValueEnum,
+  derive_where::derive_where,
   edit_distance::edit_distance,
   lexiclean::Lexiclean,
   libc::EXIT_FAILURE,

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive_where::derive_where(Debug, PartialEq)]
+#[derive_where(Debug, PartialEq)]
 #[derive(Clone)]
 pub(crate) enum Thunk<'src> {
   Nullary {

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -1,46 +1,46 @@
 use super::*;
 
-#[derive(Derivative)]
-#[derivative(Debug, Clone, PartialEq = "feature_allow_slow_enum")]
+#[derive_where::derive_where(Debug, PartialEq)]
+#[derive(Clone)]
 pub(crate) enum Thunk<'src> {
   Nullary {
     name: Name<'src>,
-    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    #[derive_where(skip(Debug, EqHashOrd))]
     function: fn(function::Context) -> FunctionResult,
   },
   Unary {
     name: Name<'src>,
-    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    #[derive_where(skip(Debug, EqHashOrd))]
     function: fn(function::Context, &str) -> FunctionResult,
     arg: Box<Expression<'src>>,
   },
   UnaryOpt {
     name: Name<'src>,
-    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    #[derive_where(skip(Debug, EqHashOrd))]
     function: fn(function::Context, &str, Option<&str>) -> FunctionResult,
     args: (Box<Expression<'src>>, Box<Option<Expression<'src>>>),
   },
   UnaryPlus {
     name: Name<'src>,
-    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    #[derive_where(skip(Debug, EqHashOrd))]
     function: fn(function::Context, &str, &[String]) -> FunctionResult,
     args: (Box<Expression<'src>>, Vec<Expression<'src>>),
   },
   Binary {
     name: Name<'src>,
-    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    #[derive_where(skip(Debug, EqHashOrd))]
     function: fn(function::Context, &str, &str) -> FunctionResult,
     args: [Box<Expression<'src>>; 2],
   },
   BinaryPlus {
     name: Name<'src>,
-    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    #[derive_where(skip(Debug, EqHashOrd))]
     function: fn(function::Context, &str, &str, &[String]) -> FunctionResult,
     args: ([Box<Expression<'src>>; 2], Vec<Expression<'src>>),
   },
   Ternary {
     name: Name<'src>,
-    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    #[derive_where(skip(Debug, EqHashOrd))]
     function: fn(function::Context, &str, &str, &str) -> FunctionResult,
     args: [Box<Expression<'src>>; 3],
   },


### PR DESCRIPTION
Running `cargo audit` on `just` repo gives the following warnings -
```
Crate:     ansi_term
Version:   0.12.1
Warning:   unmaintained
Title:     ansi_term is Unmaintained
Date:      2021-08-18
ID:        RUSTSEC-2021-0139
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0139
Dependency tree:
ansi_term 0.12.1
└── just 1.36.0

Crate:     derivative
Version:   2.2.0
Warning:   unmaintained
Title:     `derivative` is unmaintained; consider using an alternative
Date:      2024-06-26
ID:        RUSTSEC-2024-0388
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0388
Dependency tree:
derivative 2.2.0
└── just 1.36.0

warning: 2 allowed warnings found
```

This PR fixes one of these two warnings by replacing `derivative` with `derive-where`, which is [how `rustc` handled this](https://github.com/rust-lang/rust/pull/127042).