### PR TITLE
fix: add cygpath handling to support Windows paths in Cygwin/MSYS2 environments

### DIFF
--- a/contrib/just.sh
+++ b/contrib/just.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# locate cygpath if available
+CYGPATH=$(command -v cygpath 2>/dev/null)
+if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]] && [[ -z "$CYGPATH" ]]; then
+  echo "cygpath.exe not found! Ensure it's installed."
+  exit 1
+fi
+
 # cd upwards to the justfile
 while [[ ! -e justfile ]]; do
   if [[ $PWD = / ]] || [[ $PWD = $JUSTSTOP ]] || [[ -e juststop ]]; then
@@ -18,7 +25,11 @@ fi
 
 declare -a RECIPES
 for ARG in "$@"; do
-  test $ARG =  '--'  && shift && break
+  test $ARG = '--' && shift && break
+  # convert paths if needed (Cygwin/MSYS2)
+  if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
+    ARG=$($CYGPATH "$ARG")
+  fi
   RECIPES+=($ARG) && shift
 done
 


### PR DESCRIPTION
- Dynamically locate and check for cygpath.exe
- Convert Windows-style paths to Unix-style paths when running in Cygwin or MSYS2
- Ensure compatibility by preserving original make/gmake logic
- Improve cross-platform usability when traversing directories and handling recipe arguments