### PR TITLE
Improve unknown start of token error message for invisible characters

### DIFF
--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -291,7 +291,15 @@ impl Display for CompileError<'_> {
       }
       UnknownFunction { function } => write!(f, "Call to unknown function `{function}`"),
       UnknownSetting { setting } => write!(f, "Unknown setting `{setting}`"),
-      UnknownStartOfToken => write!(f, "Unknown start of token:"),
+      UnknownStartOfToken { token } => write!(
+        f,
+        "Unknown start of token {}:",
+        if token.is_ascii() {
+          format!("'{token}'")
+        } else {
+          format!("'{token}' ({})", token.escape_unicode())
+        }
+      ),
       UnpairedCarriageReturn => write!(f, "Unpaired carriage return"),
       UnterminatedBacktick => write!(f, "Unterminated backtick"),
       UnterminatedInterpolation => write!(f, "Unterminated interpolation"),

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -291,15 +291,13 @@ impl Display for CompileError<'_> {
       }
       UnknownFunction { function } => write!(f, "Call to unknown function `{function}`"),
       UnknownSetting { setting } => write!(f, "Unknown setting `{setting}`"),
-      UnknownStartOfToken { token } => write!(
-        f,
-        "Unknown start of token {}:",
-        if token.is_ascii() {
-          format!("'{token}'")
-        } else {
-          format!("'{token}' ({})", token.escape_unicode())
+      UnknownStartOfToken { start } => {
+        write!(f, "Unknown start of token '{start}'")?;
+        if !start.is_ascii_graphic() {
+          write!(f, " (U+{:04X})", *start as u32)?;
         }
-      ),
+        write!(f, ":")
+      }
       UnpairedCarriageReturn => write!(f, "Unpaired carriage return"),
       UnterminatedBacktick => write!(f, "Unterminated backtick"),
       UnterminatedInterpolation => write!(f, "Unterminated interpolation"),

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -296,7 +296,7 @@ impl Display for CompileError<'_> {
         if !start.is_ascii_graphic() {
           write!(f, " (U+{:04X})", *start as u32)?;
         }
-        write!(f, ":")
+        Ok(())
       }
       UnpairedCarriageReturn => write!(f, "Unpaired carriage return"),
       UnterminatedBacktick => write!(f, "Unterminated backtick"),

--- a/src/compile_error_kind.rs
+++ b/src/compile_error_kind.rs
@@ -154,7 +154,7 @@ pub(crate) enum CompileErrorKind<'src> {
     setting: &'src str,
   },
   UnknownStartOfToken {
-    token: char,
+    start: char,
   },
   UnpairedCarriageReturn,
   UnterminatedBacktick,

--- a/src/compile_error_kind.rs
+++ b/src/compile_error_kind.rs
@@ -153,7 +153,9 @@ pub(crate) enum CompileErrorKind<'src> {
   UnknownSetting {
     setting: &'src str,
   },
-  UnknownStartOfToken,
+  UnknownStartOfToken {
+    token: char,
+  },
   UnpairedCarriageReturn,
   UnterminatedBacktick,
   UnterminatedInterpolation,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -505,7 +505,7 @@ impl<'src> Lexer<'src> {
       _ if Self::is_identifier_start(start) => self.lex_identifier(),
       _ => {
         self.advance()?;
-        Err(self.error(UnknownStartOfToken { token: start }))
+        Err(self.error(UnknownStartOfToken { start }))
       }
     }
   }
@@ -2121,7 +2121,7 @@ mod tests {
     line:   0,
     column: 0,
     width:  1,
-    kind:   UnknownStartOfToken { token: '%'},
+    kind:   UnknownStartOfToken { start: '%'},
   }
 
   error! {
@@ -2182,7 +2182,7 @@ mod tests {
     line:   0,
     column: 0,
     width:  1,
-    kind:   UnknownStartOfToken{ token: '-'},
+    kind:   UnknownStartOfToken{ start: '-'},
   }
 
   error! {
@@ -2192,7 +2192,7 @@ mod tests {
     line:   0,
     column: 0,
     width:  1,
-    kind:   UnknownStartOfToken { token: '0' },
+    kind:   UnknownStartOfToken { start: '0' },
   }
 
   error! {
@@ -2262,7 +2262,7 @@ mod tests {
     line:   0,
     column: 1,
     width:  1,
-    kind:   UnknownStartOfToken { token: '%'},
+    kind:   UnknownStartOfToken { start: '%'},
   }
 
   error! {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -505,7 +505,7 @@ impl<'src> Lexer<'src> {
       _ if Self::is_identifier_start(start) => self.lex_identifier(),
       _ => {
         self.advance()?;
-        Err(self.error(UnknownStartOfToken))
+        Err(self.error(UnknownStartOfToken { token: start }))
       }
     }
   }
@@ -2121,7 +2121,7 @@ mod tests {
     line:   0,
     column: 0,
     width:  1,
-    kind:   UnknownStartOfToken,
+    kind:   UnknownStartOfToken { token: '%'},
   }
 
   error! {
@@ -2182,7 +2182,7 @@ mod tests {
     line:   0,
     column: 0,
     width:  1,
-    kind:   UnknownStartOfToken,
+    kind:   UnknownStartOfToken{ token: '-'},
   }
 
   error! {
@@ -2192,7 +2192,7 @@ mod tests {
     line:   0,
     column: 0,
     width:  1,
-    kind:   UnknownStartOfToken,
+    kind:   UnknownStartOfToken { token: '0' },
   }
 
   error! {
@@ -2262,7 +2262,7 @@ mod tests {
     line:   0,
     column: 1,
     width:  1,
-    kind:   UnknownStartOfToken,
+    kind:   UnknownStartOfToken { token: '%'},
   }
 
   error! {

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1685,10 +1685,25 @@ test! {
 \u{200b}foo := 'bar'
 ",
   stderr:   "
-error: Unknown start of token '\u{200b}' (\\u{200b}):
+error: Unknown start of token '\u{200b}' (U+200B):
  ——▶ justfile:1:1
   │
 1 │ \u{200b}foo := 'bar'
+  │ ^
+",
+   status:   EXIT_FAILURE,
+}
+
+test! {
+  name:     unknown_start_of_token_ascii_control_char,
+  justfile: "
+\0foo := 'bar'
+",
+  stderr:   "
+error: Unknown start of token '\0' (U+0000):
+ ——▶ justfile:1:1
+  │
+1 │ \0foo := 'bar'
   │ ^
 ",
    status:   EXIT_FAILURE,

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -558,9 +558,11 @@ echo `echo command interpolation`
 ",
 }
 
-test! {
-  name:     line_error_spacing,
-  justfile: r"
+#[test]
+fn line_error_spacing() {
+  Test::new()
+    .justfile(
+      r"
 
 
 
@@ -572,14 +574,17 @@ test! {
 
 ^^^
 ",
-  stdout:   "",
-  stderr:   "error: Unknown start of token '^':
+    )
+    .stderr(
+      "error: Unknown start of token '^'
   ——▶ justfile:10:1
    │
 10 │ ^^^
    │ ^
 ",
-  status:   EXIT_FAILURE,
+    )
+    .status(EXIT_FAILURE)
+    .run();
 }
 
 test! {
@@ -1664,49 +1669,67 @@ test! {
   status:   EXIT_FAILURE,
 }
 
-test! {
-  name:     unknown_start_of_token,
-  justfile: "
+#[test]
+fn unknown_start_of_token() {
+  Test::new()
+    .justfile(
+      "
 assembly_source_files = %(wildcard src/arch/$(arch)/*.s)
-",
-  stderr:   r"
-    error: Unknown start of token '%':
+      ",
+    )
+    .stderr(
+      r"
+    error: Unknown start of token '%'
      ——▶ justfile:1:25
       │
     1 │ assembly_source_files = %(wildcard src/arch/$(arch)/*.s)
       │                         ^
   ",
-   status:   EXIT_FAILURE,
+    )
+    .status(EXIT_FAILURE)
+    .run();
 }
 
-test! {
-  name:     unknown_start_of_token_invisible_unicode,
-  justfile: "
+#[test]
+fn unknown_start_of_token_invisible_unicode() {
+  Test::new()
+    .justfile(
+      "
 \u{200b}foo := 'bar'
-",
-  stderr:   "
-error: Unknown start of token '\u{200b}' (U+200B):
+      ",
+    )
+    .stderr(
+      "
+error: Unknown start of token '\u{200b}' (U+200B)
  ——▶ justfile:1:1
   │
 1 │ \u{200b}foo := 'bar'
   │ ^
 ",
-   status:   EXIT_FAILURE,
+    )
+    .status(EXIT_FAILURE)
+    .run();
 }
 
-test! {
-  name:     unknown_start_of_token_ascii_control_char,
-  justfile: "
+#[test]
+fn unknown_start_of_token_ascii_control_char() {
+  Test::new()
+    .justfile(
+      "
 \0foo := 'bar'
 ",
-  stderr:   "
-error: Unknown start of token '\0' (U+0000):
+    )
+    .stderr(
+      "
+error: Unknown start of token '\0' (U+0000)
  ——▶ justfile:1:1
   │
 1 │ \0foo := 'bar'
   │ ^
 ",
-   status:   EXIT_FAILURE,
+    )
+    .status(EXIT_FAILURE)
+    .run();
 }
 
 test! {

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -573,7 +573,7 @@ test! {
 ^^^
 ",
   stdout:   "",
-  stderr:   "error: Unknown start of token:
+  stderr:   "error: Unknown start of token '^':
   ——▶ justfile:10:1
    │
 10 │ ^^^
@@ -1670,12 +1670,27 @@ test! {
 assembly_source_files = %(wildcard src/arch/$(arch)/*.s)
 ",
   stderr:   r"
-    error: Unknown start of token:
+    error: Unknown start of token '%':
      ——▶ justfile:1:25
       │
     1 │ assembly_source_files = %(wildcard src/arch/$(arch)/*.s)
       │                         ^
   ",
+   status:   EXIT_FAILURE,
+}
+
+test! {
+  name:     unknown_start_of_token_invisible_unicode,
+  justfile: "
+\u{200b}foo := 'bar'
+",
+  stderr:   "
+error: Unknown start of token '\u{200b}' (\\u{200b}):
+ ——▶ justfile:1:1
+  │
+1 │ \u{200b}foo := 'bar'
+  │ ^
+",
    status:   EXIT_FAILURE,
 }
 


### PR DESCRIPTION
Resolves https://github.com/casey/just/issues/1016

The approach I implemented is displaying the unknown token in single quotes, but if it's not an ASCII character then it is also escaped and displayed in parenthesis.

## Invisible character

### Before

```
error: Unknown start of token:
  |
1 | ﻿test:
  | ^
```

### After

```
error: Unknown start of token '' (\u{200b}):
  |
1 | ﻿test:
  | ^
```

## ASCII character

### Before

```
error: Unknown start of token:
  |
1 | %﻿test:
  | ^
```

### After

```
error: Unknown start of token '%':
  |
1 | %﻿test:
  | ^
```