### PR TITLE
feat: inline modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3733,6 +3733,15 @@ Available recipes:
     foo ... # foo is a great module!
 ```
 
+Modules can be defined inline. Currently inline modules can not contain further modules or inline modules.
+
+```justfile
+# foo is an inline module!
+foo::
+  hello:
+    @echo "Hello from inside the inline foo module"
+```
+
 Modules are still missing a lot of features, for example, the ability to depend
 on recipes and refer to variables in other modules. See the
 [module improvement tracking issue](https://github.com/casey/just/issues/2252)

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -62,6 +62,22 @@ impl<'run, 'src> Analyzer<'run, 'src> {
               }
             }
           }
+          Item::ModuleInline(ModuleInline {
+            doc, name, groups, ..
+          }) => {
+            Self::define(&mut definitions, *name, "module", false)?;
+            let absolute = root.join(name.lexeme());
+
+            self.modules.insert(Self::analyze(
+              asts,
+              doc.clone(),
+              groups.as_slice(),
+              loaded,
+              Some(*name),
+              paths,
+              &absolute,
+            )?);
+          }
           Item::Module {
             absolute,
             doc,

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -162,6 +162,9 @@ impl Display for CompileError<'_> {
         ShowWhitespace(expected),
         ShowWhitespace(found)
       ),
+      InlineModuleCannotBeNested { parent_module } => {
+        write!(f, "Inline module `{parent_module}` cannot be nested")
+      }
       Internal { message } => write!(
         f,
         "Internal error, this may indicate a bug in just: {message}\n\

--- a/src/compile_error_kind.rs
+++ b/src/compile_error_kind.rs
@@ -65,6 +65,9 @@ pub(crate) enum CompileErrorKind<'src> {
     expected: &'src str,
     found: &'src str,
   },
+  InlineModuleCannotBeNested {
+    parent_module: &'src str,
+  },
   Internal {
     message: String,
   },

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -87,6 +87,12 @@ impl Compiler {
               return Err(Error::MissingImportFile { path: *path });
             }
           }
+          Item::ModuleInline(ModuleInline { ast, name, .. }) => {
+            // Don't need to think about circular imports because nesting isn't allowed.
+            let path = current.path.join(name.lexeme());
+            paths.insert(path.clone(), relative.join(name.lexeme()));
+            asts.insert(path, ast.clone());
+          }
           _ => {}
         }
       }

--- a/src/item.rs
+++ b/src/item.rs
@@ -20,6 +20,7 @@ pub(crate) enum Item<'src> {
     optional: bool,
     relative: Option<StringLiteral<'src>>,
   },
+  ModuleInline(ModuleInline<'src>),
   Recipe(UnresolvedRecipe<'src>),
   Set(Set<'src>),
   Unexport {
@@ -64,6 +65,7 @@ impl Display for Item<'_> {
 
         Ok(())
       }
+      Self::ModuleInline(inline_module) => write!(f, "{}::", inline_module.name),
       Self::Recipe(recipe) => write!(f, "{}", recipe.color_display(Color::never())),
       Self::Set(set) => write!(f, "{set}"),
       Self::Unexport { name } => write!(f, "unexport {name}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub(crate) use {
     list::List,
     load_dotenv::load_dotenv,
     loader::Loader,
+    module_inline::ModuleInline,
     module_path::ModulePath,
     name::Name,
     namepath::Namepath,
@@ -229,6 +230,7 @@ mod line;
 mod list;
 mod load_dotenv;
 mod loader;
+mod module_inline;
 mod module_path;
 mod name;
 mod namepath;

--- a/src/module_inline.rs
+++ b/src/module_inline.rs
@@ -1,0 +1,9 @@
+use super::{Ast, Name};
+
+#[derive(Debug, Clone)]
+pub struct ModuleInline<'src> {
+  pub(crate) ast: Ast<'src>,
+  pub(crate) doc: Option<String>,
+  pub(crate) groups: Vec<String>,
+  pub(crate) name: Name<'src>,
+}

--- a/src/node.rs
+++ b/src/node.rs
@@ -52,6 +52,7 @@ impl<'src> Node<'src> for Item<'src> {
 
         tree
       }
+      Self::ModuleInline(inline_mod) => inline_mod.tree(),
       Self::Recipe(recipe) => recipe.tree(),
       Self::Set(set) => set.tree(),
       Self::Unexport { name } => {
@@ -343,5 +344,15 @@ impl<'src> Node<'src> for Warning {
 impl<'src> Node<'src> for str {
   fn tree(&self) -> Tree<'src> {
     Tree::atom("comment").push(["\"", self, "\""].concat())
+  }
+}
+
+impl<'src> Node<'src> for ModuleInline<'src> {
+  fn tree(&self) -> Tree<'src> {
+    Tree::list([
+      Tree::atom("mod_inline"),
+      Tree::atom(self.name.lexeme()),
+      self.ast.tree(),
+    ])
   }
 }

--- a/tests/inline_modules.rs
+++ b/tests/inline_modules.rs
@@ -1,0 +1,137 @@
+use super::*;
+
+#[test]
+fn inline_module() {
+  Test::new()
+    .justfile(
+      r"
+      foo::
+        bar:
+          @echo BAR",
+    )
+    .arg("foo::bar")
+    .stdout("BAR\n")
+    .run();
+}
+
+#[test]
+fn inline_module_normal_recipe_works() {
+  Test::new()
+    .justfile(
+      r"
+      bar:
+        @echo BAR
+
+      foo::
+        bar:
+          @echo SHOULDNT_BE_HERE",
+    )
+    .arg("bar")
+    .stdout("BAR\n")
+    .run();
+}
+
+#[test]
+fn inline_module_normal_recipe_works_module_first() {
+  Test::new()
+    .justfile(
+      r"
+      foo::
+        bar:
+          @echo SHOULDNT_BE_HERE
+
+      bar:
+        @echo BAR",
+    )
+    .arg("bar")
+    .stdout("BAR\n")
+    .run();
+}
+
+// Remove once nesting support is added
+#[test]
+fn double_inline_module_fails() {
+  Test::new()
+    .justfile(
+      r"
+      foo::
+        bar::
+          baz:
+            @echo BAZ",
+    )
+    .arg("foo::bar::baz")
+    .test_round_trip(false)
+    .status(1)
+    .stderr("error: Inline module `foo` cannot be nested\n ——▶ justfile:2:3\n  │\n2 │   bar::\n  │   ^^^\n")
+    .run();
+}
+
+// Remove once nesting support is added
+#[test]
+fn module_in_inline_module_fails() {
+  Test::new()
+    .justfile(
+      r"
+      foo::
+        mod bar
+        ",
+    )
+    .arg("foo::bar::baz")
+    .test_round_trip(false)
+    .status(1)
+    .stderr(
+      "error: Inline module `foo` cannot be nested\n ——▶ justfile:2:7\n  │\n2 │   mod bar\n  │       ^^^\n",
+    )
+    .run();
+}
+
+#[test]
+fn module_and_inline_module_of_same_name_fails() {
+  Test::new()
+    .write("foo.just", "")
+    .justfile(
+      r"
+      mod foo
+
+      foo::
+
+        ",
+    )
+    .arg("foo::bar::baz")
+    .test_round_trip(false)
+    .status(1)
+    .stderr("error: Module `foo` first defined on line 1 is redefined on line 3\n ——▶ justfile:3:1\n  │\n3 │ foo::\n  │ ^^^\n")
+    .run();
+}
+
+#[test]
+fn bad_inline_module_attribute_fails() {
+  Test::new()
+    .justfile(
+      r"
+        [no-cd]
+        foo::
+      ",
+    )
+    .test_round_trip(false)
+    .arg("--list")
+    .stderr("error: Module `foo` has invalid attribute `no-cd`\n ——▶ justfile:2:1\n  │\n2 │ foo::\n  │ ^^^\n")
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn empty_doc_attribute_on_inline_module() {
+  Test::new()
+    .justfile(
+      r"
+        # Suppressed comment
+        [doc]
+        foo::
+      ",
+    )
+    .test_round_trip(false)
+    .arg("--list")
+    .stdout("Available recipes:\n    foo ...\n")
+    .run();
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -81,6 +81,7 @@ mod groups;
 mod ignore_comments;
 mod imports;
 mod init;
+mod inline_modules;
 mod invocation_directory;
 mod json;
 mod line_prefixes;


### PR DESCRIPTION
Draft for non-nested inline modules according to the syntax mainly agreed upon in #2442.

Syntax:

```justfile
# foo is an inline module!
foo::
  hello:
    @echo "Hello from inside the inline foo module"
```

Contributes to #2252.

I think there's still a couple of open questions that need to be clarified before something like this PR can be merged
- Should the entire module code depending on filepaths be refactored to accommodate for inline modules that don't directly correspond to a file.
- what should `module_directory`  and `module_directory` do when used inside an inline module? Should probably just fail?
- Probably more
