### PR TITLE
add just-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,10 @@ The [zed-just](https://github.com/jackTabsCode/zed-just/) extension by
 [jackTabsCode](https://github.com/jackTabsCode) is avilable on the
 [Zed extensions page](https://zed.dev/extensions?query=just).
 
+### Model Context Protocol
+[just-mcp](http://github.com/promptexecution/just-mcp) agentic tooling (ex: co-pilot, claude code, claude desktop, gemini-cli, openai codex, hundreds more) can discover & execute justfile commands with parameters without dangerous bash access.  
+
+
 ### Other Editors
 
 Feel free to send me the commands necessary to get syntax highlighting working


### PR DESCRIPTION
👋 i've built a way to let llms speak just. 

if it isn't immediately obvious the benefit of having llms use just vs. bash is that running just commands (via mcp) provides an context-saving abstraction where they don't need to waste context, ex: opening/reading a bash file, or python script or whatever.  the llm via mcp simply gets the command, the parameters and the hint.  it's in their memory "these are commands available to you" so no need to say `execute just -l` to get a list of commands, inevitably the start reading the justfile, then they try to write justfile (like it's a makefile), then they corrupt the justfile and then it's just a bad time.  just with it's evolving syntax simply doens't have a large enough corpus even in the frontier models today.  we need more popular repos that are part of the training dataset to have justfiles. 

please consider just is a powerful tool for anybody doing agent execution.  A huge number of self-hostable gpu/cpu open source models, as they're known "sm0l" models often have less than 32k, some as low as 8k, just-mcp has insanely low overhead, probably better than every other tool.   justfiles are easy for humans, and low overhead for llms.  sure some people would rather build a full python fastapi server -- but if for quick and dirty, just-mcp is just easy-as. 

just-mcp is safer than bash. if you read hackernews there's a story at least once a day of how xyz operators llms start to forget & hallucinate and eventually start breaking down & deleting files and don't all sorts of nasty unwanted things. the fact is if llms take in too much information, if they exceed their context (which really only takes scanning one large file).   giving llms unsupervised (auto-approved) unrestricted bash access and not carefully monitoring thier context consumption is a recipe for disaster. using justfile fixes that. even if the llm is allowed to modify their own bash script, the next context is memoized by the justfile which is hopefully backed in an idempotent git repo. 

just also has a lot of useful patterns that can be used to introduce logging, or using other sm0l models to inspect commands & parameters transparently before they actually execute -- (without distracting attention or wasting context from the agent).  similar to how python decorators work.  even if you give the llm bash access, you can have a secondary model with a fresh context for every command scanning it asking "is this harmful or dangerous" and if it is, it's rejected and never run. 

i've been using just with my agents for about a year, today - 100% of the popular llms, chatgpt, etc. don't grok the syntax, especially the newer features.  most people aren't sophisticated enough to do their own finetuning and frankly there aren't sufficient valid examples for training.  i've started to create a synthetic dataset of just examples. 

in addition to this - i'll also be publishing in the next few days, a new vscode extension based on the just-lsp that integrates 100% of the vscode extension features, and uses this package.   this allows autocomplete's and syntax linting to happen in realtime, i'm currently working on in-context examples (this happens in the background, at the lsp layer) it makes a mistake, it gets highlighted, it checks the examples, and then it fixes the code.  this will solve the problems authoring just for vscode and all it's variants, cursor, windsurf, cline, roo, etc.   the current plugins don't do that (they aren't lsp or integrated in a way the models can use them, also several of them have bugs with recent syntax)
