### PR TITLE
Recovery Dependencies - Execute Receipe(s) on Recipe Failure 

### DIFF
--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -219,9 +219,7 @@ impl<'src> Justfile<'src> {
 
       let mut evaluator = Evaluator::new(&context, true, &scope);
       if let Err(err) = result {
-        if invocation.recipe.recoveries().peekable().peek().is_none()
-          || context.config.no_dependencies
-        {
+        if invocation.recipe.recoveries().next().is_none() || context.config.no_dependencies {
           return Err(err);
         }
 

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -219,21 +219,21 @@ impl<'src> Justfile<'src> {
 
       let mut evaluator = Evaluator::new(&context, true, &scope);
       if let Err(err) = result {
-        if invocation.recipe.recoveries().peekable().peek().is_none() {
+        if invocation.recipe.recoveries().peekable().peek().is_none()
+          || context.config.no_dependencies
+        {
           return Err(err);
         }
 
-        if !context.config.no_dependencies {
-          let mut ran = Ran::default();
+        let mut ran = Ran::default();
 
-          for Dependency { recipe, arguments } in invocation.recipe.recoveries() {
-            let evaluated = arguments
-              .iter()
-              .map(|argument| evaluator.evaluate_expression(argument))
-              .collect::<RunResult<Vec<String>>>()?;
+        for Dependency { recipe, arguments } in invocation.recipe.recoveries() {
+          let evaluated = arguments
+            .iter()
+            .map(|argument| evaluator.evaluate_expression(argument))
+            .collect::<RunResult<Vec<String>>>()?;
 
-            Self::run_recipe(&evaluated, &context, &mut ran, recipe, true)?;
-          }
+          Self::run_recipe(&evaluated, &context, &mut ran, recipe, true)?;
         }
       }
     }

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -351,15 +351,16 @@ impl<'src> Justfile<'src> {
         return Err(err);
       }
 
-      let mut ran = Ran::default();
+      if !context.config.no_dependencies {
+        let mut ran = Ran::default();
+        for Dependency { recipe, arguments } in recipe.recoveries() {
+          let evaluated = arguments
+            .iter()
+            .map(|argument| evaluator.evaluate_expression(argument))
+            .collect::<RunResult<Vec<String>>>()?;
 
-      for Dependency { recipe, arguments } in recipe.recoveries() {
-        let evaluated = arguments
-          .iter()
-          .map(|argument| evaluator.evaluate_expression(argument))
-          .collect::<RunResult<Vec<String>>>()?;
-
-        Self::run_recipe(&evaluated, context, &mut ran, recipe, true)?;
+          Self::run_recipe(&evaluated, context, &mut ran, recipe, true)?;
+        }
       }
     } else if !context.config.no_dependencies {
       let mut ran = Ran::default();

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -198,6 +198,7 @@ impl<'src> Justfile<'src> {
     }
 
     let mut ran = Ran::default();
+
     for invocation in invocations {
       let context = ExecutionContext {
         config,
@@ -207,18 +208,34 @@ impl<'src> Justfile<'src> {
         search,
       };
 
-      Self::run_recipe(
-        &invocation
-          .arguments
-          .iter()
-          .copied()
-          .map(str::to_string)
-          .collect::<Vec<String>>(),
-        &context,
-        &mut ran,
-        invocation.recipe,
-        false,
-      )?;
+      let evaluated = &invocation
+        .arguments
+        .iter()
+        .copied()
+        .map(str::to_string)
+        .collect::<Vec<String>>();
+
+      let result = Self::run_recipe(evaluated, &context, &mut ran, invocation.recipe, false);
+
+      let mut evaluator = Evaluator::new(&context, true, &scope);
+      if let Err(err) = result {
+        if invocation.recipe.recoveries().peekable().peek().is_none() {
+          return Err(err);
+        }
+
+        if !context.config.no_dependencies {
+          let mut ran = Ran::default();
+
+          for Dependency { recipe, arguments } in invocation.recipe.recoveries() {
+            let evaluated = arguments
+              .iter()
+              .map(|argument| evaluator.evaluate_expression(argument))
+              .collect::<RunResult<Vec<String>>>()?;
+
+            Self::run_recipe(&evaluated, &context, &mut ran, recipe, true)?;
+          }
+        }
+      }
     }
 
     Ok(())
@@ -344,25 +361,10 @@ impl<'src> Justfile<'src> {
       }
     }
 
-    let result = recipe.run(context, &scope, &positional, is_dependency);
+    // eprintln!("name:{} scope:{}", recipe.name, is_dependency);
+    recipe.run(context, &scope, &positional, is_dependency)?;
 
-    if let Err(err) = result {
-      if recipe.recoveries().peekable().peek().is_none() {
-        return Err(err);
-      }
-
-      if !context.config.no_dependencies {
-        let mut ran = Ran::default();
-        for Dependency { recipe, arguments } in recipe.recoveries() {
-          let evaluated = arguments
-            .iter()
-            .map(|argument| evaluator.evaluate_expression(argument))
-            .collect::<RunResult<Vec<String>>>()?;
-
-          Self::run_recipe(&evaluated, context, &mut ran, recipe, true)?;
-        }
-      }
-    } else if !context.config.no_dependencies {
+    if !context.config.no_dependencies {
       let mut ran = Ran::default();
 
       for Dependency { recipe, arguments } in recipe.subsequents() {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1118,6 +1118,12 @@ mod tests {
   }
 
   test! {
+    name:   bar_bar,
+    text:   "||",
+    tokens: (BarBar),
+  }
+
+  test! {
     name:   equals,
     text:   "=",
     tokens: (Equals),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -956,6 +956,22 @@ impl<'run, 'src> Parser<'run, 'src> {
       dependencies.append(&mut subsequents);
     }
 
+    let if_error = dependencies.len();
+
+    if self.accepted(BarBar)? {
+      let mut recoveries = Vec::new();
+
+      while let Some(recovery) = self.accept_dependency()? {
+        recoveries.push(recovery);
+      }
+
+      if recoveries.is_empty() {
+        return Err(self.unexpected_token()?);
+      }
+
+      dependencies.append(&mut recoveries);
+    }
+
     self.expect_eol()?;
 
     let body = self.parse_body()?;
@@ -1007,6 +1023,7 @@ impl<'run, 'src> Parser<'run, 'src> {
       dependencies,
       doc: doc.filter(|doc| !doc.is_empty()),
       file_depth: self.file_depth,
+      if_error,
       import_offsets: self.import_offsets.clone(),
       name,
       namepath: self
@@ -2533,7 +2550,7 @@ mod tests {
     column:  9,
     width:   1,
     kind:    UnexpectedToken{
-      expected: vec![AmpersandAmpersand, Comment, Eof, Eol, Identifier, ParenL],
+      expected: vec![AmpersandAmpersand, BarBar, Comment, Eof, Eol, Identifier, ParenL],
       found: Equals
     },
   }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -540,8 +540,12 @@ impl<D: Display> ColorDisplay for Recipe<'_, D> {
     write!(f, ":")?;
 
     for (i, dependency) in self.dependencies.iter().enumerate() {
-      if i == self.priors {
+      if i == self.priors && self.subsequents().next().is_some() {
         write!(f, " &&")?;
+      }
+
+      if i == self.if_error {
+        write!(f, " ||")?;
       }
 
       write!(f, " {dependency}")?;

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -25,6 +25,7 @@ pub(crate) struct Recipe<'src, D = Dependency<'src>> {
   pub(crate) doc: Option<String>,
   #[serde(skip)]
   pub(crate) file_depth: u32,
+  pub(crate) if_error: usize,
   #[serde(skip)]
   pub(crate) import_offsets: Vec<usize>,
   pub(crate) name: Name<'src>,
@@ -503,7 +504,11 @@ impl<'src, D> Recipe<'src, D> {
   }
 
   pub(crate) fn subsequents(&self) -> impl Iterator<Item = &D> {
-    self.dependencies.iter().skip(self.priors)
+    self.dependencies[self.priors..self.if_error].iter()
+  }
+
+  pub(crate) fn recoveries(&self) -> impl Iterator<Item = &D> {
+    self.dependencies[self.if_error..].iter()
   }
 }
 

--- a/src/unresolved_recipe.rs
+++ b/src/unresolved_recipe.rs
@@ -50,6 +50,7 @@ impl<'src> UnresolvedRecipe<'src> {
       dependencies,
       doc: self.doc,
       file_depth: self.file_depth,
+      if_error: self.if_error,
       import_offsets: self.import_offsets,
       name: self.name,
       namepath: self.namepath,

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1460,6 +1460,27 @@ fn no_trailing_newline() {
 }
 
 #[test]
+fn recovery() {
+  Test::new()
+    .arg("--dump")
+    .justfile(
+      "
+    bar:
+    foo: || bar
+        echo foo",
+    )
+    .stdout(
+      "
+    bar:
+
+    foo: || bar
+        echo foo
+  ",
+    )
+    .run();
+}
+
+#[test]
 fn subsequent() {
   Test::new()
     .arg("--dump")

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -63,6 +63,7 @@ struct Recipe<'a> {
   body: Vec<Value>,
   dependencies: Vec<Dependency<'a>>,
   doc: Option<&'a str>,
+  if_error: u32,
   name: &'a str,
   namepath: &'a str,
   parameters: Vec<Parameter<'a>>,
@@ -277,6 +278,7 @@ fn dependencies() {
               ..default()
             }]
             .into(),
+            if_error: 1,
             priors: 1,
             ..default()
           },
@@ -356,6 +358,7 @@ fn dependency_argument() {
               .into(),
             }]
             .into(),
+            if_error: 1,
             priors: 1,
             ..default()
           },
@@ -601,6 +604,7 @@ fn priors() {
             .into(),
             name: "b",
             namepath: "b",
+            if_error: 2,
             priors: 1,
             ..default()
           },

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -103,6 +103,7 @@ mod private;
 mod quiet;
 mod quote;
 mod readme;
+mod recoveries;
 mod recursion_limit;
 mod regexes;
 mod request;

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1634,7 +1634,7 @@ fn unexpected_token_in_dependency_position() {
     .arg("foo")
     .justfile("foo: 'bar'")
     .stderr(
-      "error: Expected '&&', comment, end of file, end of line, \
+      "error: Expected '&&', '||', comment, end of file, end of line, \
     identifier, or '(', but found string
  ——▶ justfile:1:6
   │

--- a/tests/no_dependencies.rs
+++ b/tests/no_dependencies.rs
@@ -33,6 +33,31 @@ fn skip_prior_dependency() {
 }
 
 #[test]
+fn skip_recovery_deps() {
+  Test::new()
+    .justfile(
+      "
+          a: || b
+              @echo 'a'
+              exit 1
+          b:
+              @echo 'b'
+
+          ",
+    )
+    .args(["--no-deps"])
+    .stdout("a\n")
+    .stderr(
+      "
+      exit 1
+      error: Recipe `a` failed on line 3 with exit code 1
+    ",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
 fn skip_dependency_multi() {
   Test::new()
     .justfile(

--- a/tests/recoveries.rs
+++ b/tests/recoveries.rs
@@ -1,0 +1,332 @@
+use super::*;
+
+#[test]
+fn one_successful_recovery() {
+  Test::new()
+    .justfile(
+      "
+    foo: || bar
+      echo foo
+      exit 1
+
+    bar:
+      echo bar
+  ",
+    )
+    .stdout(
+      "
+    foo
+    bar
+  ",
+    )
+    .stderr(
+      "
+    echo foo
+    exit 1
+    echo bar
+  ",
+    )
+    .run();
+}
+
+#[test]
+fn two_successful_recoveries() {
+  Test::new()
+    .justfile(
+      "
+    foo: || bar bar2
+      echo foo
+      exit 1
+
+    bar:
+      echo bar
+
+    bar2:
+      echo bar2
+  ",
+    )
+    .stdout(
+      "
+    foo
+    bar
+    bar2
+  ",
+    )
+    .stderr(
+      "
+    echo foo
+    exit 1
+    echo bar
+    echo bar2
+  ",
+    )
+    .run();
+}
+
+#[test]
+fn one_failed_recovery() {
+  Test::new()
+    .justfile(
+      "
+    foo: || bar
+      echo foo
+      exit 2
+
+    bar:
+      echo bar
+      exit 1
+  ",
+    )
+    .stdout(
+      "
+    foo
+    bar
+  ",
+    )
+    .stderr(
+      "
+    echo foo
+    exit 2
+    echo bar
+    exit 1
+    error: Recipe `bar` failed on line 7 with exit code 1
+  ",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn first_of_two_recoveries_fail() {
+  Test::new()
+    .justfile(
+      "
+    foo: || bar bar2
+      echo foo
+      exit 2
+
+    bar:
+      echo bar
+      exit 1
+
+    bar2:
+      echo bar2
+  ",
+    )
+    .stdout(
+      "
+    foo
+    bar
+  ",
+    )
+    .stderr(
+      "
+    echo foo
+    exit 2
+    echo bar
+    exit 1
+    error: Recipe `bar` failed on line 7 with exit code 1
+  ",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn recoveries_with_other_dependencies() {
+  Test::new()
+    .justfile(
+      "
+    a: b && c || d
+      echo a
+      exit 1
+
+    b:
+      echo b
+
+    c:
+      echo c
+
+    d:
+      echo d
+
+  ",
+    )
+    .stdout(
+      "
+    b
+    a
+    d
+  ",
+    )
+    .stderr(
+      "
+    echo b
+    echo a
+    exit 1
+    echo d
+  ",
+    )
+    .run();
+}
+
+#[test]
+fn circular_dependency() {
+  Test::new()
+    .justfile(
+      "
+    foo: || foo
+  ",
+    )
+    .stderr(
+      "
+    error: Recipe `foo` depends on itself
+     ——▶ justfile:1:9
+      │
+    1 │ foo: || foo
+      │         ^^^
+  ",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn unknown() {
+  Test::new()
+    .justfile(
+      "
+    foo: || bar
+  ",
+    )
+    .stderr(
+      "
+    error: Recipe `foo` has unknown dependency `bar`
+     ——▶ justfile:1:9
+      │
+    1 │ foo: || bar
+      │         ^^^
+  ",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn unknown_argument() {
+  Test::new()
+    .justfile(
+      "
+    bar x:
+
+    foo: || (bar y)
+  ",
+    )
+    .stderr(
+      "
+    error: Variable `y` not defined
+     ——▶ justfile:3:14
+      │
+    3 │ foo: || (bar y)
+      │              ^
+  ",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn argument() {
+  Test::new()
+    .justfile(
+      "
+    foo: || (bar 'hello')
+      exit 1
+
+    bar x:
+      echo {{ x }}
+  ",
+    )
+    .stdout(
+      "
+    hello
+  ",
+    )
+    .stderr(
+      "
+    exit 1
+    echo hello
+  ",
+    )
+    .run();
+}
+
+#[test]
+fn duplicate_recoveries_dont_run() {
+  Test::new()
+    .justfile(
+      "
+    a: || b c
+      echo a
+      exit 1
+
+    b: d
+      echo b
+
+    c: d
+      echo c
+
+    d:
+      echo d
+  ",
+    )
+    .stdout(
+      "
+    a
+    d
+    b
+    c
+  ",
+    )
+    .stderr(
+      "
+    echo a
+    exit 1
+    echo d
+    echo b
+    echo c
+  ",
+    )
+    .run();
+}
+
+#[test]
+fn recoveries_run_even_if_already_ran_as_prior() {
+  Test::new()
+    .justfile(
+      "
+    a: b || b
+      echo a
+      exit 1
+
+    b:
+      echo b
+  ",
+    )
+    .stdout(
+      "
+    b
+    a
+    b
+  ",
+    )
+    .stderr(
+      "
+    echo b
+    echo a
+    exit 1
+    echo b
+  ",
+    )
+    .run();
+}

--- a/tests/recoveries.rs
+++ b/tests/recoveries.rs
@@ -330,3 +330,69 @@ fn recoveries_run_even_if_already_ran_as_prior() {
     )
     .run();
 }
+
+#[test]
+fn recoveries_in_pre_deps() {
+  Test::new()
+    .justfile(
+      "
+    a: b || c
+      echo a
+
+    b:
+      echo b
+      exit 1
+
+    c:
+      echo c
+  ",
+    )
+    .stdout(
+      "
+    b
+    c
+  ",
+    )
+    .stderr(
+      "
+    echo b
+    exit 1
+    echo c
+  ",
+    )
+    .run();
+}
+
+#[test]
+fn recoveries_in_post_deps() {
+  Test::new()
+    .justfile(
+      "
+    a: && b || c
+      echo a
+
+    b:
+      echo b
+      exit 1
+
+    c:
+      echo c
+  ",
+    )
+    .stdout(
+      "
+    a
+    b
+    c
+  ",
+    )
+    .stderr(
+      "
+    echo a
+    echo b
+    exit 1
+    echo c
+  ",
+    )
+    .run();
+}


### PR DESCRIPTION
This PR adds the `||` syntax to the dependency system, allowing recipes to run on failure. 

This is based on discussion in https://github.com/casey/just/issues/2583

Example:
```
# justfile
foo: || bar
  echo foo
   exit 1

bar:
  echo bar

# stdout
foo
bar
```

Please let me know if any additional work needs to be done or changes to the current behaviour.

One potential improvement that could be considered is passing the status code from the failing recipe into the recovery recipes
