### PR TITLE
Add `[metadata]` attribute for adding custom metadata to recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2093,12 +2093,13 @@ change their behavior.
 | Name | Type | Description |
 |------|------|-------------|
 | `[confirm]`<sup>1.17.0</sup> | recipe | Require confirmation prior to executing recipe. |
-| `[confirm('PROMPT')]`<sup>1.23.0</sup> | recipe | Require confirmation prior to executing recipe with a custom prompt. |
-| `[doc('DOC')]`<sup>1.27.0</sup> | module, recipe | Set recipe or module's [documentation comment](#documentation-comments) to `DOC`. |
-| `[extension('EXT')]`<sup>1.32.0</sup> | recipe | Set shebang recipe script's file extension to `EXT`. `EXT` should include a period if one is desired. |
-| `[group('NAME')]`<sup>1.27.0</sup> | module, recipe | Put recipe or module in in [group](#groups) `NAME`. |
+| `[confirm(PROMPT)]`<sup>1.23.0</sup> | recipe | Require confirmation prior to executing recipe with a custom prompt. |
+| `[doc(DOC)]`<sup>1.27.0</sup> | module, recipe | Set recipe or module's [documentation comment](#documentation-comments) to `DOC`. |
+| `[extension(EXT)]`<sup>1.32.0</sup> | recipe | Set shebang recipe script's file extension to `EXT`. `EXT` should include a period if one is desired. |
+| `[group(NAME)]`<sup>1.27.0</sup> | module, recipe | Put recipe or module in in [group](#groups) `NAME`. |
 | `[linux]`<sup>1.8.0</sup> | recipe | Enable recipe on Linux. |
 | `[macos]`<sup>1.8.0</sup> | recipe | Enable recipe on MacOS. |
+| `[metadata(METADATA)]`<sup>master</sup> | recipe | Attach `METADATA` to recipe. |
 | `[no-cd]`<sup>1.9.0</sup> | recipe | Don't change directory before executing recipe. |
 | `[no-exit-message]`<sup>1.7.0</sup> | recipe | Don't print an error message if recipe fails. |
 | `[no-quiet]`<sup>1.23.0</sup> | recipe | Override globally quiet recipes and always echo out the recipe. |

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -33,8 +33,6 @@ impl AttributeDiscriminant {
   fn argument_range(self) -> RangeInclusive<usize> {
     match self {
       Self::Confirm | Self::Doc => 0..=1,
-      Self::Metadata => 1..=usize::MAX,
-      Self::Group | Self::Extension | Self::WorkingDirectory => 1..=1,
       Self::ExitMessage
       | Self::Linux
       | Self::Macos
@@ -46,6 +44,8 @@ impl AttributeDiscriminant {
       | Self::Private
       | Self::Unix
       | Self::Windows => 0..=0,
+      Self::Extension | Self::Group | Self::WorkingDirectory => 1..=1,
+      Self::Metadata => 1..=usize::MAX,
       Self::Script => 0..=usize::MAX,
     }
   }
@@ -127,21 +127,6 @@ impl Display for Attribute<'_> {
     write!(f, "{}", self.name())?;
 
     match self {
-      Self::Confirm(Some(argument))
-      | Self::Doc(Some(argument))
-      | Self::Extension(argument)
-      | Self::Group(argument)
-      | Self::WorkingDirectory(argument) => write!(f, "({argument})")?,
-      Self::Script(Some(shell)) => write!(f, "({shell})")?,
-      Self::Metadata(arguments) => write!(
-        f,
-        "({})",
-        arguments
-          .iter()
-          .map(StringLiteral::to_string)
-          .collect::<Vec<_>>()
-          .join(", ")
-      )?,
       Self::Confirm(None)
       | Self::Doc(None)
       | Self::ExitMessage
@@ -156,6 +141,22 @@ impl Display for Attribute<'_> {
       | Self::Script(None)
       | Self::Unix
       | Self::Windows => {}
+      Self::Confirm(Some(argument))
+      | Self::Doc(Some(argument))
+      | Self::Extension(argument)
+      | Self::Group(argument)
+      | Self::WorkingDirectory(argument) => write!(f, "({argument})")?,
+      Self::Metadata(arguments) => {
+        write!(f, "(")?;
+        for (i, argument) in arguments.iter().enumerate() {
+          if i > 0 {
+            write!(f, ", ")?;
+          }
+          write!(f, "{argument}")?;
+        }
+        write!(f, ")")?;
+      }
+      Self::Script(Some(shell)) => write!(f, "({shell})")?,
     }
 
     Ok(())

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -132,6 +132,63 @@ fn unexpected_attribute_argument() {
 }
 
 #[test]
+fn multiple_metadata_attributes() {
+  Test::new()
+    .justfile(
+      "
+      [metadata('example')]
+      [metadata('sample')]
+      [no-exit-message]
+      foo:
+        exit 1
+    ",
+    )
+    .stderr("exit 1\n")
+    .status(1)
+    .run();
+}
+
+#[test]
+fn multiple_metadata_attributes_with_multiple_args() {
+  Test::new()
+    .justfile(
+      "
+      [metadata('example', 'arg1')]
+      [metadata('sample', 'argument')]
+      [no-exit-message]
+      foo:
+        exit 1
+    ",
+    )
+    .stderr("exit 1\n")
+    .status(1)
+    .run();
+}
+
+#[test]
+fn expected_metadata_attribute_argument() {
+  Test::new()
+    .justfile(
+      "
+      [metadata]
+      foo:
+        exit 1
+    ",
+    )
+    .stderr(
+      "
+        error: Attribute `metadata` got 0 arguments but takes at least 1 argument
+         ——▶ justfile:1:2
+          │
+        1 │ [metadata]
+          │  ^^^^^^^^
+          ",
+    )
+    .status(1)
+    .run();
+}
+
+#[test]
 fn doc_attribute() {
   Test::new()
     .justfile(

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -784,6 +784,88 @@ fn attribute() {
 }
 
 #[test]
+fn metadata_attribute() {
+  case(
+    "
+      [metadata('example')]
+      foo:
+    ",
+    Module {
+      first: Some("foo"),
+      recipes: [(
+        "foo",
+        Recipe {
+          attributes: [json!({"metadata": ["example"]})].into(),
+          name: "foo",
+          namepath: "foo",
+          ..default()
+        },
+      )]
+      .into(),
+      ..default()
+    },
+  );
+}
+
+#[test]
+fn multiple_metadata_attributes() {
+  case(
+    "
+      [metadata('example')]
+      [metadata('sample')]
+      foo:
+    ",
+    Module {
+      first: Some("foo"),
+      recipes: [(
+        "foo",
+        Recipe {
+          attributes: [
+            json!({"metadata": ["example"]}),
+            json!({"metadata": ["sample"]}),
+          ]
+          .into(),
+          name: "foo",
+          namepath: "foo",
+          ..default()
+        },
+      )]
+      .into(),
+      ..default()
+    },
+  );
+}
+
+#[test]
+fn multiple_metadata_attributes_with_arguments() {
+  case(
+    "
+      [metadata('example', 'arg1')]
+      [metadata('sample', 'argument')]
+      foo:
+    ",
+    Module {
+      first: Some("foo"),
+      recipes: [(
+        "foo",
+        Recipe {
+          attributes: [
+            json!({"metadata": ["example", "arg1"]}),
+            json!({"metadata": ["sample", "argument"]}),
+          ]
+          .into(),
+          name: "foo",
+          namepath: "foo",
+          ..default()
+        },
+      )]
+      .into(),
+      ..default()
+    },
+  );
+}
+
+#[test]
 fn module() {
   case_with_submodule(
     "

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -784,7 +784,7 @@ fn attribute() {
 }
 
 #[test]
-fn metadata_attribute() {
+fn single_metadata_attribute() {
   case(
     "
       [metadata('example')]
@@ -837,7 +837,7 @@ fn multiple_metadata_attributes() {
 }
 
 #[test]
-fn multiple_metadata_attributes_with_arguments() {
+fn multiple_metadata_attributes_with_multiple_arguments() {
   case(
     "
       [metadata('example', 'arg1')]


### PR DESCRIPTION
This PR adds `metadata` attribute, which can appear multiple times on a recipe. The attribute takes a list of strings and its value can be inspected via JSON dump of the `justfile`.

The primary motivation is custom tooling built around `just` that can be used to, for example, automate creation of CI pipelines and other pre-processing that is outside of `just`'s scope.

Fixes: https://github.com/casey/just/issues/2703