### PR TITLE
docs: suggest more sophisticated default recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,7 +752,7 @@ beginning of your `justfile` that lists the available recipes:
 
 ```just
 _default:
-  @{{just_executable()}} --list --justfile {{justfile()}}
+  @{{quote(just_executable())}} --list --justfile={{quote(justfile())}}
 ```
 
 ### Listing Available Recipes

--- a/README.md
+++ b/README.md
@@ -751,8 +751,8 @@ If no recipe makes sense as the default recipe, you can add a recipe to the
 beginning of your `justfile` that lists the available recipes:
 
 ```just
-default:
-  just --list
+_default:
+  @{{just_executable()}} --list --justfile {{justfile()}}
 ```
 
 ### Listing Available Recipes


### PR DESCRIPTION
makes the default command
- hidden in `just --list`
- not echo its cmdline
- work when `just` is not on `PATH`
- work with non-standard justfile name / when invoked from another working directory