### PR TITLE
Update uv shebang script example to use the `-S` option for `env`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2915,7 +2915,7 @@ Of course, a shebang also works:
 
 ```just
 hello:
-  #!/usr/bin/env uv run --script
+  #!/usr/bin/env -S uv run --script
   print("Hello from Python!")
 ```
 


### PR DESCRIPTION
Adjust the uv shebang example to use the `-S` option for `env` as well (just like the bash example above).