### PR TITLE
Don not ascend above `--ceiling` when looking for `justfile`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,7 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         os:
         - ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,6 @@ jobs:
 
   test:
     strategy:
-      fail-fast: false
       matrix:
         os:
         - ubuntu-latest

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use {
 pub(crate) struct Config {
   pub(crate) alias_style: AliasStyle,
   pub(crate) allow_missing: bool,
+  pub(crate) ceiling: Option<PathBuf>,
   pub(crate) check: bool,
   pub(crate) color: Color,
   pub(crate) command_color: Option<ansi_term::Color>,
@@ -92,6 +93,7 @@ mod arg {
   pub(crate) const ALIAS_STYLE: &str = "ALIAS_STYLE";
   pub(crate) const ALLOW_MISSING: &str = "ALLOW-MISSING";
   pub(crate) const ARGUMENTS: &str = "ARGUMENTS";
+  pub(crate) const CEILING: &str = "CEILING";
   pub(crate) const CHECK: &str = "CHECK";
   pub(crate) const CHOOSER: &str = "CHOOSER";
   pub(crate) const CLEAR_SHELL_ARGS: &str = "CLEAR-SHELL-ARGS";
@@ -160,6 +162,14 @@ impl Config {
           .default_value("right")
           .help("Set list command alias display style")
           .conflicts_with(arg::NO_ALIASES),
+      )
+      .arg(
+        Arg::new(arg::CEILING)
+          .long("ceiling")
+          .env("JUST_CEILING")
+          .action(ArgAction::Set)
+          .value_parser(value_parser!(PathBuf))
+          .help("Do not ascend above <CEILING> directory when searching for a justfile."),
       )
       .arg(
         Arg::new(arg::CHECK)
@@ -777,6 +787,7 @@ impl Config {
         .unwrap()
         .clone(),
       allow_missing: matches.get_flag(arg::ALLOW_MISSING),
+      ceiling: matches.get_one::<PathBuf>(arg::CEILING).cloned(),
       check: matches.get_flag(arg::CHECK),
       color: (*matches.get_one::<UseColor>(arg::COLOR).unwrap()).into(),
       command_color: matches

--- a/src/search.rs
+++ b/src/search.rs
@@ -187,6 +187,8 @@ impl Search {
       }
 
       if let Some(ceiling) = ceiling {
+        dbg!(directory);
+        dbg!(ceiling);
         if directory == ceiling {
           break;
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -187,8 +187,6 @@ impl Search {
       }
 
       if let Some(ceiling) = ceiling {
-        dbg!(directory);
-        dbg!(ceiling);
         if directory == ceiling {
           break;
         }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -70,7 +70,11 @@ impl Subcommand {
       _ => {}
     }
 
-    let search = Search::find(&config.search_config, &config.invocation_directory)?;
+    let search = Search::find(
+      config.ceiling.as_deref(),
+      &config.invocation_directory,
+      &config.search_config,
+    )?;
 
     if let Edit = self {
       return Self::edit(&search);
@@ -132,7 +136,9 @@ impl Subcommand {
 
       if fallback {
         if let Err(err @ (Error::UnknownRecipe { .. } | Error::UnknownSubmodule { .. })) = result {
-          search = search.search_parent_directory().map_err(|_| err)?;
+          search = search
+            .search_parent_directory(config.ceiling.as_deref())
+            .map_err(|_| err)?;
 
           if config.verbosity.loquacious() {
             eprintln!(
@@ -366,7 +372,11 @@ impl Subcommand {
   }
 
   fn init(config: &Config) -> RunResult<'static> {
-    let search = Search::init(&config.search_config, &config.invocation_directory)?;
+    let search = Search::init(
+      &config.search_config,
+      &config.invocation_directory,
+      config.ceiling.as_deref(),
+    )?;
 
     if search.justfile.is_file() {
       return Err(Error::InitExists {

--- a/tests/ceiling.rs
+++ b/tests/ceiling.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+#[test]
+fn justfile_run_search_stops_at_ceiling_dir() {
+  let tempdir = tempdir();
+
+  let ceiling = tempdir.path().join("foo");
+
+  fs::create_dir(&ceiling).unwrap();
+
+  let ceiling = ceiling.canonicalize().unwrap();
+
+  Test::with_tempdir(tempdir)
+    .justfile(
+      "
+        foo:
+          echo bar
+      ",
+    )
+    .create_dir("foo/bar")
+    .current_dir("foo/bar")
+    .args(["--ceiling", ceiling.to_str().unwrap()])
+    .stderr("error: No justfile found\n")
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn ceiling_can_be_passed_as_environment_variable() {
+  let tempdir = tempdir();
+
+  let ceiling = tempdir.path().join("foo");
+
+  fs::create_dir(&ceiling).unwrap();
+
+  let ceiling = ceiling.canonicalize().unwrap();
+
+  Test::with_tempdir(tempdir)
+    .justfile(
+      "
+        foo:
+          echo bar
+      ",
+    )
+    .create_dir("foo/bar")
+    .current_dir("foo/bar")
+    .env("JUST_CEILING", ceiling.to_str().unwrap())
+    .stderr("error: No justfile found\n")
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn justfile_init_search_stops_at_ceiling_dir() {
+  let tempdir = tempdir();
+
+  let ceiling = tempdir.path().join("foo");
+
+  fs::create_dir(&ceiling).unwrap();
+
+  let ceiling = ceiling.canonicalize().unwrap();
+
+  let Output { tempdir, .. } = Test::with_tempdir(tempdir)
+    .no_justfile()
+    .test_round_trip(false)
+    .create_dir(".git")
+    .create_dir("foo/bar")
+    .current_dir("foo/bar")
+    .args(["--init", "--ceiling", ceiling.to_str().unwrap()])
+    .stderr_regex("Wrote justfile to `.*/foo/bar/justfile`\n")
+    .run();
+
+  assert_eq!(
+    fs::read_to_string(tempdir.path().join("foo/bar/justfile")).unwrap(),
+    just::INIT_JUSTFILE
+  );
+}

--- a/tests/ceiling.rs
+++ b/tests/ceiling.rs
@@ -67,7 +67,11 @@ fn justfile_init_search_stops_at_ceiling_dir() {
     .create_dir("foo/bar")
     .current_dir("foo/bar")
     .args(["--init", "--ceiling", ceiling.to_str().unwrap()])
-    .stderr_regex("Wrote justfile to `.*/foo/bar/justfile`\n")
+    .stderr_regex(if cfg!(windows) {
+      "Wrote justfile to `.*\\foo\\bar\\justfile`\n"
+    } else {
+      "Wrote justfile to `.*/foo/bar/justfile`\n"
+    })
     .run();
 
   assert_eq!(

--- a/tests/ceiling.rs
+++ b/tests/ceiling.rs
@@ -68,7 +68,7 @@ fn justfile_init_search_stops_at_ceiling_dir() {
     .current_dir("foo/bar")
     .args(["--init", "--ceiling", ceiling.to_str().unwrap()])
     .stderr_regex(if cfg!(windows) {
-      "Wrote justfile to `.*\\foo\\bar\\justfile`\n"
+      r"Wrote justfile to `.*\\foo\\bar\\justfile`\n"
     } else {
       "Wrote justfile to `.*/foo/bar/justfile`\n"
     })

--- a/tests/ceiling.rs
+++ b/tests/ceiling.rs
@@ -8,6 +8,7 @@ fn justfile_run_search_stops_at_ceiling_dir() {
 
   fs::create_dir(&ceiling).unwrap();
 
+  #[cfg(not(windows))]
   let ceiling = ceiling.canonicalize().unwrap();
 
   Test::with_tempdir(tempdir)
@@ -33,6 +34,7 @@ fn ceiling_can_be_passed_as_environment_variable() {
 
   fs::create_dir(&ceiling).unwrap();
 
+  #[cfg(not(windows))]
   let ceiling = ceiling.canonicalize().unwrap();
 
   Test::with_tempdir(tempdir)
@@ -58,6 +60,7 @@ fn justfile_init_search_stops_at_ceiling_dir() {
 
   fs::create_dir(&ceiling).unwrap();
 
+  #[cfg(not(windows))]
   let ceiling = ceiling.canonicalize().unwrap();
 
   let Output { tempdir, .. } = Test::with_tempdir(tempdir)

--- a/tests/ceiling.rs
+++ b/tests/ceiling.rs
@@ -18,7 +18,7 @@ fn justfile_run_search_stops_at_ceiling_dir() {
       ",
     )
     .create_dir("foo/bar")
-    .current_dir("foo/bar")
+    .current_dir(if cfg!(windows) { "foo\\bar" } else { "foo/bar" })
     .args(["--ceiling", ceiling.to_str().unwrap()])
     .stderr("error: No justfile found\n")
     .status(EXIT_FAILURE)

--- a/tests/ceiling.rs
+++ b/tests/ceiling.rs
@@ -18,7 +18,7 @@ fn justfile_run_search_stops_at_ceiling_dir() {
       ",
     )
     .create_dir("foo/bar")
-    .current_dir(if cfg!(windows) { "foo\\bar" } else { "foo/bar" })
+    .current_dir("foo/bar")
     .args(["--ceiling", ceiling.to_str().unwrap()])
     .stderr("error: No justfile found\n")
     .status(EXIT_FAILURE)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -52,6 +52,7 @@ mod assignment;
 mod attributes;
 mod backticks;
 mod byte_order_mark;
+mod ceiling;
 mod changelog;
 mod choose;
 mod command;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -147,7 +147,6 @@ impl Test {
     self
   }
 
-  #[allow(unused)]
   pub(crate) fn test_round_trip(mut self, test_round_trip: bool) -> Self {
     self.test_round_trip = test_round_trip;
     self


### PR DESCRIPTION
Add a `--ceiling` option, which can also be passed as `JUST_CEILING`. When searching for a Justfile to run, or for a project root in which to initialize a justfile, don't ascend above the ceiling.

For example:

```console
$ pwd
/foo/bar/baz
$ echo foo: > /foo/justfile
$ just --ceiling /foo/bar
error: No justfile found
```