### PR TITLE
Use correct scope for aliases and dependencies in submodules

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -188,6 +188,7 @@ impl<'run, 'src> Analyzer<'run, 'src> {
       doc: doc.filter(|doc| !doc.is_empty()),
       groups: groups.into(),
       loaded: loaded.into(),
+      module_path: ast.module_path.clone(),
       modules: self.modules,
       name,
       recipes,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,6 +6,7 @@ use super::*;
 #[derive(Debug, Clone)]
 pub(crate) struct Ast<'src> {
   pub(crate) items: Vec<Item<'src>>,
+  pub(crate) module_path: String,
   pub(crate) unstable_features: BTreeSet<UnstableFeature>,
   pub(crate) warnings: Vec<Warning>,
   pub(crate) working_directory: PathBuf,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -23,11 +23,10 @@ impl<'src, 'run> Evaluator<'src, 'run> {
       config,
       dotenv,
       module,
-      scope: parent,
       search,
     };
 
-    let mut scope = context.scope.child();
+    let mut scope = parent.child();
     let mut unknown_overrides = Vec::new();
 
     for (name, value) in overrides {
@@ -325,8 +324,9 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     is_dependency: bool,
     arguments: &[String],
     parameters: &[Parameter<'src>],
+    scope: &'run Scope<'src, 'run>,
   ) -> RunResult<'src, (Scope<'src, 'run>, Vec<String>)> {
-    let mut evaluator = Self::new(context, is_dependency, context.scope);
+    let mut evaluator = Self::new(context, is_dependency, scope);
 
     let mut positional = Vec::new();
 

--- a/src/execution_context.rs
+++ b/src/execution_context.rs
@@ -5,7 +5,6 @@ pub(crate) struct ExecutionContext<'src: 'run, 'run> {
   pub(crate) config: &'run Config,
   pub(crate) dotenv: &'run BTreeMap<String, String>,
   pub(crate) module: &'run Justfile<'src>,
-  pub(crate) scope: &'run Scope<'src, 'run>,
   pub(crate) search: &'run Search,
 }
 

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -315,14 +315,7 @@ impl<'src> Justfile<'src> {
     }
 
     let scope = scopes
-      .get(
-        recipe
-          .namepath
-          .to_string()
-          .rsplit_once("::")
-          .map(|(module, _recipe)| module)
-          .unwrap_or_default(),
-      )
+      .get(&recipe.module_path())
       .expect("failed to retrieve scope for module");
 
     if !context.config.yes && !recipe.confirm()? {

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -314,15 +314,15 @@ impl<'src> Justfile<'src> {
       return Ok(());
     }
 
-    let scope = scopes
-      .get(&recipe.module_path())
-      .expect("failed to retrieve scope for module");
-
     if !context.config.yes && !recipe.confirm()? {
       return Err(Error::NotConfirmed {
         recipe: recipe.name(),
       });
     }
+
+    let scope = scopes
+      .get(&recipe.module_path())
+      .expect("failed to retrieve scope for module");
 
     let (outer, positional) =
       Evaluator::evaluate_parameters(context, is_dependency, arguments, &recipe.parameters, scope)?;

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -118,11 +118,8 @@ impl<'src> Justfile<'src> {
     };
 
     let root = Scope::root();
-
-    let arena: Arena<Scope> = Arena::new();
-
+    let arena = Arena::new();
     let mut scopes = BTreeMap::new();
-
     self.evaluate_assignments(
       &arena,
       config,

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -211,19 +211,10 @@ impl<'src> Justfile<'src> {
 
     let groups = ArgumentParser::parse_arguments(self, &arguments)?;
 
-    let arena: Arena<Scope> = Arena::new();
     let mut invocations = Vec::<Invocation>::new();
 
     for group in &groups {
-      invocations.push(self.invocation(
-        &arena,
-        &group.arguments,
-        config,
-        &dotenv,
-        &group.path,
-        0,
-        search,
-      )?);
+      invocations.push(self.invocation(&group.arguments, &group.path, 0)?);
     }
 
     if config.one && invocations.len() > 1 {
@@ -285,13 +276,9 @@ impl<'src> Justfile<'src> {
 
   fn invocation<'run>(
     &'run self,
-    arena: &'run Arena<Scope<'src, 'run>>,
     arguments: &[&'run str],
-    config: &'run Config,
-    dotenv: &'run BTreeMap<String, String>,
     path: &'run [String],
     position: usize,
-    search: &'run Search,
   ) -> RunResult<'src, Invocation<'src, 'run>> {
     if position + 1 == path.len() {
       let recipe = self.get_recipe(&path[position]).unwrap();
@@ -302,7 +289,7 @@ impl<'src> Justfile<'src> {
       })
     } else {
       let module = self.modules.get(&path[position]).unwrap();
-      module.invocation(arena, arguments, config, dotenv, path, position + 1, search)
+      module.invocation(arguments, path, position + 1)
     }
   }
 

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -237,9 +237,9 @@ impl<'src> Justfile<'src> {
           .map(str::to_string)
           .collect::<Vec<String>>(),
         &context,
+        false,
         &ran,
         invocation.recipe,
-        false,
         &scopes,
       )?;
     }
@@ -301,9 +301,9 @@ impl<'src> Justfile<'src> {
   fn run_recipe(
     arguments: &[String],
     context: &ExecutionContext<'src, '_>,
+    is_dependency: bool,
     ran: &Ran<'src>,
     recipe: &Recipe<'src>,
-    is_dependency: bool,
     scopes: &BTreeMap<String, &Scope<'src, '_>>,
   ) -> RunResult<'src> {
     let mutex = ran.mutex(&recipe.namepath, arguments);
@@ -383,7 +383,7 @@ impl<'src> Justfile<'src> {
         for (recipe, arguments) in evaluated {
           handles.push(
             thread_scope
-              .spawn(move || Self::run_recipe(&arguments, context, ran, recipe, true, scopes)),
+              .spawn(move || Self::run_recipe(&arguments, context, true, ran, recipe, scopes)),
           );
         }
         for handle in handles {
@@ -395,7 +395,7 @@ impl<'src> Justfile<'src> {
       })?;
     } else {
       for (recipe, arguments) in evaluated {
-        Self::run_recipe(&arguments, context, ran, recipe, true, scopes)?;
+        Self::run_recipe(&arguments, context, true, ran, recipe, scopes)?;
       }
     }
 

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -69,7 +69,7 @@ impl<'src> Justfile<'src> {
     )
   }
 
-  fn evaluate_scopes<'run>(
+  fn evaluate_assignments<'run>(
     &'run self,
     arena: &'run Arena<Scope<'src, 'run>>,
     config: &'run Config,
@@ -86,7 +86,7 @@ impl<'src> Justfile<'src> {
     scopes.get(&self.module_path).unwrap();
 
     for module in self.modules.values() {
-      module.evaluate_scopes(arena, config, dotenv, overrides, root, scopes, search)?;
+      module.evaluate_assignments(arena, config, dotenv, overrides, root, scopes, search)?;
     }
 
     Ok(())
@@ -123,7 +123,7 @@ impl<'src> Justfile<'src> {
 
     let mut scopes = BTreeMap::new();
 
-    self.evaluate_scopes(
+    self.evaluate_assignments(
       &arena,
       config,
       &dotenv,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -441,9 +441,9 @@ impl<'run, 'src> Parser<'run, 'src> {
             } else {
               let doc = pop_doc_comment(&mut items, eol_since_last_comment);
               items.push(Item::Recipe(self.parse_recipe(
+                take_attributes(),
                 doc,
                 false,
-                take_attributes(),
               )?));
             }
           }
@@ -451,9 +451,9 @@ impl<'run, 'src> Parser<'run, 'src> {
       } else if self.accepted(At)? {
         let doc = pop_doc_comment(&mut items, eol_since_last_comment);
         items.push(Item::Recipe(self.parse_recipe(
+          take_attributes(),
           doc,
           true,
-          take_attributes(),
         )?));
       } else {
         return Err(self.unexpected_token()?);
@@ -902,9 +902,9 @@ impl<'run, 'src> Parser<'run, 'src> {
   /// Parse a recipe
   fn parse_recipe(
     &mut self,
+    attributes: AttributeSet<'src>,
     doc: Option<&'src str>,
     quiet: bool,
-    attributes: AttributeSet<'src>,
   ) -> CompileResult<'src, UnresolvedRecipe<'src>> {
     let name = self.parse_name()?;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -475,13 +475,13 @@ impl<'run, 'src> Parser<'run, 'src> {
 
     Ok(Ast {
       items,
-      unstable_features: self.unstable_features,
-      warnings: Vec::new(),
-      working_directory: self.working_directory.into(),
       module_path: self
         .module_namepath
         .map(ToString::to_string)
         .unwrap_or_default(),
+      unstable_features: self.unstable_features,
+      warnings: Vec::new(),
+      working_directory: self.working_directory.into(),
     })
   }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -478,6 +478,10 @@ impl<'run, 'src> Parser<'run, 'src> {
       unstable_features: self.unstable_features,
       warnings: Vec::new(),
       working_directory: self.working_directory.into(),
+      module_path: self
+        .module_namepath
+        .map(ToString::to_string)
+        .unwrap_or_default(),
     })
   }
 

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -57,6 +57,12 @@ impl<'src, D> Recipe<'src, D> {
     }
   }
 
+  pub(crate) fn module_path(&self) -> String {
+    let mut path = self.namepath.to_string();
+    path.truncate(path.find("::").unwrap_or_default());
+    path
+  }
+
   pub(crate) fn name(&self) -> &'src str {
     self.name.lexeme()
   }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -36,6 +36,20 @@ pub(crate) struct Recipe<'src, D = Dependency<'src>> {
   pub(crate) shebang: bool,
 }
 
+impl<'src> Recipe<'src> {
+  fn foo(&self, modules: &mut BTreeSet<Vec<Name<'src>>>) {
+    let path = self.namepath.split_last().1;
+
+    if !modules.contains(path) {
+      modules.insert(path.into());
+    }
+
+    for dependency in &self.dependencies {
+      dependency.recipe.foo(modules);
+    }
+  }
+}
+
 impl<'src, D> Recipe<'src, D> {
   pub(crate) fn argument_range(&self) -> RangeInclusive<usize> {
     self.min_arguments()..=self.max_arguments()

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -36,21 +36,6 @@ pub(crate) struct Recipe<'src, D = Dependency<'src>> {
   pub(crate) shebang: bool,
 }
 
-impl<'src> Recipe<'src> {
-  #[allow(unused)]
-  fn modules(&self, modules: &mut BTreeSet<Vec<Name<'src>>>) {
-    let path = self.namepath.split_last().1;
-
-    if !modules.contains(path) {
-      modules.insert(path.into());
-    }
-
-    for dependency in &self.dependencies {
-      dependency.recipe.modules(modules);
-    }
-  }
-}
-
 impl<'src, D> Recipe<'src, D> {
   pub(crate) fn argument_range(&self) -> RangeInclusive<usize> {
     self.min_arguments()..=self.max_arguments()

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -37,7 +37,8 @@ pub(crate) struct Recipe<'src, D = Dependency<'src>> {
 }
 
 impl<'src> Recipe<'src> {
-  fn foo(&self, modules: &mut BTreeSet<Vec<Name<'src>>>) {
+  #[allow(unused)]
+  fn modules(&self, modules: &mut BTreeSet<Vec<Name<'src>>>) {
     let path = self.namepath.split_last().1;
 
     if !modules.contains(path) {
@@ -45,7 +46,7 @@ impl<'src> Recipe<'src> {
     }
 
     for dependency in &self.dependencies {
-      dependency.recipe.foo(modules);
+      dependency.recipe.modules(modules);
     }
   }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -107,6 +107,7 @@ mod recursion_limit;
 mod regexes;
 mod request;
 mod run;
+mod scope;
 mod script;
 mod search;
 mod search_arguments;

--- a/tests/scope.rs
+++ b/tests/scope.rs
@@ -1,0 +1,34 @@
+use super::*;
+
+#[test]
+fn dependencies_in_submodules_run_with_submodule_scope() {
+  Test::new()
+    .write("bar.just", "x := 'X'\nbar a=x:\n echo {{ a }} {{ x }}")
+    .justfile(
+      "
+        mod bar
+
+        foo: bar::bar
+      ",
+    )
+    .stdout("X X\n")
+    .stderr("echo X X\n")
+    .run();
+}
+
+#[test]
+fn aliases_in_submodules_run_with_submodule_scope() {
+  Test::new()
+    .write("bar.just", "x := 'X'\nbar a=x:\n echo {{ a }} {{ x }}")
+    .justfile(
+      "
+        mod bar
+
+        alias foo := bar::bar
+      ",
+    )
+    .arg("foo")
+    .stdout("X X\n")
+    .stderr("echo X X\n")
+    .run();
+}


### PR DESCRIPTION
#2632 introduced a bug whereby running an alias pointing to a recipe in a submodule would not create or use the correct scope. #2672 created another way to hit the bug, this time by running a dependency in a submodule.


```just
// justfile
mod foo

alias a := foo::bar

b: foo::bar
```

```just
// foo.just

x := 'y'

bar:
  echo {{ x }}
```

Both `just a` and `just b` cause a runtime error when trying to evaluate `x`, which isn't defined.

Depending on a recipe in a submodule hasn't made it into a release yet, but aliasing a recipe in a submodule has, and I'm surprised the bug hasn't been reported.

This PR evaluates the assignment scope of all submodules, and runs recipes with the scope of the submodule that contains it.

One thing I'm not sure about, which is why it's still a draft, is whether or not we should only evaluate scopes of modules containing recipes that we're actually going to run.

We could go through all directly invoked recipes and all transitive dependencies, collect the set of their submodules, and then only evaluate assignments for those submodules.