### PR TITLE
Add env attribute to set environment variables for recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2139,6 +2139,7 @@ change their behavior.
 | `[confirm(PROMPT)]`<sup>1.23.0</sup> | recipe | Require confirmation prior to executing recipe with a custom prompt. |
 | `[default]`<sup>1.43.0</sup> | recipe | Use recipe as module's default recipe. |
 | `[doc(DOC)]`<sup>1.27.0</sup> | module, recipe | Set recipe or module's [documentation comment](#documentation-comments) to `DOC`. |
+| `[env(ENV_VAR, VALUE)]` <sup>1.44</sup> | recipe | Set env vars that apply only to this recipe. |
 | `[extension(EXT)]`<sup>1.32.0</sup> | recipe | Set shebang recipe script's file extension to `EXT`. `EXT` should include a period if one is desired. |
 | `[group(NAME)]`<sup>1.27.0</sup> | module, recipe | Put recipe or module in [group](#groups) `NAME`. |
 | `[linux]`<sup>1.8.0</sup> | recipe | Enable recipe on Linux. |
@@ -2514,6 +2515,17 @@ Parameters prefixed with a `$` will be exported as environment variables:
 
 ```just
 test $RUST_BACKTRACE="1":
+  # will print a stack trace if it crashes
+  cargo test
+```
+
+Or you can use the `[env(env_var, value)]` attribute to set environment variables that
+apply only to this recipe:
+
+```just
+
+[env("RUST_BACKTRACE", "1")]
+test:
   # will print a stack trace if it crashes
   cargo test
 ```

--- a/README.md
+++ b/README.md
@@ -2139,7 +2139,7 @@ change their behavior.
 | `[confirm(PROMPT)]`<sup>1.23.0</sup> | recipe | Require confirmation prior to executing recipe with a custom prompt. |
 | `[default]`<sup>1.43.0</sup> | recipe | Use recipe as module's default recipe. |
 | `[doc(DOC)]`<sup>1.27.0</sup> | module, recipe | Set recipe or module's [documentation comment](#documentation-comments) to `DOC`. |
-| `[env(ENV_VAR, VALUE)]` <sup>1.44</sup> | recipe | Set env vars that apply only to this recipe. |
+| `[env(ENV_VAR, VALUE)]` <sup>master</sup> | recipe | Set env vars that apply only to this recipe. |
 | `[extension(EXT)]`<sup>1.32.0</sup> | recipe | Set shebang recipe script's file extension to `EXT`. `EXT` should include a period if one is desired. |
 | `[group(NAME)]`<sup>1.27.0</sup> | module, recipe | Put recipe or module in [group](#groups) `NAME`. |
 | `[linux]`<sup>1.8.0</sup> | recipe | Enable recipe on Linux. |
@@ -2519,7 +2519,7 @@ test $RUST_BACKTRACE="1":
   cargo test
 ```
 
-Or you can use the `[env(env_var, value)]` attribute to set environment variables that
+You can also use the `[env(NAME, VALUE)]` attribute to export environment variables to a specific recipe:
 apply only to this recipe:
 
 ```just

--- a/README.md
+++ b/README.md
@@ -2139,7 +2139,7 @@ change their behavior.
 | `[confirm(PROMPT)]`<sup>1.23.0</sup> | recipe | Require confirmation prior to executing recipe with a custom prompt. |
 | `[default]`<sup>1.43.0</sup> | recipe | Use recipe as module's default recipe. |
 | `[doc(DOC)]`<sup>1.27.0</sup> | module, recipe | Set recipe or module's [documentation comment](#documentation-comments) to `DOC`. |
-| `[env(ENV_VAR, VALUE)]` <sup>master</sup> | recipe | Set env vars that apply only to this recipe. |
+| `[env(ENV_VAR, VALUE)]` <sup>master</sup> | recipe | Set environment variables for recipe. |
 | `[extension(EXT)]`<sup>1.32.0</sup> | recipe | Set shebang recipe script's file extension to `EXT`. `EXT` should include a period if one is desired. |
 | `[group(NAME)]`<sup>1.27.0</sup> | module, recipe | Put recipe or module in [group](#groups) `NAME`. |
 | `[linux]`<sup>1.8.0</sup> | recipe | Enable recipe on Linux. |
@@ -2519,11 +2519,10 @@ test $RUST_BACKTRACE="1":
   cargo test
 ```
 
-You can also use the `[env(NAME, VALUE)]` attribute to export environment variables to a specific recipe:
-apply only to this recipe:
+You can also use the `[env(NAME, VALUE)]` attribute to export environment
+variables to a specific recipe:
 
 ```just
-
 [env("RUST_BACKTRACE", "1")]
 test:
   # will print a stack trace if it crashes

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -182,17 +182,7 @@ impl<'src> Attribute<'src> {
       AttributeDiscriminant::Default => Self::Default,
       AttributeDiscriminant::Doc => Self::Doc(arguments.into_iter().next()),
       AttributeDiscriminant::Env => {
-        let [key, value]: [StringLiteral; 2] =
-          arguments
-            .try_into()
-            .map_err(|arguments: Vec<StringLiteral>| {
-              name.error(CompileErrorKind::AttributeArgumentCountMismatch {
-                attribute: name,
-                found: arguments.len(),
-                min: 2,
-                max: 2,
-              })
-            })?;
+        let [key, value]: [StringLiteral; 2] = arguments.try_into().unwrap();
         Self::Env(key, value)
       }
       AttributeDiscriminant::ExitMessage => Self::ExitMessage,

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -23,6 +23,7 @@ pub(crate) enum Attribute<'src> {
   Confirm(Option<StringLiteral<'src>>),
   Default,
   Doc(Option<StringLiteral<'src>>),
+  Env(StringLiteral<'src>, StringLiteral<'src>),
   ExitMessage,
   Extension(StringLiteral<'src>),
   Group(StringLiteral<'src>),
@@ -61,6 +62,7 @@ impl AttributeDiscriminant {
       Self::Confirm | Self::Doc => 0..=1,
       Self::Script => 0..=usize::MAX,
       Self::Arg | Self::Extension | Self::Group | Self::WorkingDirectory => 1..=1,
+      Self::Env => 2..=2,
       Self::Metadata => 1..=usize::MAX,
     }
   }
@@ -179,6 +181,20 @@ impl<'src> Attribute<'src> {
       AttributeDiscriminant::Confirm => Self::Confirm(arguments.into_iter().next()),
       AttributeDiscriminant::Default => Self::Default,
       AttributeDiscriminant::Doc => Self::Doc(arguments.into_iter().next()),
+      AttributeDiscriminant::Env => {
+        let [key, value]: [StringLiteral; 2] =
+          arguments
+            .try_into()
+            .map_err(|arguments: Vec<StringLiteral>| {
+              name.error(CompileErrorKind::AttributeArgumentCountMismatch {
+                attribute: name,
+                found: arguments.len(),
+                min: 2,
+                max: 2,
+              })
+            })?;
+        Self::Env(key, value)
+      }
       AttributeDiscriminant::ExitMessage => Self::ExitMessage,
       AttributeDiscriminant::Extension => Self::Extension(arguments.into_iter().next().unwrap()),
       AttributeDiscriminant::Group => Self::Group(arguments.into_iter().next().unwrap()),
@@ -243,7 +259,7 @@ impl<'src> Attribute<'src> {
   pub(crate) fn repeatable(&self) -> bool {
     matches!(
       self,
-      Attribute::Arg { .. } | Attribute::Group(_) | Attribute::Metadata(_),
+      Attribute::Arg { .. } | Attribute::Env(_, _) | Attribute::Group(_) | Attribute::Metadata(_),
     )
   }
 }
@@ -307,6 +323,7 @@ impl Display for Attribute<'_> {
       | Self::Extension(argument)
       | Self::Group(argument)
       | Self::WorkingDirectory(argument) => write!(f, "({argument})")?,
+      Self::Env(key, value) => write!(f, "({key}, {value})")?,
       Self::Metadata(arguments) => {
         write!(f, "(")?;
         for (i, argument) in arguments.iter().enumerate() {

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -131,6 +131,12 @@ impl Display for CompileError<'_> {
         first.ordinal(),
         self.token.line.ordinal(),
       ),
+      DuplicateEnvAttribute { variable, first } => write!(
+        f,
+        "Environment variable `{variable}` first set on line {} is set again on line {}",
+        first.ordinal(),
+        self.token.line.ordinal(),
+      ),
       DuplicateDefault { recipe } => write!(
         f,
         "Recipe `{recipe}` has duplicate `[default]` attribute, which may only appear once per module",

--- a/src/compile_error_kind.rs
+++ b/src/compile_error_kind.rs
@@ -42,6 +42,10 @@ pub(crate) enum CompileErrorKind<'src> {
   DuplicateDefault {
     recipe: &'src str,
   },
+  DuplicateEnvAttribute {
+    variable: String,
+    first: usize,
+  },
   DuplicateOption {
     recipe: &'src str,
     option: Switch,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3,6 +3,7 @@ use super::*;
 pub(crate) struct Evaluator<'src: 'run, 'run> {
   assignments: Option<&'run Table<'src, Assignment<'src>>>,
   context: Option<ExecutionContext<'src, 'run>>,
+  env_vars: BTreeMap<String, String>,
   is_dependency: bool,
   non_const_assignments: Table<'src, Name<'src>>,
   scope: Scope<'src, 'run>,
@@ -53,6 +54,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     let mut evaluator = Self {
       assignments: Some(assignments),
       context: None,
+      env_vars: BTreeMap::new(),
       is_dependency: false,
       non_const_assignments: Table::new(),
       scope,
@@ -201,6 +203,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     let mut evaluator = Self {
       assignments: Some(&module.assignments),
       context: Some(context),
+      env_vars: BTreeMap::new(),
       is_dependency: false,
       non_const_assignments: Table::new(),
       scope,
@@ -273,12 +276,12 @@ impl<'src, 'run> Evaluator<'src, 'run> {
           return Ok(format!("`{contents}`"));
         }
 
-        Self::run_command(context, &self.scope, contents, &[]).map_err(|output_error| {
-          Error::Backtick {
+        Self::run_command(context, &self.env_vars, &self.scope, contents, &[]).map_err(
+          |output_error| Error::Backtick {
             token: *token,
             output_error,
-          }
-        })
+          },
+        )
       }
       Expression::Call { thunk } => {
         use Thunk::*;
@@ -436,6 +439,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
 
   pub(crate) fn run_command(
     context: &ExecutionContext,
+    env_vars: &BTreeMap<String, String>,
     scope: &Scope,
     command: &str,
     args: &[&str],
@@ -459,6 +463,10 @@ impl<'src, 'run> Evaluator<'src, 'run> {
         Stdio::inherit()
       })
       .stdout(Stdio::piped());
+
+    for (key, value) in env_vars {
+      cmd.env(key, value);
+    }
 
     cmd.output_guard_stdout()
   }
@@ -498,7 +506,13 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     recipe: &Recipe<'src>,
     scope: &'run Scope<'src, 'run>,
   ) -> RunResult<'src, (Scope<'src, 'run>, Vec<String>)> {
-    let mut evaluator = Self::new(context, is_dependency, scope);
+    let mut env_vars = BTreeMap::new();
+    for attribute in &recipe.attributes {
+      if let Attribute::Env(key, value) = attribute {
+        env_vars.insert(key.cooked.clone(), value.cooked.clone());
+      }
+    }
+    let mut evaluator = Self::new(context, env_vars, is_dependency, scope);
 
     let mut positional = Vec::new();
 
@@ -550,12 +564,14 @@ impl<'src, 'run> Evaluator<'src, 'run> {
 
   pub(crate) fn new(
     context: &ExecutionContext<'src, 'run>,
+    env_vars: BTreeMap<String, String>,
     is_dependency: bool,
     scope: &'run Scope<'src, 'run>,
   ) -> Self {
     Self {
       assignments: None,
       context: Some(*context),
+      env_vars,
       is_dependency,
       non_const_assignments: Table::new(),
       scope: scope.child(),

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -506,12 +506,18 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     recipe: &Recipe<'src>,
     scope: &'run Scope<'src, 'run>,
   ) -> RunResult<'src, (Scope<'src, 'run>, Vec<String>)> {
-    let mut env = BTreeMap::new();
-    for attribute in &recipe.attributes {
-      if let Attribute::Env(key, value) = attribute {
-        env.insert(key.cooked.clone(), value.cooked.clone());
-      }
-    }
+    let env = recipe
+      .attributes
+      .iter()
+      .filter_map(|attribute| {
+        if let Attribute::Env(key, value) = attribute {
+          Some((key.cooked.clone(), value.cooked.clone()))
+        } else {
+          None
+        }
+      })
+      .collect();
+
     let mut evaluator = Self::new(context, env, is_dependency, scope);
 
     let mut positional = Vec::new();

--- a/src/function.rs
+++ b/src/function.rs
@@ -544,8 +544,14 @@ fn shell(context: Context, command: &str, args: &[String]) -> FunctionResult {
     .chain(args.iter().map(String::as_str))
     .collect::<Vec<&str>>();
 
-  Evaluator::run_command(context.execution_context, context.scope, command, &args)
-    .map_err(|output_error| output_error.to_string())
+  Evaluator::run_command(
+    context.execution_context,
+    &BTreeMap::new(),
+    context.scope,
+    command,
+    &args,
+  )
+  .map_err(|output_error| output_error.to_string())
 }
 
 fn shoutykebabcase(_context: Context, s: &str) -> FunctionResult {

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -308,7 +308,7 @@ impl<'src> Justfile<'src> {
 
     let scope = outer.child();
 
-    let mut evaluator = Evaluator::new(&context, true, &scope);
+    let mut evaluator = Evaluator::new(&context, BTreeMap::new(), true, &scope);
 
     Self::run_dependencies(
       config,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1380,6 +1380,7 @@ impl<'run, 'src> Parser<'run, 'src> {
     let mut arg_attributes = BTreeMap::new();
     let mut attributes = Vec::new();
     let mut discriminants = BTreeMap::new();
+    let mut env_attributes = BTreeMap::new();
 
     let mut token = None;
 
@@ -1451,6 +1452,17 @@ impl<'run, 'src> Parser<'run, 'src> {
           }
 
           arg_attributes.insert(arg.cooked.clone(), name.line);
+        }
+
+        if let Attribute::Env(variable, _) = &attribute {
+          if let Some(&first) = env_attributes.get(&variable.cooked) {
+            return Err(name.error(CompileErrorKind::DuplicateEnvAttribute {
+              variable: variable.cooked.clone(),
+              first,
+            }));
+          }
+
+          env_attributes.insert(variable.cooked.clone(), name.line);
         }
 
         discriminants.insert(attribute.discriminant(), name.line);

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -222,7 +222,7 @@ impl<'src, D> Recipe<'src, D> {
       }
     }
 
-    let evaluator = Evaluator::new(context, is_dependency, scope);
+    let evaluator = Evaluator::new(context, BTreeMap::new(), is_dependency, scope);
 
     if self.is_script() {
       self.run_script(context, scope, positional, evaluator)

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -327,6 +327,12 @@ impl<'src, D> Recipe<'src, D> {
         cmd.stdout(Stdio::null());
       }
 
+      for attribute in &self.attributes {
+        if let Attribute::Env(key, value) = attribute {
+          cmd.env(&key.cooked, &value.cooked);
+        }
+      }
+
       cmd.export(
         &context.module.settings,
         context.dotenv,
@@ -475,6 +481,12 @@ impl<'src, D> Recipe<'src, D> {
 
     if self.takes_positional_arguments(&context.module.settings) {
       command.args(positional);
+    }
+
+    for attribute in &self.attributes {
+      if let Attribute::Env(key, value) = attribute {
+        command.env(&key.cooked, &value.cooked);
+      }
     }
 
     command.export(

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -424,3 +424,26 @@ fn env_attribute_too_many_arguments() {
     )
     .failure();
 }
+
+#[test]
+fn env_attribute_duplicate_error() {
+  Test::new()
+    .justfile(
+      "
+        [env('VAR1', 'value1')]
+        [env('VAR1', 'value 2')]
+        foo:
+          @echo $VAR1
+      ",
+    )
+    .stderr(
+      "
+  error: Environment variable `VAR1` first set on line 1 is set again on line 2
+   ——▶ justfile:2:2
+    │
+  2 │ [env('VAR1', 'value 2')]
+    │  ^^^
+",
+    )
+    .failure();
+}

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -320,11 +320,10 @@ fn env_attribute_single() {
       "
         [env('MY_VAR', 'my_value')]
         foo:
-          echo $MY_VAR
+          @echo $MY_VAR
       ",
     )
     .stdout("my_value\n")
-    .stderr("echo $MY_VAR\n")
     .run();
 }
 
@@ -336,11 +335,10 @@ fn env_attribute_multiple() {
         [env('VAR1', 'value1')]
         [env('VAR2', 'value 2')]
         foo:
-          echo $VAR1 $VAR2
+          @echo $VAR1 $VAR2
       ",
     )
     .stdout("value1 value 2\n")
-    .stderr("echo $VAR1 $VAR2\n")
     .run();
 }
 

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -343,6 +343,20 @@ fn env_attribute_multiple() {
 }
 
 #[test]
+fn env_attribute_in_recipe_params() {
+  Test::new()
+    .justfile(
+      r#"
+[env("foo", "bar")]
+baz x=`echo ${foo}.txt`:
+    @echo {{x}}
+"#,
+    )
+    .stdout("bar.txt\n")
+    .run();
+}
+
+#[test]
 fn env_attribute_too_few_arguments() {
   Test::new()
     .justfile(

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -357,6 +357,32 @@ baz x=`echo ${foo}.txt`:
 }
 
 #[test]
+fn env_attribute_not_in_env_function() {
+  Test::new()
+    .justfile(
+      r#"
+
+[env("foo", "bar")]
+baz:
+  @echo {{ env("foo") }}.txt
+
+    "#,
+    )
+    .stderr(
+      r#"
+error: Call to function `env` failed: environment variable `foo` not present
+ ——▶ justfile:4:12
+  │
+4 │   @echo {{ env("foo") }}.txt
+  │            ^^^
+
+"#,
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
 fn env_attribute_too_few_arguments() {
   Test::new()
     .justfile(

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -312,3 +312,80 @@ fn shell_expanded_strings_can_be_used_in_attributes() {
     )
     .success();
 }
+
+#[test]
+fn env_attribute_single() {
+  Test::new()
+    .justfile(
+      "
+        [env('MY_VAR', 'my_value')]
+        foo:
+          echo $MY_VAR
+      ",
+    )
+    .stdout("my_value\n")
+    .stderr("echo $MY_VAR\n")
+    .run();
+}
+
+#[test]
+fn env_attribute_multiple() {
+  Test::new()
+    .justfile(
+      "
+        [env('VAR1', 'value1')]
+        [env('VAR2', 'value 2')]
+        foo:
+          echo $VAR1 $VAR2
+      ",
+    )
+    .stdout("value1 value 2\n")
+    .stderr("echo $VAR1 $VAR2\n")
+    .run();
+}
+
+#[test]
+fn env_attribute_1_arg() {
+  Test::new()
+    .justfile(
+      "
+        [env('MY_VAR')]
+        foo:
+          echo bar
+      ",
+    )
+    .stderr(
+      "
+  error: Attribute `env` got 1 argument but takes 2 arguments
+   ——▶ justfile:1:2
+    │
+  1 │ [env('MY_VAR')]
+    │  ^^^
+",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}
+
+#[test]
+fn env_attribute_3_args() {
+  Test::new()
+    .justfile(
+      "
+        [env('A', 'B', 'C')]
+        foo:
+          echo bar
+      ",
+    )
+    .stderr(
+      "
+  error: Attribute `env` got 3 arguments but takes 2 arguments
+   ——▶ justfile:1:2
+    │
+  1 │ [env('A', 'B', 'C')]
+    │  ^^^
+",
+    )
+    .status(EXIT_FAILURE)
+    .run();
+}

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -345,7 +345,7 @@ fn env_attribute_multiple() {
 }
 
 #[test]
-fn env_attribute_1_arg() {
+fn env_attribute_too_few_arguments() {
   Test::new()
     .justfile(
       "
@@ -368,7 +368,7 @@ fn env_attribute_1_arg() {
 }
 
 #[test]
-fn env_attribute_3_args() {
+fn env_attribute_too_many_arguments() {
   Test::new()
     .justfile(
       "

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -324,7 +324,7 @@ fn env_attribute_single() {
       ",
     )
     .stdout("my_value\n")
-    .run();
+    .success();
 }
 
 #[test]
@@ -339,7 +339,7 @@ fn env_attribute_multiple() {
       ",
     )
     .stdout("value1 value 2\n")
-    .run();
+    .success();
 }
 
 #[test]
@@ -353,7 +353,7 @@ baz x=`echo ${foo}.txt`:
 "#,
     )
     .stdout("bar.txt\n")
-    .run();
+    .success();
 }
 
 #[test]
@@ -378,8 +378,7 @@ error: Call to function `env` failed: environment variable `foo` not present
 
 "#,
     )
-    .status(EXIT_FAILURE)
-    .run();
+    .failure();
 }
 
 #[test]
@@ -401,8 +400,7 @@ fn env_attribute_too_few_arguments() {
     │  ^^^
 ",
     )
-    .status(EXIT_FAILURE)
-    .run();
+    .failure();
 }
 
 #[test]
@@ -424,6 +422,5 @@ fn env_attribute_too_many_arguments() {
     │  ^^^
 ",
     )
-    .status(EXIT_FAILURE)
-    .run();
+    .failure();
 }


### PR DESCRIPTION
The env attribute accepts two arguments (env_var, value) and can be used multiple times per recipe to set environment variables without using the existing `$parameter` syntax:

```just
[env('API_KEY', 'secret')]
[env('LOG_LEVEL', 'debug')]
deploy:
    ./deploy.sh
```

Addresses https://github.com/casey/just/issues/2825