### PR TITLE
Fix README.md copy paste error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1700,7 +1700,7 @@ foo := env('FOO') || 'DEFAULT_VALUE'
   ```just
   set unstable
 
-  bosh := require("bosh")
+  bosh := which("bosh")
 
   @test:
       echo "bosh: '{{bosh}}'"

--- a/README.md
+++ b/README.md
@@ -2908,7 +2908,7 @@ hello:
 Recipes with a `[script(COMMAND)]`<sup>1.32.0</sup> attribute are run as
 scripts interpreted by `COMMAND`. This avoids some of the issues with shebang
 recipes, such as the use of `cygpath` on Windows, the need to use
-`/usr/bin/env`, and inconsistences in shebang line splitting across Unix OSs.
+`/usr/bin/env`, and inconsistencies in shebang line splitting across Unix OSs.
 
 Recipes with an empty `[script]` attribute are executed with the value of `set
 script-interpreter := […]`<sup>1.33.0</sup>, defaulting to `sh -eu`, and *not*


### PR DESCRIPTION
Seems like it was copy pasted but forgot to replace `require` with `which`.

EDIT: Also did a pass with [typos](https://github.com/crate-ci/typos) and found a single typo.