### PR TITLE
Add "file_content(filename)" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1835,6 +1835,7 @@ which will halt execution.
 - `path_exists(path)` - Returns `true` if the path points at an existing entity
   and `false` otherwise. Traverses symbolic links, and returns `false` if the
   path is inaccessible or points to a broken symlink.
+- `file_content(path)` - Returns the content of the file as a string.
 
 ##### Error Reporting
 

--- a/README.md
+++ b/README.md
@@ -1835,7 +1835,8 @@ which will halt execution.
 - `path_exists(path)` - Returns `true` if the path points at an existing entity
   and `false` otherwise. Traverses symbolic links, and returns `false` if the
   path is inaccessible or points to a broken symlink.
-- `file_content(path)` - Returns the content of the file as a string.
+- `read_to_string(path)`<sup>master</sup> - Returns the content of file at
+  `path` as a string.
 
 ##### Error Reporting
 

--- a/README.md
+++ b/README.md
@@ -1836,7 +1836,7 @@ which will halt execution.
   and `false` otherwise. Traverses symbolic links, and returns `false` if the
   path is inaccessible or points to a broken symlink.
 - `read_to_string(path)`<sup>master</sup> - Returns the content of file at
-  `path` as a string.
+  `path` as string.
 
 ##### Error Reporting
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -66,6 +66,7 @@ pub(crate) fn get(name: &str) -> Option<Function> {
     "extension" => Unary(extension),
     "file_name" => Unary(file_name),
     "file_stem" => Unary(file_stem),
+    "file_content" => Unary(file_content),
     "home_directory" => Nullary(|_| dir("home", dirs::home_dir)),
     "invocation_directory" => Nullary(invocation_directory),
     "invocation_directory_native" => Nullary(invocation_directory_native),
@@ -170,6 +171,15 @@ fn blake3_file(context: Context, path: &str) -> FunctionResult {
     .update_mmap_rayon(&path)
     .map_err(|err| format!("Failed to hash `{}`: {err}", path.display()))?;
   Ok(hasher.finalize().to_string())
+}
+
+fn file_content(context: Context, filename: &str) -> FunctionResult {
+  let path = context.evaluator.context.working_directory().join(filename);
+  let contents = fs::read_to_string(path);
+  if let Err(err) = &contents {
+    return Err(format!("error reading file `{filename}`: {err}"));
+  }
+  Ok(contents.unwrap())
 }
 
 fn canonicalize(context: Context, path: &str) -> FunctionResult {

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -764,6 +764,24 @@ fn file_content() {
 }
 
 #[test]
+fn file_content_file_not_found() {
+  Test::new()
+    .justfile("x := sha256(file_content('sub/shafile_NON_EXISTENT'))")
+    .args(["--evaluate", "x"])
+    .stderr(
+      "
+      error: Call to function `file_content` failed: error reading file `sub/shafile_NON_EXISTENT`: No such file or directory (os error 2)
+       ——▶ justfile:1:13
+        │
+      1 │ x := sha256(file_content('sub/shafile_NON_EXISTENT'))
+        │             ^^^^^^^^^^^^
+      ",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
 fn just_pid() {
   let Output { stdout, pid, .. } = Test::new()
     .args(["--evaluate", "x"])

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -749,39 +749,6 @@ fn sha256_file() {
 }
 
 #[test]
-fn file_content() {
-  Test::new()
-    .justfile("x := sha256(file_content('sub/shafile'))")
-    .tree(tree! {
-      sub: {
-        shafile: "just is great\n",
-      }
-    })
-    .current_dir("sub")
-    .args(["--evaluate", "x"])
-    .stdout("177b3d79aaafb53a7a4d7aaba99a82f27c73370e8cb0295571aade1e4fea1cd2")
-    .run();
-}
-
-#[test]
-fn file_content_file_not_found() {
-  Test::new()
-    .justfile("x := sha256(file_content('sub/shafile_NON_EXISTENT'))")
-    .args(["--evaluate", "x"])
-    .stderr(
-      "
-      error: Call to function `file_content` failed: error reading file `sub/shafile_NON_EXISTENT`: No such file or directory (os error 2)
-       ——▶ justfile:1:13
-        │
-      1 │ x := sha256(file_content('sub/shafile_NON_EXISTENT'))
-        │             ^^^^^^^^^^^^
-      ",
-    )
-    .status(EXIT_FAILURE)
-    .run();
-}
-
-#[test]
 fn just_pid() {
   let Output { stdout, pid, .. } = Test::new()
     .args(["--evaluate", "x"])
@@ -1288,6 +1255,26 @@ fn style_unknown() {
           │             ^^^^^
       "#,
     )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn read_to_string() {
+  Test::new()
+    .justfile("foo := read_to_string('bar')")
+    .write("bar", "baz")
+    .args(["--evaluate", "foo"])
+    .stdout("baz")
+    .run();
+}
+
+#[test]
+fn read_to_string_not_found() {
+  Test::new()
+    .justfile("foo := read_to_string('bar')")
+    .args(["--evaluate", "foo"])
+    .stderr_regex(r"error: Call to function `read_to_string` failed: I/O error reading `bar`: .*")
     .status(EXIT_FAILURE)
     .run();
 }

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -749,6 +749,21 @@ fn sha256_file() {
 }
 
 #[test]
+fn file_content() {
+  Test::new()
+    .justfile("x := sha256(file_content('sub/shafile'))")
+    .tree(tree! {
+      sub: {
+        shafile: "just is great\n",
+      }
+    })
+    .current_dir("sub")
+    .args(["--evaluate", "x"])
+    .stdout("177b3d79aaafb53a7a4d7aaba99a82f27c73370e8cb0295571aade1e4fea1cd2")
+    .run();
+}
+
+#[test]
 fn just_pid() {
   let Output { stdout, pid, .. } = Test::new()
     .args(["--evaluate", "x"])


### PR DESCRIPTION
This PR adds `file_content()` function, which loads a file content as a string.

In task runners like `just`, one often needs to load from the file system (like "VERSION.txt" etc.).