### PR TITLE
Ignore I/O errors when writing changelog

### DIFF
--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -181,7 +181,7 @@ impl Subcommand {
   }
 
   fn changelog() {
-    print!("{}", include_str!("../CHANGELOG.md"));
+    write!(io::stdout(), "{}", include_str!("../CHANGELOG.md")).ok();
   }
 
   fn choose<'src>(


### PR DESCRIPTION
This prevents a panic when doing `just --changelog | less`.