### PR TITLE
Use raw_arg on Windows to fix handling of spaces in commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,8 @@ jobs:
 
     - name: Test
       run: cargo test --all
+      env:
+        RUST_BACKTRACE: '1'
 
     - name: Test install.sh
       run: |

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -282,7 +282,10 @@ impl<'src, D> Recipe<'src, D> {
       }
 
       #[cfg(target_os = "windows")]
-      std::os::windows::process::CommandExt::raw_arg(&mut cmd, command);
+      {
+        use std::os::windows::process::CommandExt;
+        cmd.raw_arg(command);
+      }
       #[cfg(not(target_os = "windows"))]
       cmd.arg(command);
 

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -281,6 +281,9 @@ impl<'src, D> Recipe<'src, D> {
         cmd.current_dir(working_directory);
       }
 
+      #[cfg(target_os = "windows")]
+      std::os::windows::process::CommandExt::raw_arg(&mut cmd, command);
+      #[cfg(not(target_os = "windows"))]
       cmd.arg(command);
 
       if self.takes_positional_arguments(&context.module.settings) {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -284,7 +284,7 @@ impl<'src, D> Recipe<'src, D> {
       #[cfg(target_os = "windows")]
       {
         use std::os::windows::process::CommandExt;
-        cmd.raw_arg(command);
+        cmd.raw_arg(format!("\"{}\"", command.replace("\"", "\\\"")));
       }
       #[cfg(not(target_os = "windows"))]
       cmd.arg(command);

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -13,3 +13,20 @@ fn bare_bash_in_shebang() {
     .stdout("FOO\n")
     .run();
 }
+
+#[test]
+fn spaces_in_windows_shell_arg() {
+  Test::new()
+    .justfile(
+      "
+        set windows-shell := [\"cmd.exe\", \"/c\"]
+        default:
+            echo FOO && \"echo FOO\"
+      ",
+    )
+    .shell(false)
+    .stdout("FOO \n")
+    .stderr("echo FOO && \"echo FOO\"\n'\"echo FOO\"' is not recognized as an internal or external command,\noperable program or batch file.\nerror: Recipe `default` failed on line 3 with exit code 1\n")
+    .status(1)
+    .run();
+}


### PR DESCRIPTION
On Windows Rust escapes arguments for security reasons, but since we are passing an argument to a shell (i.e. can execute arbitrary code anyway), this should be disabled in order to correctly support quoting and spaces in commands.

https://doc.rust-lang.org/std/process/index.html#windows-argument-splitting

Fixes #1639.