### PR TITLE
fix formatting of attributes on modules

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -45,11 +45,21 @@ impl Display for Item<'_> {
         write!(f, " {relative}")
       }
       Self::Module {
+        doc,
+        groups,
         name,
         relative,
         optional,
         ..
       } => {
+        if let Some(docstr) = doc {
+          writeln!(f, "# {docstr}")?;
+        }
+
+        for group in groups.iter() {
+          writeln!(f, "[group('{}')]", group)?;
+        }
+
         write!(f, "mod")?;
 
         if *optional {

--- a/tests/modules.rs
+++ b/tests/modules.rs
@@ -998,3 +998,27 @@ fn empty_doc_attribute_on_module() {
     .stdout("Available recipes:\n    foo ...\n")
     .run();
 }
+
+#[test]
+fn modules_with_attributes_are_dumped_correctly() {
+  Test::new()
+    .write("foo.just", "foo:\n @echo FOO")
+    .justfile(
+      "
+        # doc
+        [group('bar')]
+        [group('baz')]
+        mod foo
+      ",
+    )
+    .arg("--dump")
+    .stdout(
+      "
+        # doc
+        [group('bar')]
+        [group('baz')]
+        mod foo
+      ",
+    )
+    .run();
+}


### PR DESCRIPTION
First off, love the tool and that it comes with a formatter built in :)

However, I found that while setting attributes on `mod` statements works perfectly, the formatter apparently is not aware of this feature. 
I just added a fairly naive implementation adding the two currently allowed attributes to the module `impl Display`. Also comes with a simple integration test.

I know that the formatter is an unstable feature and not the highest priority, but I personally use it and would love to see this fixed. Let me know if any of this needs fixing up, I'll happily do it :)