### PR TITLE
Show full example of getting XDG user directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1927,8 +1927,14 @@ details.
 - `home_directory()` - The user's home directory.
 
 If you would like to use XDG base directories on all platforms you can use the
-`env(…)` function with the appropriate environment variable, e.g.,
-`env('XDG_CACHE_HOME')`.
+`env(…)` function with the appropriate environment variable and fallback, e.g.
+```just
+xdg_config_dir := if env('XDG_CONFIG_HOME', '') =~ '^/' {
+  env('XDG_CONFIG_HOME')
+} else {
+  home_directory() / '.config'
+}
+```
 
 ### Constants
 

--- a/README.md
+++ b/README.md
@@ -1927,7 +1927,11 @@ details.
 - `home_directory()` - The user's home directory.
 
 If you would like to use XDG base directories on all platforms you can use the
-`env(…)` function with the appropriate environment variable and fallback, e.g.
+`env(…)` function with the appropriate environment variable and fallback,
+although note that the XDG specificiation requires ignoring non-absolute paths,
+so for full compatibility with spec-complient applications, you would need to
+do:
+
 ```just
 xdg_config_dir := if env('XDG_CONFIG_HOME', '') =~ '^/' {
   env('XDG_CONFIG_HOME')


### PR DESCRIPTION
Per [XDG base directory specification](https://specifications.freedesktop.org/basedir-spec/latest/), getting an XDG user directory involves a bit more than reading an environment variable:

> All paths set in these environment variables must be absolute. If an implementation encounters a relative path in any of these variables it should consider the path invalid and ignore it.
> ...
> `$XDG_CONFIG_HOME` defines the base directory relative to which user-specific configuration files should be stored. If `$XDG_CONFIG_HOME` is either not set or empty, a default equal to `$HOME/.config` should be used.

This PR expands the example to fully show how to get an XDG user directory in a justfile.