### PR TITLE
Update README.md with uv tool install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,11 @@ most Windows users.)
       <td><a href=https://snapcraft.io/just>just</a></td>
       <td><code>snap install --edge --classic just</code></td>
     </tr>
+    <tr>
+      <td><a href=https://pipx.pypa.io/stable/>uv</a></td>
+      <td><a href=https://pypi.org/project/rust-just/>rust-just</a></td>
+      <td><code>uv tool install rust-just</code></td>
+    </tr>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ most Windows users.)
       <td><code>snap install --edge --classic just</code></td>
     </tr>
     <tr>
-      <td><a href=https://pipx.pypa.io/stable/>uv</a></td>
+      <td><a href=https://docs.astral.sh/uv/>uv</a></td>
       <td><a href=https://pypi.org/project/rust-just/>rust-just</a></td>
       <td><code>uv tool install rust-just</code></td>
     </tr>


### PR DESCRIPTION
I saw that you had a prior PR coming in which added `uv` to the readme, which you rejected in June.

I would argue that going into October 2025, `uv` is one of the most prominent and used package manager for Python packages out there.

I believe there are equally many or even more ppl installing tools using `uv tool install` compared to using `pipx` at this point.

With that said I believe this is a must to provide in the readme 😊