### PR TITLE
Clarify behavior of `trim_end_match` in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1791,13 +1791,13 @@ The process ID is: 420
   [Replacement string syntax](https://docs.rs/regex/latest/regex/struct.Regex.html#replacement-string-syntax).
 - `trim(s)` - Remove leading and trailing whitespace from `s`.
 - `trim_end(s)` - Remove trailing whitespace from `s`.
-- `trim_end_match(s, substr)` - Remove suffix of `s` matching `substr`.
-- `trim_end_matches(s, substr)` - Repeatedly remove suffixes of `s` matching
-  `substr`.
+- `trim_end_match(s, substring)` - Remove suffix of `s` matching `substring`.
+- `trim_end_matches(s, substring)` - Repeatedly remove suffixes of `s` matching
+  `substring`.
 - `trim_start(s)` - Remove leading whitespace from `s`.
-- `trim_start_match(s, substr)` - Remove prefix of `s` matching `substr`.
-- `trim_start_matches(s, substr)` - Repeatedly remove prefixes of `s` matching
-  `substr`.
+- `trim_start_match(s, substring)` - Remove prefix of `s` matching `substring`.
+- `trim_start_matches(s, substring)` - Repeatedly remove prefixes of `s`
+  matching `substring`.
 
 #### Case Conversion
 

--- a/README.md
+++ b/README.md
@@ -1791,13 +1791,13 @@ The process ID is: 420
   [Replacement string syntax](https://docs.rs/regex/latest/regex/struct.Regex.html#replacement-string-syntax).
 - `trim(s)` - Remove leading and trailing whitespace from `s`.
 - `trim_end(s)` - Remove trailing whitespace from `s`.
-- `trim_end_match(s, pat)` - Remove suffix of `s` matching `pat`.
-- `trim_end_matches(s, pat)` - Repeatedly remove suffixes of `s` matching
-  `pat`.
+- `trim_end_match(s, substr)` - Remove suffix of `s` matching `substr`.
+- `trim_end_matches(s, substr)` - Repeatedly remove suffixes of `s` matching
+  `substr`.
 - `trim_start(s)` - Remove leading whitespace from `s`.
-- `trim_start_match(s, pat)` - Remove prefix of `s` matching `pat`.
-- `trim_start_matches(s, pat)` - Repeatedly remove prefixes of `s` matching
-  `pat`.
+- `trim_start_match(s, substr)` - Remove prefix of `s` matching `substr`.
+- `trim_start_matches(s, substr)` - Repeatedly remove prefixes of `s` matching
+  `substr`.
 
 #### Case Conversion
 

--- a/README.中文.md
+++ b/README.中文.md
@@ -1196,11 +1196,11 @@ The executable is at: /bin/just
 - `replace_regex(s, regex, replacement)` - 将 `s` 中所有的 `regex` 替换为 `replacement`。正则表达式由 [Rust `regex` 包](https://docs.rs/regex/latest/regex/) 提供。参见 [语法文档](https://docs.rs/regex/latest/regex/#syntax) 以了解使用示例。
 - `trim(s)` - 去掉 `s` 的首尾空格。
 - `trim_end(s)` - 去掉 `s` 的尾部空格。
-- `trim_end_match(s, pat)` - 删除与 `pat` 匹配的 `s` 的后缀。
-- `trim_end_matches(s, pat)` - 反复删除与 `pat` 匹配的 `s` 的后缀。
+- `trim_end_match(s, substr)` - 删除与 `substr` 匹配的 `s` 的后缀。
+- `trim_end_matches(s, substr)` - 反复删除与 `substr` 匹配的 `s` 的后缀。
 - `trim_start(s)` - 去掉 `s` 的首部空格。
-- `trim_start_match(s, pat)` - 删除与 `pat` 匹配的 `s` 的前缀。
-- `trim_start_matches(s, pat)` - 反复删除与 `pat` 匹配的 `s` 的前缀。
+- `trim_start_match(s, substr)` - 删除与 `substr` 匹配的 `s` 的前缀。
+- `trim_start_matches(s, substr)` - 反复删除与 `substr` 匹配的 `s` 的前缀。
 
 #### 大小写转换
 


### PR DESCRIPTION
I was super confused about why my regex wasn't working with `trim_end_match` and it wasn't until I found https://github.com/casey/just/issues/1658 that I figured out why.

I think calling the second parameter `pat`tern implies that it's a regex pattern when it's not. I changed it to `substr` to imply it's just a regular string (it is), we could also add additional docs to that effect.

fixes https://github.com/casey/just/issues/1983 