### PR TITLE
Add cli option to print out json serialized Justfile

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub(crate) struct Config {
   pub(crate) list_heading: String,
   pub(crate) list_prefix: String,
   pub(crate) list_submodules: bool,
+  pub(crate) human_readable: bool,
   pub(crate) load_dotenv: bool,
   pub(crate) no_aliases: bool,
   pub(crate) no_dependencies: bool,
@@ -111,6 +112,7 @@ mod arg {
   pub(crate) const LIST_HEADING: &str = "LIST-HEADING";
   pub(crate) const LIST_PREFIX: &str = "LIST-PREFIX";
   pub(crate) const LIST_SUBMODULES: &str = "LIST-SUBMODULES";
+  pub(crate) const LIST_JSON: &str = "LIST-JSON";
   pub(crate) const NO_ALIASES: &str = "NO-ALIASES";
   pub(crate) const NO_DEPS: &str = "NO-DEPS";
   pub(crate) const NO_DOTENV: &str = "NO-DOTENV";
@@ -313,6 +315,15 @@ impl Config {
           .help("List recipes in submodules")
           .action(ArgAction::SetTrue)
           .requires(cmd::LIST),
+      )
+      .arg(
+        Arg::new(arg::LIST_JSON)
+          .short('j')
+          .long("json")
+          .env("JUST_LIST_JSON")
+          .help("Print parsable json version of a module")
+          .action(ArgAction::SetTrue)
+          .requires(cmd::LIST)
       )
       .arg(
         Arg::new(arg::NO_ALIASES)
@@ -810,6 +821,7 @@ impl Config {
       list_heading: matches.get_one::<String>(arg::LIST_HEADING).unwrap().into(),
       list_prefix: matches.get_one::<String>(arg::LIST_PREFIX).unwrap().into(),
       list_submodules: matches.get_flag(arg::LIST_SUBMODULES),
+      human_readable: !matches.get_flag(arg::LIST_JSON),
       load_dotenv: !matches.get_flag(arg::NO_DOTENV),
       no_aliases: matches.get_flag(arg::NO_ALIASES),
       no_dependencies: matches.get_flag(arg::NO_DEPS),

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -450,7 +450,16 @@ impl Subcommand {
         })?;
     }
 
-    Self::list_module(config, module, 0);
+    if config.human_readable {
+      Self::list_module(config, module, 0);
+    } else {
+      let serialize_just_result = serde_json::to_string(module);
+      if let Ok(serialized_just) = serialize_just_result {
+        println!("{}", serialized_just);
+      } else {
+        return Err(Error::Internal { message: "Error serializing just module.".to_string() });
+      }
+    }
 
     Ok(())
   }


### PR DESCRIPTION
# The problem

There's currently no easy way to integrate `just` as a utility subprocess due to the way printing is designed first-and-foremost to be human readable. This is a sane default value, but being able to return a serialized representation of a justfile would simplify writing just file wrappers that can take multiple target justfiles into consideration (i.e. not hard coded to look at a single just file). 

# This patch

I've added a helpful utility CLI flag (`--json`) to the `--list` command for those of us who want to integrate just into a GUI framework or want to create utility wrappers and other GUI/TUI uses. Since `serde` gives us json serialization for free, this was a relatively quick way to add json parsing to my application. This cuts down the work of having to reimplement a justfile parser and doesn't require exposing all of the justfile parsing functions as a public library (long term, this would be nice as well.) 

For an example, checkout this branch and try the following: 
```
cargo run -- -f ./some/justfile --list --json
```

<details>
<summary>Here's a silly example of some output, collapsed for legibility's sake</summary>

```json
{
  "aliases": {},
  "assignments": {},
  "first": "test",
  "doc": null,
  "groups": [],
  "modules": {
    "fuzzy": {
      "aliases": {},
      "assignments": {},
      "first": "yoshi",
      "doc": null,
      "groups": [],
      "modules": {},
      "recipes": {
        "yoshi": {
          "attributes": [],
          "body": [
            [
              "@echo \"Yoshi!\""
            ]
          ],
          "dependencies": [],
          "doc": null,
          "name": "yoshi",
          "namepath": "fuzzy::yoshi",
          "parameters": [],
          "priors": 0,
          "private": false,
          "quiet": false,
          "shebang": false
        }
      },
      "settings": {
        "allow_duplicate_recipes": false,
        "allow_duplicate_variables": false,
        "dotenv_filename": null,
        "dotenv_load": false,
        "dotenv_override": false,
        "dotenv_path": null,
        "dotenv_required": false,
        "export": false,
        "fallback": false,
        "ignore_comments": false,
        "no_exit_message": false,
        "positional_arguments": false,
        "quiet": false,
        "shell": null,
        "tempdir": null,
        "unstable": false,
        "windows_powershell": false,
        "windows_shell": null,
        "working_directory": null
      },
      "source": "/home/eoin/Code/rust/just-gui/fuzzy.just",
      "unexports": [],
      "warnings": []
    }
  },
  "recipes": {
    "test": {
      "attributes": [],
      "body": [
        [
          "@echo \"123\""
        ]
      ],
      "dependencies": [],
      "doc": null,
      "name": "test",
      "namepath": "test",
      "parameters": [],
      "priors": 0,
      "private": false,
      "quiet": false,
      "shebang": false
    },
    "test2": {
      "attributes": [],
      "body": [
        [
          "@echo \"This is a second command\""
        ]
      ],
      "dependencies": [],
      "doc": null,
      "name": "test2",
      "namepath": "test2",
      "parameters": [],
      "priors": 0,
      "private": false,
      "quiet": false,
      "shebang": false
    }
  },
  "settings": {
    "allow_duplicate_recipes": false,
    "allow_duplicate_variables": false,
    "dotenv_filename": null,
    "dotenv_load": false,
    "dotenv_override": false,
    "dotenv_path": null,
    "dotenv_required": false,
    "export": false,
    "fallback": false,
    "ignore_comments": false,
    "no_exit_message": false,
    "positional_arguments": false,
    "quiet": false,
    "shell": null,
    "tempdir": null,
    "unstable": false,
    "windows_powershell": false,
    "windows_shell": null,
    "working_directory": null
  },
  "source": "/home/eoin/Code/rust/just-gui/justfile",
  "unexports": [],
  "warnings": []
}
```

</details>

This should provide enough data in a universably parse-able way that people can integrate just module parsing into their applications without having to try to parse the human readable output.

### My usecase

I'm writing a utility for managing system-level just files for installation wizards and this being merged would help streamline the process of using just as a subproc instead of integrating it as a library (though this would also be useful.)

### Minor interface concerns / Looking for feedback

While I think this implementation *works*, I'd like feedback on whether you think this means of exporting the json data is appropriate. It would basically mean that all data serialization would be tied to the actual justfile data structure layout, which might mean that changing the struct layout would force developers to "adapt" if they're making GUI frontends. 

A simple solution would be to add a `just` version number into the `JustFile` struct; Developers could make on-the-fly adjustments if the data structure ever changes majorly or can error handle accordingly by requesting specific versions of `just` as a dependency. 


