### PR TITLE
Document new Vim/Neovim built-in support for justfile syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,9 @@ editor to use `make` syntax highlighting for `just`.
 
 ### Vim and Neovim
 
+Vim >= 9.1.1042 and Neovim >= 0.11 support Justfile syntax highlighting
+out of the box, thanks to [pbnj](https://github.com/pbnj).
+
 #### `vim-just`
 
 The [vim-just](https://github.com/NoahTheDuke/vim-just) plugin provides syntax

--- a/README.md
+++ b/README.md
@@ -469,8 +469,9 @@ editor to use `make` syntax highlighting for `just`.
 
 ### Vim and Neovim
 
-Vim >= 9.1.1042 and Neovim >= 0.11 support Justfile syntax highlighting
-out of the box, thanks to [pbnj](https://github.com/pbnj).
+Vim version 9.1.1042 or better and Neovim version 0.11 or better support
+Justfile syntax highlighting out of the box, thanks to
+[pbnj](https://github.com/pbnj).
 
 #### `vim-just`
 


### PR DESCRIPTION
https://github.com/vim/vim/pull/16466
https://github.com/neovim/neovim/pull/32131

For context, this is not `vim-just` itself, this is an independent downstream - see https://github.com/NoahTheDuke/vim-just/issues/111