### PR TITLE
docs: note that set shell is not used for [script]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2755,9 +2755,9 @@ scripts interpreted by `COMMAND`. This avoids some of the issues with shebang
 recipes, such as the use of `cygpath` on Windows, the need to use
 `/usr/bin/env`, and inconsistences in shebang line splitting across Unix OSs.
 
-Recipes with an empty `[script]` attribute are executed with the value of
-`set script-interpreter := […]`<sup>1.33.0</sup>, defaulting to `sh -eu`.
-Note that the `set shell` value is *not* used for `[script]` recipes.
+Recipes with an empty `[script]` attribute are executed with the value of `set
+script-interpreter := […]`<sup>1.33.0</sup>, defaulting to `sh -eu`, and *not*
+the value of `set shell`.
 
 The body of the recipe is evaluated, written to disk in the temporary
 directory, and run by passing its path as an argument to `COMMAND`.

--- a/README.md
+++ b/README.md
@@ -2757,6 +2757,7 @@ recipes, such as the use of `cygpath` on Windows, the need to use
 
 Recipes with an empty `[script]` attribute are executed with the value of
 `set script-interpreter := […]`<sup>1.33.0</sup>, defaulting to `sh -eu`.
+Note that the `set shell` value is *not* used for `[script]` recipes.
 
 The body of the recipe is evaluated, written to disk in the temporary
 directory, and run by passing its path as an argument to `COMMAND`.


### PR DESCRIPTION
this was surprising functionality for me.

IMHO I think inheriting `shell` if `script-interpreter` is not set might be better
