### PR TITLE
Add Just icon in SVG format

### DIFF
--- a/www/just.svg
+++ b/www/just.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Just</title><circle cx="12" cy="12" r="12" fill="#000"/><ellipse cx="12" cy="5.7" rx="3.25" ry="3.35" fill="#fff"/><ellipse cx="12" cy="18.3" rx="3.25" ry="3.35" fill="#fff"/></svg>


### PR DESCRIPTION
Hello, I'm a maintainer of [simple-icons](https://github.com/simple-icons/simple-icons).

Simple-icons is the icon provider for shields.io. I would like to add a new SVG icon, Just, to our library, and add an SVG format icon in original repo.

I wanted to ask if you would be happy for us to include the Just icon in our collection?