### PR TITLE
Prefer pwsh.exe over powershell.exe in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Like PowerShell:
 
 ```just
 # use PowerShell instead of sh:
-set shell := ["powershell.exe", "-c"]
+set shell := ["pwsh.exe", "-c"]
 
 hello:
   Write-Host "Hello, world!"
@@ -120,7 +120,7 @@ list:
 ```
 
 You can also set the shell using command-line arguments. For example, to use
-PowerShell, launch `just` with `--shell powershell.exe --shell-arg -c`.
+PowerShell, launch `just` with `--shell pwsh.exe --shell-arg -c`.
 
 (PowerShell is installed by default on Windows 7 SP1 and Windows Server 2008 R2
 S1 and later, and `cmd.exe` is quite fiddly, so PowerShell is recommended for
@@ -1211,7 +1211,7 @@ an additional flag, often `-c`, to make them evaluate the first argument.
 use `windows-shell`:
 
 ```just
-set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+set windows-shell := ["pwsh.exe", "-NoLogo", "-Command"]
 
 hello:
   Write-Host "Hello, world!"

--- a/examples/kitchen-sink.just
+++ b/examples/kitchen-sink.just
@@ -1,5 +1,5 @@
 set shell := ["sh", "-c"]
-set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+set windows-shell := ["pwsh.exe", "-NoLogo", "-Command"]
 set allow-duplicate-recipes
 set positional-arguments
 set dotenv-load

--- a/examples/powershell.just
+++ b/examples/powershell.just
@@ -1,18 +1,15 @@
 # Cross platform shebang:
 shebang := if os() == 'windows' {
-  'powershell.exe'
+  'pwsh.exe'
 } else {
   '/usr/bin/env pwsh'
 }
 
 # Set shell for non-Windows OSs:
-set shell := ["powershell", "-c"]
+set shell := ["pwsh", "-c"]
 
 # Set shell for Windows OSs:
-set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
-
-# If you have PowerShell Core installed and want to use it,
-# use `pwsh.exe` instead of `powershell.exe`
+set windows-shell := ["pwsh.exe", "-NoLogo", "-Command"]
 
 linewise:
   Write-Host "Hello, world!"


### PR DESCRIPTION
Fixes #2604.

@john-cd Since which version of windows is `pwsh.exe` installed on by default? I want to make sure it's widely available before changing the docs.