### PR TITLE
Fix exported parameters with defaults consuming variadic arguments

### DIFF
--- a/tests/parameters.rs
+++ b/tests/parameters.rs
@@ -50,3 +50,18 @@ fn star_may_follow_default() {
     .stdout("hello goodbye\n")
     .run();
 }
+
+#[test]
+fn exported_parameter_with_default_and_variadic() {
+  Test::new()
+    .justfile(
+      "
+        test $THE_ENV='hi' *args:
+          @echo $THE_ENV
+          @echo {{args}}
+      ",
+    )
+    .args(["test", "this", "arg", "gets", "assigned"])
+    .stdout("hi\nthis arg gets assigned\n")
+    .run();
+}


### PR DESCRIPTION
## Problem


When using Parameters prefixed with a $ will be exported as environment variables alongside variadic parameters, the exported parameter would incorrectly consume command line arguments instead of using its value.

  **Before:**
  ```just
  test $THE_ENV='env value' *args:
    echo $THE_ENV
    echo {{args}}

  $ just test this arg gets assigned
  # Output:
  this              # THE_ENV got "this" instead of "env value"
  arg gets assigned  # args got remaining arguments
```

  After:
```
  $ just test this arg gets assigned
  # Output:
  env value                       # THE_ENV uses default value "env value"
  this arg gets assigned  # args gets all command line arguments
```
  Root Cause

  The parameter evaluation logic in evaluate_parameters() processed parameters sequentially without considering that exported parameters with defaults should prefer their default values when variadic parameters are present.
   This caused exported parameters to steal arguments intended for variadic parameters.

Fixes #2825 