### PR TITLE
Disable mdbook-linkcheck

### DIFF
--- a/book/en/book.toml
+++ b/book/en/book.toml
@@ -10,4 +10,4 @@ build-dir = "build"
 git-repository-url = "https://github.com/casey/just"
 site-url = "/man/en/"
 
-[output.linkcheck]
+# [output.linkcheck]

--- a/book/zh/book.toml
+++ b/book/zh/book.toml
@@ -10,4 +10,4 @@ build-dir = "build"
 git-repository-url = "https://github.com/casey/just"
 site-url = "/man/zh/"
 
-[output.linkcheck]
+# [output.linkcheck]


### PR DESCRIPTION
`mdbook-linkcheck` seems not to be actively maintained, and is producing errors, so disable it.

There is an [mdbook-linkcheck2](https://github.com/marxin/mdbook-linkcheck2), but it doesn't seem super widely used, so lets wait a little bit before trying it. Hopefully it gets more widely used, so we can be more sure that it's not going to steal our ssh keys or whatever.