### PR TITLE
Don't treat SIGINFO as a fatal signal

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -230,7 +230,7 @@ impl<'src> Error<'src> {
         output_error: OutputError::Interrupted(signal),
         ..
       }
-      | Self::Interrupted { signal } => signal.code(),
+      | Self::Interrupted { signal } => Some(signal.code()),
       _ => None,
     }
   }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -36,8 +36,23 @@ impl Signal {
     Signal::Terminate,
   ];
 
-  pub(crate) fn code(self) -> Option<i32> {
-    128i32.checked_add(self.number())
+  pub(crate) fn code(self) -> i32 {
+    128i32.checked_add(self.number()).unwrap()
+  }
+
+  pub(crate) fn is_fatal(self) -> bool {
+    match self {
+      Self::Hangup | Self::Interrupt | Self::Quit | Self::Terminate => true,
+      #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+      ))]
+      Self::Info => false,
+    }
   }
 
   pub(crate) fn number(self) -> i32 {
@@ -122,6 +137,13 @@ mod tests {
   fn signals_fit_in_u8() {
     for signal in Signal::ALL {
       assert!(signal.number() <= i32::from(u8::MAX));
+    }
+  }
+
+  #[test]
+  fn signals_have_valid_exit_codes() {
+    for signal in Signal::ALL {
+      signal.code();
     }
   }
 

--- a/src/signal_handler.rs
+++ b/src/signal_handler.rs
@@ -40,20 +40,14 @@ impl SignalHandler {
   }
 
   fn interrupt(&mut self, signal: Signal) {
-    if self.children.is_empty() {
-      process::exit(signal.code().unwrap_or(1));
-    }
+    if signal.is_fatal() {
+      if self.children.is_empty() {
+        process::exit(signal.code());
+      }
 
-    #[cfg(any(
-      target_os = "dragonfly",
-      target_os = "freebsd",
-      target_os = "ios",
-      target_os = "macos",
-      target_os = "netbsd",
-      target_os = "openbsd",
-    ))]
-    if signal != Signal::Info && self.caught.is_none() {
-      self.caught = Some(signal);
+      if self.caught.is_none() {
+        self.caught = Some(signal);
+      }
     }
 
     match signal {


### PR DESCRIPTION
When receiving SIGINFO, don't exit if we have no children, and don't report it if we receive it when we do have children.