### PR TITLE
Keep `[private]` attribute when formatting assignments

### DIFF
--- a/src/assignment.rs
+++ b/src/assignment.rs
@@ -5,9 +5,14 @@ pub(crate) type Assignment<'src> = Binding<'src, Expression<'src>>;
 
 impl Display for Assignment<'_> {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    if self.private {
+      writeln!(f, "[private]")?;
+    }
+
     if self.export {
       write!(f, "export ")?;
     }
+
     write!(f, "{} := {}", self.name, self.value)
   }
 }

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1155,3 +1155,22 @@ fn if_else() {
     )
     .run();
 }
+
+#[test]
+fn private_variable() {
+  Test::new()
+    .justfile(
+      "
+        [private]
+        foo := 'bar'
+      ",
+    )
+    .arg("--dump")
+    .stdout(
+      "
+        [private]
+        foo := 'bar'
+      ",
+    )
+    .run();
+}


### PR DESCRIPTION
Fixes #2591.