### PR TITLE
refactor: changelog rev

### DIFF
--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -181,7 +181,19 @@ impl Subcommand {
   }
 
   fn changelog() {
-    print!("{}", include_str!("../CHANGELOG.md"));
+    let cl = include_str!("../CHANGELOG.md");
+    let mut content = String::new();
+    for line in cl.lines().rev() {
+      if line.starts_with("[") {
+        // version
+        println!("{}", line);
+        // changelog content
+        print!("{}", content);
+        content = String::new();
+      } else {
+        content = format!("{}\n{}", line, content);
+      }
+    }
   }
 
   fn choose<'src>(


### PR DESCRIPTION
## Description

`just --changelog` should prioritize displaying the latest changelog.

## preview

<img width="1313" alt="image" src="https://github.com/user-attachments/assets/ed10565d-db36-477b-a236-b378299dea73" />

