### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: just-format
+  name: just-format
+  description: "Runs just --unstable --fmt on changed files"
+  entry: just --unstable --fmt -f 
+  files: '\.?[jJ][uU][sS][tT][fF][iI][lL][eE]'
+  language: rust

--- a/bin/just-format
+++ b/bin/just-format
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Check if just is available
+if ! command -v just >/dev/null 2>&1; then
+  echo >&2 "Error: 'just' command not found"
+  exit 1
+fi
+
+# Process each file passed as an argument
+for file in "$@"; do
+  just --unstable --fmt -f "$file"
+done


### PR DESCRIPTION
Can we add a pre-commit hook for the new format parameter?

I original wrote this as:
```yaml
- id: just-format
  name: just-format
  description: "Runs just --unstable --fmt on changed files"
  entry: just --unstable --fmt -f 
  files: '\.?[jJ][uU][sS][tT][fF][iI][lL][eE]'
  language: rust
```
This has the benefit that it would auto-install just, and doesn't require it to be on the local system, but it will only work when there's one justfile in the repo since the just command won't allow multiple filenames to be passed in.

So instead, this PR uses a script runner to process each matching file individually, but depends on just to be already installed in the local environment.