### PR TITLE
Add Windows-specific setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,18 @@ Installation
 `just` should run on any system with a reasonable `sh`, including Linux, MacOS,
 and the BSDs.
 
+### Notes for Windows
 On Windows, `just` works with the `sh` provided by
 [Git for Windows](https://git-scm.com),
 [GitHub Desktop](https://desktop.github.com), or
 [Cygwin](http://www.cygwin.com).
 
-If you'd rather not install `sh`, you can use the `shell` setting to use the
-shell of your choice.
+To run `just` on Windows, you must use one of the following setups:
+* Option 1: Run `just` from within one of the shells above (i.e. Git Bash).
+* Option 2: To run `just` from within PowerShell or CMD, you must one have a `sh` executable on your system PATH.
+  * For example, add `C:\Program Files\Git\bin` and `C:\Program Files\Git\usr\bin` to your PATH.
+* Option 3: If you'd rather not install `sh`, or rather not modify your PATH, you can use the `shell` setting to use the
+shell of your choice (see below).
 
 Like PowerShell:
 

--- a/README.md
+++ b/README.md
@@ -99,10 +99,9 @@ On Windows, `just` works with the `sh` provided by
 
 To run `just` on Windows, you must use one of the following setups:
 * Option 1: Run `just` from within one of the shells above (i.e. Git Bash).
-* Option 2: To run `just` from within PowerShell or CMD, you must one have a `sh` executable on your system PATH.
+* Option 2: To run `just` from within PowerShell or CMD, you must have a `sh` executable on your system PATH.
   * For example, add `C:\Program Files\Git\bin` and `C:\Program Files\Git\usr\bin` to your PATH.
-* Option 3: If you'd rather not install `sh`, or rather not modify your PATH, you can use the `shell` setting to use the
-shell of your choice (see below).
+* Option 3: If you'd rather not install `sh`, or rather not modify your PATH, you can use the `shell` setting to use the shell of your choice (see below).
 
 Like PowerShell:
 


### PR DESCRIPTION
Adding these instructions based on my own difficulties getting `just` to work on Windows (See #2828)