### PR TITLE
readme: promote `env()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1645,7 +1645,7 @@ olleh := shell('import sys; print(sys.argv[2][::-1])', 'hello')
 
 #### Environment Variables
 
-- `env(key)` — Retrieves the environment variable with name `key`, aborting
+- `env(key)`<sup>1.15.0</sup> — Retrieves the environment variable with name `key`, aborting
   if it is not present.
 
 ```just
@@ -1660,10 +1660,10 @@ $ just
 /home/user1
 ```
 
-- `env_var_or_default(key, default)` — Retrieves the environment variable with
+- `env(key, default)`<sup>1.15.0</sup> — Retrieves the environment variable with
   name `key`, returning `default` if it is not present.
-- `env(key)`<sup>1.15.0</sup> — Alias for `env_var(key)`.
-- `env(key, default)`<sup>1.15.0</sup> — Alias for `env_var_or_default(key, default)`.
+- `env_var(key)` — Deprecated alias for `env(key)`.
+- `env_var_or_default(key, default)` — Deprecated alias for `env(key, default)`.
 
 A default can be substituted for an empty environment variable value with the
 `||` operator, currently unstable:
@@ -2446,8 +2446,8 @@ HOME is '/home/myuser'
 
 #### Setting `just` Variables from Environment Variables
 
-Environment variables can be propagated to `just` variables using the functions
-`env_var()` and `env_var_or_default()`. See
+Environment variables can be propagated to `just` variables using the `env()` function.
+See
 [environment-variables](#environment-variables).
 
 ### Recipe Parameters


### PR DESCRIPTION
Completes the documentation update @casey started in https://github.com/casey/just/pull/2545#discussion_r1895161726

I interpreted that comment as basically saying `env_var()` and `env_var_or_default()` are now deprecated in favor of `env()`, so this PR also adds notes that those two functions are deprecated.  Please let me know if this is incorrect.