### PR TITLE
Forbid duplicated non-repeatable attributes

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -6,7 +6,7 @@ use super::*;
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
 #[strum_discriminants(name(AttributeDiscriminant))]
-#[strum_discriminants(derive(EnumString))]
+#[strum_discriminants(derive(EnumString, Ord, PartialOrd))]
 #[strum_discriminants(strum(serialize_all = "kebab-case"))]
 pub(crate) enum Attribute<'src> {
   Confirm(Option<StringLiteral<'src>>),
@@ -96,8 +96,16 @@ impl<'src> Attribute<'src> {
     })
   }
 
+  pub(crate) fn discriminant(&self) -> AttributeDiscriminant {
+    self.into()
+  }
+
   pub(crate) fn name(&self) -> &'static str {
     self.into()
+  }
+
+  pub(crate) fn repeatable(&self) -> bool {
+    matches!(self, Attribute::Group(_))
   }
 }
 

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -230,3 +230,26 @@ fn extension_on_linewise_error() {
     .status(EXIT_FAILURE)
     .run();
 }
+
+#[test]
+fn duplicate_non_repeatable_attributes_are_forbidden() {
+  Test::new()
+    .justfile(
+      "
+        [confirm: 'yes']
+        [confirm: 'no']
+        baz:
+      ",
+    )
+    .stderr(
+      "
+  error: Recipe attribute `confirm` first used on line 1 is duplicated on line 2
+   ——▶ justfile:2:2
+    │
+  2 │ [confirm: 'no']
+    │  ^^^^^^^
+",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}


### PR DESCRIPTION
Forbid duplicated non-repeatable attributes in the parser. Duplicate attributes with different values were previously accepted by the compiler, often to ill effect, like multiple `confirm` attributes being allowed on a recipe, but only one being respected.

This fixes that by disallowing all duplicate non-repeatable attributes, regardless of whether they have different arguments or not. The only repeatable attribute is the `[group]` attribute, since recipes can be in multiple groups.

This is a backwards compatibility break, but it is most definitely a bug, and backwards compatibility breaking bug fixes are allowed.