### PR TITLE
Resolve cygpath from env `JUST_CYGPATH`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -209,7 +209,7 @@ impl Config {
           .action(ArgAction::Set)
           .value_parser(value_parser!(PathBuf))
           .default_value("cygpath")
-          .help("Use binary at <CYGPATH> convert between unix and Windows paths."),
+          .help("Use binary at <CYGPATH> to convert between unix and Windows paths."),
       )
       .arg(
         Arg::new(arg::DOTENV_FILENAME)

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ pub(crate) struct Config {
   pub(crate) check: bool,
   pub(crate) color: Color,
   pub(crate) command_color: Option<ansi_term::Color>,
-  pub(crate) cygpath: Option<PathBuf>,
+  pub(crate) cygpath: PathBuf,
   pub(crate) dotenv_filename: Option<String>,
   pub(crate) dotenv_path: Option<PathBuf>,
   pub(crate) dry_run: bool,
@@ -208,8 +208,8 @@ impl Config {
           .env("JUST_CYGPATH")
           .action(ArgAction::Set)
           .value_parser(value_parser!(PathBuf))
-          .hide(!cfg!(windows))
-          .help("Convert unix paths to Windows paths using <CYGPATH>")
+          .default_value("cygpath")
+          .help("Use binary at <CYGPATH> convert between unix and Windows paths."),
       )
       .arg(
         Arg::new(arg::DOTENV_FILENAME)
@@ -783,7 +783,7 @@ impl Config {
         .get_one::<CommandColor>(arg::COMMAND_COLOR)
         .copied()
         .map(CommandColor::into),
-      cygpath: matches.get_one::<PathBuf>(arg::CYGPATH).map(Into::into),
+      cygpath: matches.get_one::<PathBuf>(arg::CYGPATH).unwrap().clone(),
       dotenv_filename: matches
         .get_one::<String>(arg::DOTENV_FILENAME)
         .map(Into::into),

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ pub(crate) struct Config {
   pub(crate) check: bool,
   pub(crate) color: Color,
   pub(crate) command_color: Option<ansi_term::Color>,
+  pub(crate) cygpath: Option<OsString>,
   pub(crate) dotenv_filename: Option<String>,
   pub(crate) dotenv_path: Option<PathBuf>,
   pub(crate) dry_run: bool,
@@ -96,6 +97,7 @@ mod arg {
   pub(crate) const CLEAR_SHELL_ARGS: &str = "CLEAR-SHELL-ARGS";
   pub(crate) const COLOR: &str = "COLOR";
   pub(crate) const COMMAND_COLOR: &str = "COMMAND-COLOR";
+  pub(crate) const CYGPATH: &str = "CYGPATH";
   pub(crate) const DOTENV_FILENAME: &str = "DOTENV-FILENAME";
   pub(crate) const DOTENV_PATH: &str = "DOTENV-PATH";
   pub(crate) const DRY_RUN: &str = "DRY-RUN";
@@ -199,6 +201,15 @@ impl Config {
           .action(ArgAction::Set)
           .value_parser(clap::value_parser!(CommandColor))
           .help("Echo recipe lines in <COMMAND-COLOR>"),
+      )
+      .arg(
+        Arg::new(arg::CYGPATH)
+          .long("cygpath")
+          .env("JUST_CYGPATH")
+          .action(ArgAction::Set)
+          .value_parser(value_parser!(OsString))
+          .hide(!cfg!(windows))
+          .help("Convert unix paths to Windows paths using <CYGPATH>")
       )
       .arg(
         Arg::new(arg::DOTENV_FILENAME)
@@ -772,6 +783,7 @@ impl Config {
         .get_one::<CommandColor>(arg::COMMAND_COLOR)
         .copied()
         .map(CommandColor::into),
+      cygpath: matches.get_one::<OsString>(arg::CYGPATH).cloned(),
       dotenv_filename: matches
         .get_one::<String>(arg::DOTENV_FILENAME)
         .map(Into::into),

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ pub(crate) struct Config {
   pub(crate) check: bool,
   pub(crate) color: Color,
   pub(crate) command_color: Option<ansi_term::Color>,
-  pub(crate) cygpath: Option<OsString>,
+  pub(crate) cygpath: Option<PathBuf>,
   pub(crate) dotenv_filename: Option<String>,
   pub(crate) dotenv_path: Option<PathBuf>,
   pub(crate) dry_run: bool,
@@ -207,7 +207,7 @@ impl Config {
           .long("cygpath")
           .env("JUST_CYGPATH")
           .action(ArgAction::Set)
-          .value_parser(value_parser!(OsString))
+          .value_parser(value_parser!(PathBuf))
           .hide(!cfg!(windows))
           .help("Convert unix paths to Windows paths using <CYGPATH>")
       )
@@ -783,7 +783,7 @@ impl Config {
         .get_one::<CommandColor>(arg::COMMAND_COLOR)
         .copied()
         .map(CommandColor::into),
-      cygpath: matches.get_one::<OsString>(arg::CYGPATH).cloned(),
+      cygpath: matches.get_one::<PathBuf>(arg::CYGPATH).map(Into::into),
       dotenv_filename: matches
         .get_one::<String>(arg::DOTENV_FILENAME)
         .map(Into::into),

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -11,7 +11,7 @@ impl Executor<'_> {
     path: &Path,
     recipe: &'src str,
     working_directory: Option<&Path>,
-    cygpath: Option<&OsString>,
+    cygpath: Option<&PathBuf>,
   ) -> RunResult<'src, Command> {
     match self {
       Self::Command(interpreter) => {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -11,6 +11,7 @@ impl Executor<'_> {
     path: &Path,
     recipe: &'src str,
     working_directory: Option<&Path>,
+    cygpath: Option<&OsString>,
   ) -> RunResult<'src, Command> {
     match self {
       Self::Command(interpreter) => {
@@ -36,7 +37,7 @@ impl Executor<'_> {
         })?;
 
         // create command to run script
-        Platform::make_shebang_command(path, working_directory, *shebang).map_err(|output_error| {
+        Platform::make_shebang_command(path, working_directory, *shebang, cygpath).map_err(|output_error| {
           Error::Cygpath {
             recipe,
             output_error,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -37,7 +37,7 @@ impl Executor<'_> {
         })?;
 
         // create command to run script
-        Platform::make_shebang_command(path, working_directory, *shebang, config).map_err(
+        Platform::make_shebang_command(config, path, *shebang, working_directory).map_err(
           |output_error| Error::Cygpath {
             recipe,
             output_error,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -8,10 +8,10 @@ pub(crate) enum Executor<'a> {
 impl Executor<'_> {
   pub(crate) fn command<'src>(
     &self,
+    config: &Config,
     path: &Path,
     recipe: &'src str,
     working_directory: Option<&Path>,
-    config: &Config,
   ) -> RunResult<'src, Command> {
     match self {
       Self::Command(interpreter) => {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -11,7 +11,7 @@ impl Executor<'_> {
     path: &Path,
     recipe: &'src str,
     working_directory: Option<&Path>,
-    cygpath: Option<&PathBuf>,
+    config: &Config,
   ) -> RunResult<'src, Command> {
     match self {
       Self::Command(interpreter) => {
@@ -37,12 +37,12 @@ impl Executor<'_> {
         })?;
 
         // create command to run script
-        Platform::make_shebang_command(path, working_directory, *shebang, cygpath).map_err(|output_error| {
-          Error::Cygpath {
+        Platform::make_shebang_command(path, working_directory, *shebang, config).map_err(
+          |output_error| Error::Cygpath {
             recipe,
             output_error,
-          }
-        })
+          },
+        )
       }
     }
   }

--- a/src/function.rs
+++ b/src/function.rs
@@ -335,6 +335,7 @@ fn invocation_directory(context: Context) -> FunctionResult {
   Platform::convert_native_path(
     &context.evaluator.context.search.working_directory,
     &context.evaluator.context.config.invocation_directory,
+    context.evaluator.context.config.cygpath.as_ref()
   )
   .map_err(|e| format!("Error getting shell path: {e}"))
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -333,7 +333,7 @@ fn file_stem(_context: Context, path: &str) -> FunctionResult {
 
 fn invocation_directory(context: Context) -> FunctionResult {
   Platform::convert_native_path(
-    &context.evaluator.context.config,
+    context.evaluator.context.config,
     &context.evaluator.context.search.working_directory,
     &context.evaluator.context.config.invocation_directory,
   )

--- a/src/function.rs
+++ b/src/function.rs
@@ -333,9 +333,9 @@ fn file_stem(_context: Context, path: &str) -> FunctionResult {
 
 fn invocation_directory(context: Context) -> FunctionResult {
   Platform::convert_native_path(
+    &context.evaluator.context.config,
     &context.evaluator.context.search.working_directory,
     &context.evaluator.context.config.invocation_directory,
-    &context.evaluator.context.config,
   )
   .map_err(|e| format!("Error getting shell path: {e}"))
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -335,7 +335,7 @@ fn invocation_directory(context: Context) -> FunctionResult {
   Platform::convert_native_path(
     &context.evaluator.context.search.working_directory,
     &context.evaluator.context.config.invocation_directory,
-    context.evaluator.context.config.cygpath.as_ref()
+    &context.evaluator.context.config,
   )
   .map_err(|e| format!("Error getting shell path: {e}"))
 }

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -2,10 +2,10 @@ use super::*;
 
 impl PlatformInterface for Platform {
   fn make_shebang_command(
-    path: &Path,
-    working_directory: Option<&Path>,
-    _shebang: Shebang,
     _config: &Config,
+    path: &Path,
+    _shebang: Shebang,
+    working_directory: Option<&Path>,
   ) -> Result<Command, OutputError> {
     // shebang scripts can be executed directly on unix
     let mut command = Command::new(path);

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -5,7 +5,7 @@ impl PlatformInterface for Platform {
     path: &Path,
     working_directory: Option<&Path>,
     _shebang: Shebang,
-    _cygpath: Option<&OsString>,
+    _cygpath: Option<&PathBuf>,
   ) -> Result<Command, OutputError> {
     // shebang scripts can be executed directly on unix
     let mut command = Command::new(path);
@@ -36,7 +36,7 @@ impl PlatformInterface for Platform {
     exit_status.signal()
   }
 
-  fn convert_native_path(_working_directory: &Path, path: &Path, _cygpath: Option<&OsString>) -> FunctionResult {
+  fn convert_native_path(_working_directory: &Path, path: &Path, _cygpath: Option<&PathBuf>) -> FunctionResult {
     path
       .to_str()
       .map(str::to_string)

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -5,6 +5,7 @@ impl PlatformInterface for Platform {
     path: &Path,
     working_directory: Option<&Path>,
     _shebang: Shebang,
+    _cygpath: Option<&OsString>,
   ) -> Result<Command, OutputError> {
     // shebang scripts can be executed directly on unix
     let mut command = Command::new(path);
@@ -35,7 +36,7 @@ impl PlatformInterface for Platform {
     exit_status.signal()
   }
 
-  fn convert_native_path(_working_directory: &Path, path: &Path) -> FunctionResult {
+  fn convert_native_path(_working_directory: &Path, path: &Path, _cygpath: Option<&OsString>) -> FunctionResult {
     path
       .to_str()
       .map(str::to_string)

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -37,9 +37,9 @@ impl PlatformInterface for Platform {
   }
 
   fn convert_native_path(
+    _config: &Config,
     _working_directory: &Path,
     path: &Path,
-    _config: &Config,
   ) -> FunctionResult {
     path
       .to_str()

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -5,7 +5,7 @@ impl PlatformInterface for Platform {
     path: &Path,
     working_directory: Option<&Path>,
     _shebang: Shebang,
-    _cygpath: Option<&PathBuf>,
+    _config: &Config,
   ) -> Result<Command, OutputError> {
     // shebang scripts can be executed directly on unix
     let mut command = Command::new(path);
@@ -36,7 +36,11 @@ impl PlatformInterface for Platform {
     exit_status.signal()
   }
 
-  fn convert_native_path(_working_directory: &Path, path: &Path, _cygpath: Option<&PathBuf>) -> FunctionResult {
+  fn convert_native_path(
+    _working_directory: &Path,
+    path: &Path,
+    _config: &Config,
+  ) -> FunctionResult {
     path
       .to_str()
       .map(str::to_string)

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -5,13 +5,14 @@ impl PlatformInterface for Platform {
     path: &Path,
     working_directory: Option<&Path>,
     shebang: Shebang,
+    cygpath: Option<&OsString>,
   ) -> Result<Command, OutputError> {
     use std::borrow::Cow;
 
     // If the path contains forward slashes…
     let command = if shebang.interpreter.contains('/') {
       // …translate path to the interpreter from unix style to windows style.
-      let mut cygpath = Command::new(env::var_os("JUST_CYGPATH").unwrap_or("cygpath".into()));
+      let mut cygpath = Command::new(cygpath.unwrap_or(&"cygpath".into()));
 
       if let Some(working_directory) = working_directory {
         cygpath.current_dir(working_directory);
@@ -56,9 +57,9 @@ impl PlatformInterface for Platform {
     None
   }
 
-  fn convert_native_path(working_directory: &Path, path: &Path) -> FunctionResult {
+  fn convert_native_path(working_directory: &Path, path: &Path, cygpath: Option<&OsString>) -> FunctionResult {
     // Translate path from windows style to unix style
-    let mut cygpath = Command::new(env::var_os("JUST_CYGPATH").unwrap_or("cygpath".into()));
+    let mut cygpath = Command::new(cygpath.unwrap_or(&"cygpath".into()));
 
     cygpath
       .current_dir(working_directory)

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -57,7 +57,7 @@ impl PlatformInterface for Platform {
     None
   }
 
-  fn convert_native_path(working_directory: &Path, path: &Path, config: &Config) -> FunctionResult {
+  fn convert_native_path(config: &Config, working_directory: &Path, path: &Path) -> FunctionResult {
     // Translate path from windows style to unix style
     let mut cygpath = Command::new(&config.cygpath);
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -11,7 +11,7 @@ impl PlatformInterface for Platform {
     // If the path contains forward slashes…
     let command = if shebang.interpreter.contains('/') {
       // …translate path to the interpreter from unix style to windows style.
-      let mut cygpath = Command::new("cygpath");
+      let mut cygpath = Command::new(env::var_os("JUST_CYGPATH").unwrap_or("cygpath".into()));
 
       if let Some(working_directory) = working_directory {
         cygpath.current_dir(working_directory);
@@ -58,7 +58,7 @@ impl PlatformInterface for Platform {
 
   fn convert_native_path(working_directory: &Path, path: &Path) -> FunctionResult {
     // Translate path from windows style to unix style
-    let mut cygpath = Command::new("cygpath");
+    let mut cygpath = Command::new(env::var_os("JUST_CYGPATH").unwrap_or("cygpath".into()));
 
     cygpath
       .current_dir(working_directory)

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2,10 +2,10 @@ use super::*;
 
 impl PlatformInterface for Platform {
   fn make_shebang_command(
-    path: &Path,
-    working_directory: Option<&Path>,
-    shebang: Shebang,
     config: &Config,
+    path: &Path,
+    shebang: Shebang,
+    working_directory: Option<&Path>,
   ) -> Result<Command, OutputError> {
     use std::borrow::Cow;
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -5,7 +5,7 @@ impl PlatformInterface for Platform {
     path: &Path,
     working_directory: Option<&Path>,
     shebang: Shebang,
-    cygpath: Option<&OsString>,
+    cygpath: Option<&PathBuf>,
   ) -> Result<Command, OutputError> {
     use std::borrow::Cow;
 
@@ -57,7 +57,7 @@ impl PlatformInterface for Platform {
     None
   }
 
-  fn convert_native_path(working_directory: &Path, path: &Path, cygpath: Option<&OsString>) -> FunctionResult {
+  fn convert_native_path(working_directory: &Path, path: &Path, cygpath: Option<&PathBuf>) -> FunctionResult {
     // Translate path from windows style to unix style
     let mut cygpath = Command::new(cygpath.unwrap_or(&"cygpath".into()));
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -5,14 +5,14 @@ impl PlatformInterface for Platform {
     path: &Path,
     working_directory: Option<&Path>,
     shebang: Shebang,
-    cygpath: Option<&PathBuf>,
+    config: &Config,
   ) -> Result<Command, OutputError> {
     use std::borrow::Cow;
 
     // If the path contains forward slashes…
     let command = if shebang.interpreter.contains('/') {
       // …translate path to the interpreter from unix style to windows style.
-      let mut cygpath = Command::new(cygpath.unwrap_or(&"cygpath".into()));
+      let mut cygpath = Command::new(&config.cygpath);
 
       if let Some(working_directory) = working_directory {
         cygpath.current_dir(working_directory);
@@ -57,9 +57,9 @@ impl PlatformInterface for Platform {
     None
   }
 
-  fn convert_native_path(working_directory: &Path, path: &Path, cygpath: Option<&PathBuf>) -> FunctionResult {
+  fn convert_native_path(working_directory: &Path, path: &Path, config: &Config) -> FunctionResult {
     // Translate path from windows style to unix style
-    let mut cygpath = Command::new(cygpath.unwrap_or(&"cygpath".into()));
+    let mut cygpath = Command::new(&config.cygpath);
 
     cygpath
       .current_dir(working_directory)

--- a/src/platform_interface.rs
+++ b/src/platform_interface.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(crate) trait PlatformInterface {
   /// translate path from "native" path to path interpreter expects
-  fn convert_native_path(working_directory: &Path, path: &Path, config: &Config) -> FunctionResult;
+  fn convert_native_path(config: &Config, working_directory: &Path, path: &Path) -> FunctionResult;
 
   /// install handler, may only be called once
   fn install_signal_handler<T: Fn(Signal) + Send + 'static>(handler: T) -> RunResult<'static>;

--- a/src/platform_interface.rs
+++ b/src/platform_interface.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(crate) trait PlatformInterface {
   /// translate path from "native" path to path interpreter expects
-  fn convert_native_path(working_directory: &Path, path: &Path) -> FunctionResult;
+  fn convert_native_path(working_directory: &Path, path: &Path, cygpath: Option<&OsString>) -> FunctionResult;
 
   /// install handler, may only be called once
   fn install_signal_handler<T: Fn(Signal) + Send + 'static>(handler: T) -> RunResult<'static>;
@@ -13,6 +13,7 @@ pub(crate) trait PlatformInterface {
     path: &Path,
     working_directory: Option<&Path>,
     shebang: Shebang,
+    cygpath: Option<&OsString>,
   ) -> Result<Command, OutputError>;
 
   /// set the execute permission on file pointed to by `path`

--- a/src/platform_interface.rs
+++ b/src/platform_interface.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(crate) trait PlatformInterface {
   /// translate path from "native" path to path interpreter expects
-  fn convert_native_path(working_directory: &Path, path: &Path, cygpath: Option<&PathBuf>) -> FunctionResult;
+  fn convert_native_path(working_directory: &Path, path: &Path, config: &Config) -> FunctionResult;
 
   /// install handler, may only be called once
   fn install_signal_handler<T: Fn(Signal) + Send + 'static>(handler: T) -> RunResult<'static>;
@@ -13,7 +13,7 @@ pub(crate) trait PlatformInterface {
     path: &Path,
     working_directory: Option<&Path>,
     shebang: Shebang,
-    cygpath: Option<&PathBuf>,
+    config: &Config,
   ) -> Result<Command, OutputError>;
 
   /// set the execute permission on file pointed to by `path`

--- a/src/platform_interface.rs
+++ b/src/platform_interface.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(crate) trait PlatformInterface {
   /// translate path from "native" path to path interpreter expects
-  fn convert_native_path(working_directory: &Path, path: &Path, cygpath: Option<&OsString>) -> FunctionResult;
+  fn convert_native_path(working_directory: &Path, path: &Path, cygpath: Option<&PathBuf>) -> FunctionResult;
 
   /// install handler, may only be called once
   fn install_signal_handler<T: Fn(Signal) + Send + 'static>(handler: T) -> RunResult<'static>;
@@ -13,7 +13,7 @@ pub(crate) trait PlatformInterface {
     path: &Path,
     working_directory: Option<&Path>,
     shebang: Shebang,
-    cygpath: Option<&OsString>,
+    cygpath: Option<&PathBuf>,
   ) -> Result<Command, OutputError>;
 
   /// set the execute permission on file pointed to by `path`

--- a/src/platform_interface.rs
+++ b/src/platform_interface.rs
@@ -10,10 +10,10 @@ pub(crate) trait PlatformInterface {
   /// construct command equivalent to running script at `path` with shebang
   /// line `shebang`
   fn make_shebang_command(
-    path: &Path,
-    working_directory: Option<&Path>,
-    shebang: Shebang,
     config: &Config,
+    path: &Path,
+    shebang: Shebang,
+    working_directory: Option<&Path>,
   ) -> Result<Command, OutputError>;
 
   /// set the execute permission on file pointed to by `path`

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -419,6 +419,7 @@ impl<'src, D> Recipe<'src, D> {
       &path,
       self.name(),
       self.working_directory(context).as_deref(),
+      config.cygpath.as_ref(),
     )?;
 
     if self.takes_positional_arguments(&context.module.settings) {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -419,7 +419,7 @@ impl<'src, D> Recipe<'src, D> {
       &path,
       self.name(),
       self.working_directory(context).as_deref(),
-      config.cygpath.as_ref(),
+      &config,
     )?;
 
     if self.takes_positional_arguments(&context.module.settings) {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -416,10 +416,10 @@ impl<'src, D> Recipe<'src, D> {
     })?;
 
     let mut command = executor.command(
+      &config,
       &path,
       self.name(),
       self.working_directory(context).as_deref(),
-      &config,
     )?;
 
     if self.takes_positional_arguments(&context.module.settings) {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -416,7 +416,7 @@ impl<'src, D> Recipe<'src, D> {
     })?;
 
     let mut command = executor.command(
-      &config,
+      config,
       &path,
       self.name(),
       self.working_directory(context).as_deref(),

--- a/tests/invocation_directory.rs
+++ b/tests/invocation_directory.rs
@@ -12,7 +12,7 @@ fn convert_native_path(path: &Path) -> String {
 #[cfg(windows)]
 fn convert_native_path(path: &Path) -> String {
   // Translate path from windows style to unix style
-  let mut cygpath = Command::new("cygpath");
+  let mut cygpath = Command::new(env::var_os("JUST_CYGPATH").unwrap_or("cygpath".into()));
   cygpath.arg("--unix");
   cygpath.arg(path);
 


### PR DESCRIPTION
I couldn't pass all the tests from my Windows setup because it seems to rely on a real `sh` program.

I did verify the env works:

```
> cargo b
> target\debug\just.exe --shell "C:\Program Files\Git\usr\bin\sh.exe" _ruby
Hello from ruby!
```

...where otherwise it prints:

```
error: Could not find `cygpath` executable to translate recipe `_ruby` shebang interpreter path:
program not found
```

Fixes #2641