### PR TITLE
Fix a typographical error in the rustbook docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,7 +771,7 @@ Available recipes:
     lint
 ```
 
-Recipes in [submodules](#modules1190) can be listed with `just --list PATH`,
+Recipes in [submodules](#modules) can be listed with `just --list PATH`,
 where `PATH` is a space- or `::`-separated module path:
 
 ```


### PR DESCRIPTION
The `modules` anchor link was specified accidentally as `#modules1190` instead of `#modules`.