### PR TITLE
feat(installer): add github token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,10 @@ to determine the latest version of `just` to install, and those API calls are
 rate-limited on a per-IP basis. To make `install.sh` more reliable in such
 circumstances, pass a specific tag to install with `--tag`.
 
+Another way to avoid rate-limiting is to pass a GitHub authentication token to
+`install.sh` as an environment variable named `GITHUB_TOKEN`, allowing it to
+authenticate its requests.
+
 [Releases](https://github.com/casey/just/releases) include a `SHA256SUM` file
 which can be used to verify the integrity of pre-built binary archives.
 

--- a/www/install.sh
+++ b/www/install.sh
@@ -2,10 +2,6 @@
 
 set -eu
 
-if [ -n "${GITHUB_ACTIONS-}" ]; then
-  set -x
-fi
-
 # Check pipefail support in a subshell, ignore if unsupported
 # shellcheck disable=SC3040
 (set -o pipefail 2> /dev/null) && set -o pipefail
@@ -55,8 +51,6 @@ download() {
   url="$1"
   output="$2"
 
-  set +x
-
   args=()
   if [ -n "${GITHUB_TOKEN+x}" ]; then
     args+=("--header" "Authorization: Bearer $GITHUB_TOKEN")
@@ -66,10 +60,6 @@ download() {
     curl --proto =https --tlsv1.2 -sSfL "${args[@]}" "$url" -o"$output"
   else
     wget --https-only --secure-protocol=TLSv1_2 --quiet "${args[@]}" "$url" -O"$output"
-  fi
-
-  if [ -n "${GITHUB_ACTIONS-}" ]; then
-    set -x
   fi
 }
 

--- a/www/install.sh
+++ b/www/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -eu
 
@@ -55,10 +55,21 @@ download() {
   url="$1"
   output="$2"
 
+  set +x
+
+  args=()
+  if [ -n "${GITHUB_TOKEN+x}" ]; then
+    args+=("--header" "Authorization: Bearer $GITHUB_TOKEN")
+  fi
+
   if command -v curl > /dev/null; then
-    curl --proto =https --tlsv1.2 -sSfL "$url" "-o$output"
+    curl --proto =https --tlsv1.2 -sSfL "${args[@]}" "$url" -o"$output"
   else
-    wget --https-only --secure-protocol=TLSv1_2 --quiet "$url" "-O$output"
+    wget --https-only --secure-protocol=TLSv1_2 --quiet "${args[@]}" "$url" -O"$output"
+  fi
+
+  if [ -n "${GITHUB_ACTIONS-}" ]; then
+    set -x
   fi
 }
 

--- a/www/install.sh
+++ b/www/install.sh
@@ -57,9 +57,9 @@ download() {
   fi
 
   if command -v curl > /dev/null; then
-    curl --proto =https --tlsv1.2 -sSfL "${args[@]}" "$url" -o"$output"
+    curl --proto =https --tlsv1.2 -sSfL ${args[@]+"${args[@]}"} "$url" -o"$output"
   else
-    wget --https-only --secure-protocol=TLSv1_2 --quiet "${args[@]}" "$url" -O"$output"
+    wget --https-only --secure-protocol=TLSv1_2 --quiet ${args[@]+"${args[@]}"} "$url" -O"$output"
   fi
 }
 

--- a/www/install.sh
+++ b/www/install.sh
@@ -53,7 +53,7 @@ download() {
 
   args=()
   if [ -n "${GITHUB_TOKEN+x}" ]; then
-    args+=("--header" "Authorization: Bearer $GITHUB_TOKEN")
+    args+=(--header "Authorization: Bearer $GITHUB_TOKEN")
   fi
 
   if command -v curl > /dev/null; then


### PR DESCRIPTION
This adds support for utilizing the env var GITHUB_TOKEN if it exists for both curl/wget download utils.
fixes #2664

I think this would be a nice way to help alleviate rate limiting issues for those who can provide a token. My only concern is that perhaps some people may be upset if they are running this script unpiped and are utilizing github actions such that the -x output shows the token in some logs. Otherwise, perhaps this is a nice feature enhancement?
Edit: this is handled now.

Would be nice to not have to fork the installer, though it seems that changes are pretty rare.