### PR TITLE
Add support for XDG_CONFIG_HOME in justfile search paths

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -395,4 +395,34 @@ mod tests {
       assert_eq!(have, Path::new(want));
     }
   }
+  #[test]
+  fn global_justfile_path_from_xdg_env(){
+    let old_value = std::env::var_os("XDG_CONFIG_HOME");
+
+    std::env::set_var("XDG_CONFIG_HOME", "/test/config");
+
+    let paths = Search::global_justfile_paths();
+    assert!(paths.contains(&PathBuf::from("/test/config/just/justfile")));
+
+    if let Some(old) = old_value {
+      std::env::set_var("XDG_CONFIG_HOME", old);
+    } else {
+      std::env::remove_var("XDG_CONFIG_HOME");
+    }
+  }
+  #[test]
+  fn global_justfile_path_when_xdg_env_not_set(){
+    let old_value = std::env::var_os("XDG_CONFIG_HOME");
+
+    std::env::set_var("XDG_CONFIG_HOME", "");
+
+    let paths = Search::global_justfile_paths();
+    assert!(!paths.contains(&PathBuf::from("/test/config/just/justfile")));
+
+    if let Some(old) = old_value {
+      std::env::set_var("XDG_CONFIG_HOME", old);
+    } else {
+      std::env::remove_var("XDG_CONFIG_HOME");
+    }
+  }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -26,6 +26,14 @@ impl Search {
           .join(DEFAULT_JUSTFILE_NAME),
       );
 
+      if let Some(xdg_config_home) = std::env::var_os("XDG_CONFIG_HOME") {
+        paths.push(
+          PathBuf::from(xdg_config_home)
+              .join("just")
+              .join(DEFAULT_JUSTFILE_NAME)
+        );
+      };
+
       for justfile_name in JUSTFILE_NAMES {
         paths.push(home_dir.join(justfile_name));
       }


### PR DESCRIPTION
- Added support for checking `$XDG_CONFIG_HOME/just/justfile` path when looking for config files with global option
- add a few tests

Fixes #2687 

feedback welcome, this is my first time contributing rust

