### PR TITLE
add arkade to cross platform package providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ most Windows users.)
     </tr>
   </thead>
   <tbody>
+      <tr>
+      <td><a href=https://github.com/alexellis/arkade>arkade</a></td>
+      <td><a href=https://github.com/alexellis/arkade?tab=readme-ov-file#catalog-of-clis>just</a></td>
+      <td><code>arkade get just</code></td>
+    </tr>
     <tr>
       <td><a href=https://asdf-vm.com>asdf</a></td>
       <td><a href=https://github.com/olofvndrhr/asdf-just>just</a></td>

--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ most Windows users.)
     </tr>
   </thead>
   <tbody>
-      <tr>
+    <tr>
       <td><a href=https://github.com/alexellis/arkade>arkade</a></td>
-      <td><a href=https://github.com/alexellis/arkade?tab=readme-ov-file#catalog-of-clis>just</a></td>
+      <td>just</td>
       <td><code>arkade get just</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
Update to the `readme` to highlight that just is also available via [arkade](https://github.com/alexellis/arkade)