### PR TITLE
Add lazy variable evaluation with `lazy` keyword

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -59,7 +59,7 @@ alias         : 'alias' NAME ':=' target eol
 
 target        : NAME ('::' NAME)*
 
-assignment    : NAME ':=' expression eol
+assignment    : 'lazy'? NAME ':=' expression eol
 
 export        : 'export' assignment
 

--- a/README.md
+++ b/README.md
@@ -1491,6 +1491,19 @@ braces:
   echo 'I {{ "{{" }}LOVE}} curly braces!'
 ```
 
+#### Lazy Evaluation
+
+By default, variables are evaluated when they are defined. If you would like a
+variable to only be evaluated when it is used for the first time, you can use the
+`lazy` keyword:
+
+```just
+lazy password := `aws ecr get-login-password --region us-west-2`
+```
+
+This is useful for values that are expensive to compute, or that may not be
+needed in every invocation of `just`.
+
 ### Strings
 
 `'single'`, `"double"`, and `'''triple'''` quoted string literals are

--- a/README.md
+++ b/README.md
@@ -1498,11 +1498,27 @@ variable to only be evaluated when it is used for the first time, you can use th
 `lazy` keyword:
 
 ```just
-lazy password := `aws ecr get-login-password --region us-west-2`
+lazy aws_account_id := `aws sts get-caller-identity --query Account --output text`
+```
+
+Once a lazy variable has been evaluated, its value is the same for the rest of
+the invocation of `just`, even if it is used multiple times:
+
+```just
+lazy timestamp := `date +%s`
+
+foo:
+  # The value is computed here
+  echo The time is {{timestamp}}
+  sleep 1
+  # The same value is used here
+  echo The time is still {{timestamp}}
 ```
 
 This is useful for values that are expensive to compute, or that may not be
-needed in every invocation of `just`.
+needed in every invocation of `just`. It also saves you from having expensive
+values being recomputed even for simple invocations of `just` that don't
+actually use them, like `just --list`.
 
 ### Strings
 

--- a/src/assignment.rs
+++ b/src/assignment.rs
@@ -9,6 +9,10 @@ impl Display for Assignment<'_> {
       writeln!(f, "[private]")?;
     }
 
+    if self.lazy {
+      write!(f, "lazy ")?;
+    }
+
     if self.export {
       write!(f, "export ")?;
     }

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -6,6 +6,7 @@ pub(crate) struct Binding<'src, V = String> {
   pub(crate) export: bool,
   #[serde(skip)]
   pub(crate) file_depth: u32,
+  pub(crate) lazy: bool,
   pub(crate) name: Name<'src>,
   #[serde(skip)]
   pub(crate) prelude: bool,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -34,6 +34,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
           scope.bind(Binding {
             export: assignment.export,
             file_depth: 0,
+            lazy: false,
             name: assignment.name,
             prelude: false,
             private: assignment.private,
@@ -183,6 +184,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
           scope.bind(Binding {
             export: assignment.export,
             file_depth: 0,
+            lazy: false,
             name: assignment.name,
             prelude: false,
             private: assignment.private,
@@ -210,7 +212,9 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     };
 
     for assignment in module.assignments.values() {
-      evaluator.evaluate_assignment(assignment)?;
+      if !assignment.lazy {
+        evaluator.evaluate_assignment(assignment)?;
+      }
     }
 
     Ok(evaluator.scope)
@@ -227,6 +231,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
         name: assignment.name,
         prelude: false,
         private: assignment.private,
+        lazy: false,
         value,
       });
     }
@@ -561,6 +566,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
         name: parameter.name,
         prelude: false,
         private: false,
+        lazy: false,
         value: values.join(" "),
       });
     }
@@ -575,7 +581,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     scope: &'run Scope<'src, 'run>,
   ) -> Self {
     Self {
-      assignments: None,
+      assignments: Some(&context.module.assignments),
       context: Some(*context),
       env,
       is_dependency,

--- a/src/execution_context.rs
+++ b/src/execution_context.rs
@@ -4,6 +4,7 @@ use super::*;
 pub(crate) struct ExecutionContext<'src: 'run, 'run> {
   pub(crate) config: &'run Config,
   pub(crate) dotenv: &'run BTreeMap<String, String>,
+  pub(crate) lazy_cache: Option<&'run Mutex<BTreeMap<(String, String), String>>>,
   pub(crate) module: &'run Justfile<'src>,
   pub(crate) search: &'run Search,
 }

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -20,6 +20,7 @@ pub(crate) enum Keyword {
   If,
   IgnoreComments,
   Import,
+  Lazy,
   Mod,
   NoExitMessage,
   PositionalArguments,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -362,6 +362,12 @@ impl<'run, 'src> Parser<'run, 'src> {
               self.parse_assignment(true, take_attributes())?,
             ));
           }
+          Some(Keyword::Lazy) if self.next_are(&[Identifier, Identifier, ColonEquals]) => {
+            self.presume_keyword(Keyword::Lazy)?;
+            items.push(Item::Assignment(
+              self.parse_assignment_lazy(take_attributes())?,
+            ));
+          }
           Some(Keyword::Unexport)
             if self.next_are(&[Identifier, Identifier, Eof])
               || self.next_are(&[Identifier, Identifier, Eol]) =>
@@ -545,6 +551,31 @@ impl<'run, 'src> Parser<'run, 'src> {
     Ok(Assignment {
       export,
       file_depth: self.file_depth,
+      name,
+      prelude: false,
+      private: private || name.lexeme().starts_with('_'),
+      lazy: false,
+      value,
+    })
+  }
+
+  fn parse_assignment_lazy(
+    &mut self,
+    attributes: AttributeSet<'src>,
+  ) -> CompileResult<'src, Assignment<'src>> {
+    let name = self.parse_name()?;
+    self.presume(ColonEquals)?;
+    let value = self.parse_expression()?;
+    self.expect_eol()?;
+
+    let private = attributes.contains(AttributeDiscriminant::Private);
+
+    attributes.ensure_valid_attributes("Assignment", *name, &[AttributeDiscriminant::Private])?;
+
+    Ok(Assignment {
+      export: false,
+      file_depth: self.file_depth,
+      lazy: true,
       name,
       prelude: false,
       private: private || name.lexeme().starts_with('_'),

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -37,6 +37,7 @@ impl<'src, 'run> Scope<'src, 'run> {
         },
         prelude: true,
         private: false,
+        lazy: false,
         value: (*value).into(),
       });
     }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -12,6 +12,8 @@ struct Alias<'a> {
 #[serde(deny_unknown_fields)]
 struct Assignment<'a> {
   export: bool,
+  #[serde(default)]
+  lazy: bool,
   name: &'a str,
   private: bool,
   value: serde_json::Value,

--- a/tests/lazy.rs
+++ b/tests/lazy.rs
@@ -1,0 +1,155 @@
+use super::*;
+
+#[test]
+fn lazy_variable_not_evaluated_if_unused() {
+  Test::new()
+    .justfile(
+      "
+        lazy expensive := `exit 1`
+
+        works:
+          @echo 'Success'
+      ",
+    )
+    .stdout("Success\n")
+    .success();
+}
+
+#[test]
+fn lazy_variable_evaluated_when_used() {
+  Test::new()
+    .justfile(
+      "
+        lazy greeting := `echo 'Hello'`
+
+        test:
+          @echo {{greeting}}
+      ",
+    )
+    .stdout("Hello\n")
+    .success();
+}
+
+#[test]
+fn lazy_variable_with_backtick_error() {
+  Test::new()
+    .justfile(
+      "
+        lazy bad := `exit 1`
+
+        test:
+          @echo {{bad}}
+      ",
+    )
+    .stderr(
+      "
+        error: Backtick failed with exit code 1
+         ——▶ justfile:1:13
+          │
+        1 │ lazy bad := `exit 1`
+          │             ^^^^^^^^
+      ",
+    )
+    .failure();
+}
+
+#[test]
+fn lazy_variable_used_multiple_times() {
+  Test::new()
+    .justfile(
+      "
+        lazy value := `echo 'test'`
+
+        test:
+          @echo {{value}}
+          @echo {{value}}
+      ",
+    )
+    .stdout("test\ntest\n")
+    .success();
+}
+
+#[test]
+fn lazy_and_export_are_separate() {
+  Test::new()
+    .justfile(
+      "
+        lazy foo := `echo 'lazy'`
+        export bar := 'exported'
+
+        test:
+          @echo {{foo}} $bar
+      ",
+    )
+    .stdout("lazy exported\n")
+    .success();
+}
+
+#[test]
+fn lazy_variable_dump() {
+  Test::new()
+    .justfile(
+      "
+        lazy greeting := `echo 'Hello'`
+        normal := 'value'
+      ",
+    )
+    .args(["--dump"])
+    .stdout(
+      "
+        lazy greeting := `echo 'Hello'`
+        normal := 'value'
+      ",
+    )
+    .success();
+}
+
+#[test]
+fn lazy_keyword_lexeme() {
+  Test::new()
+    .justfile(
+      "
+        lazy := 'not a keyword here'
+
+        test:
+          @echo {{lazy}}
+      ",
+    )
+    .stdout("not a keyword here\n")
+    .success();
+}
+
+#[test]
+fn lazy_variable_in_dependency() {
+  Test::new()
+    .justfile(
+      "
+        lazy value := `echo 'computed'`
+
+        dep:
+          @echo {{value}}
+
+        main: dep
+          @echo 'done'
+      ",
+    )
+    .args(["main"])
+    .stdout("computed\ndone\n")
+    .success();
+}
+
+#[test]
+fn lazy_with_private() {
+  Test::new()
+    .justfile(
+      "
+        [private]
+        lazy _secret := `echo 'hidden'`
+
+        test:
+          @echo {{_secret}}
+      ",
+    )
+    .stdout("hidden\n")
+    .success();
+}

--- a/tests/lazy.rs
+++ b/tests/lazy.rs
@@ -153,3 +153,26 @@ fn lazy_with_private() {
     .stdout("hidden\n")
     .success();
 }
+
+#[test]
+fn lazy_variable_evaluated_once() {
+  Test::new()
+    .justfile(
+      "
+        lazy value := `date +%s%N`
+
+        test:
+          #!/usr/bin/env bash
+          first={{value}}
+          second={{value}}
+          if [ \"$first\" = \"$second\" ]; then
+            echo \"PASS: $first\"
+          else
+            echo \"FAIL: first=$first second=$second\"
+            exit 1
+          fi
+      ",
+    )
+    .stdout_regex("^PASS: \\d+\\n$")
+    .success();
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -87,6 +87,7 @@ mod init;
 mod interpolation;
 mod invocation_directory;
 mod json;
+mod lazy;
 mod line_prefixes;
 mod list;
 mod logical_operators;


### PR DESCRIPTION
I have been checking #953 for many years now waiting for this feature to land and getting all frustrated and bent out of shape, and after having to write another Makefile, I have started hate writing Rust to put some simple implementation forward rather than suffer in silence.

This PR implements lazy evaluation for variable assignments using a new `lazy` keyword. This is something that had been discussed as a potential way forward by someone, and as we all know if two people on GitHub give it a tick that is all the green lights we need. 

The main motivation for this is that over the years I have been unable to really suggest just as an alternative because I often need to get things like credentials to log into AWS services or some such, and having them execute on every invocation just gets way too expensive.

I am not sure what I need to update in terms of the documentation, grammar, etc. but I thought I would at least put this forward and let everyone throw tomatoes at it so at least I gave addressing the issue a try.

I have tried to write tests for this that, hopefully, cover all of the bases and edge cases, but my experience with the more exotic features of just is somewhere between zero and very limited.

```
Usage:
  lazy credentials := `aws sts get-session-token`

  # credentials are only evaluated if this recipe runs
  deploy:
    ./deploy.sh {{credentials}}
```

Fixes #953