### PR TITLE
Print executed commands if run in verbose mode

### DIFF
--- a/src/command_ext.rs
+++ b/src/command_ext.rs
@@ -11,11 +11,11 @@ pub(crate) trait CommandExt {
 
   fn export_scope(&mut self, settings: &Settings, scope: &Scope, unexports: &HashSet<String>);
 
-  fn output_guard(self) -> (io::Result<process::Output>, Option<Signal>);
+  fn output_guard(self, config: &Config) -> (io::Result<process::Output>, Option<Signal>);
 
-  fn output_guard_stdout(self) -> Result<String, OutputError>;
+  fn output_guard_stdout(self, config: &Config) -> Result<String, OutputError>;
 
-  fn status_guard(self) -> (io::Result<ExitStatus>, Option<Signal>);
+  fn status_guard(self, config: &Config) -> (io::Result<ExitStatus>, Option<Signal>);
 }
 
 impl CommandExt for Command {
@@ -53,12 +53,12 @@ impl CommandExt for Command {
     }
   }
 
-  fn output_guard(self) -> (io::Result<process::Output>, Option<Signal>) {
-    SignalHandler::spawn(self, process::Child::wait_with_output)
+  fn output_guard(self, config: &Config) -> (io::Result<process::Output>, Option<Signal>) {
+    SignalHandler::spawn(self, config, process::Child::wait_with_output)
   }
 
-  fn output_guard_stdout(self) -> Result<String, OutputError> {
-    let (result, caught) = self.output_guard();
+  fn output_guard_stdout(self, config: &Config) -> Result<String, OutputError> {
+    let (result, caught) = self.output_guard(config);
 
     let output = result.map_err(OutputError::Io)?;
 
@@ -79,7 +79,7 @@ impl CommandExt for Command {
     )
   }
 
-  fn status_guard(self) -> (io::Result<ExitStatus>, Option<Signal>) {
-    SignalHandler::spawn(self, |mut child| child.wait())
+  fn status_guard(self, config: &Config) -> (io::Result<ExitStatus>, Option<Signal>) {
+    SignalHandler::spawn(self, config, |mut child| child.wait())
   }
 }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -291,7 +291,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
       })
       .stdout(Stdio::piped());
 
-    cmd.output_guard_stdout()
+    cmd.output_guard_stdout(self.context.config)
   }
 
   pub(crate) fn evaluate_line(

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -158,7 +158,7 @@ impl<'src> Justfile<'src> {
 
         command.export(&self.settings, &dotenv, &scope, &self.unexports);
 
-        let (result, caught) = command.status_guard();
+        let (result, caught) = command.status_guard(config);
 
         let status = result.map_err(|io_error| Error::CommandInvoke {
           binary: binary.clone(),

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -25,7 +25,7 @@ impl PlatformInterface for Platform {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-      Cow::Owned(cygpath.output_guard_stdout()?)
+      Cow::Owned(cygpath.output_guard_stdout(config)?)
     } else {
       // …otherwise use it as-is.
       Cow::Borrowed(shebang.interpreter)
@@ -69,7 +69,7 @@ impl PlatformInterface for Platform {
       .stdout(Stdio::piped())
       .stderr(Stdio::piped());
 
-    match cygpath.output_guard_stdout() {
+    match cygpath.output_guard_stdout(config) {
       Ok(shell_path) => Ok(shell_path),
       Err(_) => path
         .to_str()

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -321,7 +321,7 @@ impl<'src, D> Recipe<'src, D> {
         &context.module.unexports,
       );
 
-      let (result, caught) = cmd.status_guard();
+      let (result, caught) = cmd.status_guard(context.config);
 
       match result {
         Ok(exit_status) => {
@@ -453,7 +453,7 @@ impl<'src, D> Recipe<'src, D> {
     );
 
     // run it!
-    let (result, caught) = command.status_guard();
+    let (result, caught) = command.status_guard(context.config);
 
     match result {
       Ok(exit_status) => exit_status.code().map_or_else(

--- a/tests/fallback.rs
+++ b/tests/fallback.rs
@@ -61,6 +61,7 @@ fn fallback_from_subdir_verbose_message() {
       Trying ../justfile
       ===> Running recipe `bar`...
       echo bar
+      + COMMAND_XTRACE
       ",
     ))
     .stdout("bar\n")


### PR DESCRIPTION
It is currently difficult to debug what went wrong in cases such as OS exec errors, because verbose output prints the file but does not say how it is run. Update spawning to print executed commands with loquacious and above verbosity. The result when run with `-v` is something like the following:

    + cd "/home/user/workspace" && "/run/user/1000/just/just-kynaKD/configure"

The `+` syntax is meant to match shell scripts run with `-x`. This gets coloring to differentiate it.

Environment variables are not printed unless `-vv` is set:

    + cd "/home/user/workspace" && RUST_BACKTRACE="1" CARGO_HOME="/cargo-home" "/run/user/1000/just/just-r2rLtg/configure"