### PR TITLE
Fix a leak of two pipes into child processes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ unicode-width = "0.2.0"
 uuid = { version = "1.0.0", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.30.1", features = ["signal", "user"] }
+nix = { version = "0.30.1", features = ["signal", "user", "fs"] }
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = { version = "3.1.1", features = ["termination"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -194,6 +194,10 @@ pub(crate) enum Error<'src> {
     source: ctrlc::Error,
   },
   #[cfg(unix)]
+  SignalHandlerPipeCloexec {
+    io_error: io::Error,
+  },
+  #[cfg(unix)]
   SignalHandlerPipeOpen {
     io_error: io::Error,
   },
@@ -704,6 +708,10 @@ impl ColorDisplay for Error<'_> {
       #[cfg(windows)]
       SignalHandlerInstall { source } => {
         write!(f, "Could not install signal handler: {source}")?;
+      }
+      #[cfg(unix)]
+      SignalHandlerPipeCloexec { io_error } => {
+        write!(f, "I/O error setting O_CLOEXEC on pipe for signal handler: {io_error}")?;
       }
       #[cfg(unix)]
       SignalHandlerPipeOpen { io_error } => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -711,11 +711,11 @@ impl ColorDisplay for Error<'_> {
       }
       #[cfg(unix)]
       SignalHandlerPipeCloexec { io_error } => {
-        write!(f, "I/O error setting O_CLOEXEC on pipe for signal handler: {io_error}")?;
+        write!(f, "I/O error setting O_CLOEXEC on signal handler pipe: {io_error}")?;
       }
       #[cfg(unix)]
       SignalHandlerPipeOpen { io_error } => {
-        write!(f, "I/O error opening pipe for signal handler: {io_error}")?;
+        write!(f, "I/O error opening signal handler pipe: {io_error}")?;
       }
       #[cfg(unix)]
       SignalHandlerSigaction { io_error, signal } => {

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -66,8 +66,10 @@ pub(crate) struct Signals(File);
 
 impl Signals {
   pub(crate) fn new() -> RunResult<'static, Self> {
-    let (read, write) = nix::unistd::pipe().map_err(|errno| Error::SignalHandlerPipeOpen {
-      io_error: errno.into(),
+    let (read, write) = nix::unistd::pipe2(nix::fcntl::OFlag::O_CLOEXEC).map_err(|errno| {
+      Error::SignalHandlerPipeOpen {
+        io_error: errno.into(),
+      }
     })?;
 
     if WRITE


### PR DESCRIPTION
Introduced in #2488, which opens a pipe pair without setting the O_CLOEXEC flag on them.

Fixes #3034