### PR TITLE
Add experimental [no-shell] attribute

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -18,6 +18,7 @@ pub(crate) enum Attribute<'src> {
   NoCd,
   NoExitMessage,
   NoQuiet,
+  NoShell,
   Openbsd,
   PositionalArguments,
   Private,
@@ -37,6 +38,7 @@ impl AttributeDiscriminant {
       | Self::NoCd
       | Self::NoExitMessage
       | Self::NoQuiet
+      | Self::NoShell
       | Self::Openbsd
       | Self::PositionalArguments
       | Self::Private
@@ -85,6 +87,7 @@ impl<'src> Attribute<'src> {
       AttributeDiscriminant::NoCd => Self::NoCd,
       AttributeDiscriminant::NoExitMessage => Self::NoExitMessage,
       AttributeDiscriminant::NoQuiet => Self::NoQuiet,
+      AttributeDiscriminant::NoShell => Self::NoShell,
       AttributeDiscriminant::Openbsd => Self::Openbsd,
       AttributeDiscriminant::PositionalArguments => Self::PositionalArguments,
       AttributeDiscriminant::Private => Self::Private,
@@ -134,6 +137,7 @@ impl Display for Attribute<'_> {
       | Self::NoCd
       | Self::NoExitMessage
       | Self::NoQuiet
+      | Self::NoShell
       | Self::Openbsd
       | Self::PositionalArguments
       | Self::Private

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -25,7 +25,7 @@ impl Shell {
 }
 
 fn clap(shell: clap_complete::Shell) -> RunResult<'static, String> {
-  fn replace(haystack: &mut String, needle: &str, replacement: &str) -> RunResult<'static, ()> {
+  fn replace(haystack: &mut String, needle: &str, replacement: &str) -> RunResult<'static> {
     if let Some(index) = haystack.find(needle) {
       haystack.replace_range(index..index + needle.len(), replacement);
       Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub(crate) use {
     shebang::Shebang,
     show_whitespace::ShowWhitespace,
     source::Source,
+    statement::Statement,
     string_delimiter::StringDelimiter,
     string_kind::StringKind,
     string_literal::StringLiteral,
@@ -97,6 +98,7 @@ pub(crate) use {
     variables::Variables,
     verbosity::Verbosity,
     warning::Warning,
+    word::Word,
   },
   camino::Utf8Path,
   clap::ValueEnum,
@@ -256,6 +258,7 @@ mod settings;
 mod shebang;
 mod show_whitespace;
 mod source;
+mod statement;
 mod string_delimiter;
 mod string_kind;
 mod string_literal;
@@ -273,3 +276,4 @@ mod use_color;
 mod variables;
 mod verbosity;
 mod warning;
+mod word;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -948,7 +948,6 @@ impl<'run, 'src> Parser<'run, 'src> {
     }
 
     Ok(Recipe {
-      shebang: shebang || script,
       attributes,
       body,
       dependencies,
@@ -961,6 +960,8 @@ impl<'run, 'src> Parser<'run, 'src> {
       priors,
       private,
       quiet,
+      shebang: shebang || script,
+      statements: None,
     })
   }
 

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -1,0 +1,6 @@
+use super::*;
+
+#[derive(PartialEq, Debug, Clone, Serialize)]
+pub(crate) struct Statement<'src> {
+  pub(crate) words: Vec<Word<'src>>,
+}

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -275,7 +275,7 @@ impl Subcommand {
     justfile.run(config, search, overrides, &recipes)
   }
 
-  fn completions(shell: completions::Shell) -> RunResult<'static, ()> {
+  fn completions(shell: completions::Shell) -> RunResult<'static> {
     println!("{}", shell.script()?);
     Ok(())
   }

--- a/src/word.rs
+++ b/src/word.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+#[derive(PartialEq, Debug, Clone, Serialize)]
+pub(crate) enum Word<'src> {
+  Expression(Expression<'src>),
+  Text(String),
+}


### PR DESCRIPTION
This PR adds an experimental `[no-shell]` attribute.

When the `[no-shell]` attribute, linewise recipe lines are *not* run with `sh` (or whatever the shell is set to) but instead is run with a very simple command parser and interpreter.

The goal is to provide the ability to run commands with no external dependencies, other than the commands themselves.

This came up in https://github.com/astral-sh/uv/issues/5903 when discussing the possibility of using `just` as a command runner for `uv`. Because `just` relies on a shell, `sh` by default, to run commands, it can't be used by projects which must be cross platform with no other dependencies.

This PR, which isn't really mergable at the moment, only supports word splitting on whitespace and `{{…}}` interpolations.

For this to be minimally useful, I think it also needs to support:

- Single and double quoted strings with the usual semantics
- Environment variable access with `$VAR`
- Selectively joining the result of `{{…}}` interpolations with adjacent text, depending on whether it's whitespace separated or not
- Making unsupported shell syntax an error, instead of passing unwanted arguments (so `echo hello > foo` is an error, instead of calling `echo` with `hello`, `>`, and `foo`)

I've been hoping for a long time that a Rust-only bourne shell would be written, but that doesn't appear to be happening, thus this PR.

I'm not sure if this PR is worth it, to be honest. There are a ton of ways to get a working `sh`, in almost every environment. If `sh` is not available, any other shell or interpreter can be used. So this covers a pretty niche use-case. Also, I'm not sure `just` is a good fit for `uv`, even if this feature was available.

Also, this feature would have to be unstable for a long time, until we were sure that we had added everything that we wanted to the shell language.