### PR TITLE
Remove no longer used Repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,8 +350,6 @@ most Windows users.)
 
 ![just package version table](https://repology.org/badge/vertical-allrepos/just.svg)
 
-![rust:just package version table](https://repology.org/badge/vertical-allrepos/rust:just.svg)
-
 ### Pre-Built Binaries
 
 Pre-built binaries for Linux, MacOS, and Windows can be found on


### PR DESCRIPTION
As of (I think) https://github.com/repology/repology-rules/commit/6da15c753bd5704d9a20b1cd2d6a464db05c56b4 Repology has merged the `rust:just` project listing into the `just` project listing.  The [`rust:just` link](https://repology.org/project/rust:just/versions) now redirects to the `just` one, and the `rust:just` badge only shows "No known packages"