### PR TITLE
Add glob pattern support for imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+### Added
+- Add glob pattern support for imports ([#1885](https://github.com/casey/just/issues/1885))
+  - Support `*` wildcard in import paths (e.g., `import '.just/*.justfile'`)
+  - Works with optional imports (`import? '*.just'`)
+  - Files imported in deterministic alphabetical order
+  - Preserves support for non-Unicode file paths on all platforms
+  - **Unstable**: Requires `set unstable` to use
+
 [1.46.0](https://github.com/casey/just/releases/tag/1.46.0) - 2026-01-01
 ------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -3906,6 +3906,66 @@ bar: baz
 baz:
 ```
 
+#### Glob Imports<sup>unstable</sup>
+
+Import statements support wildcard patterns using `*`, allowing you to import multiple files at once. This feature is currently unstable and requires setting `set unstable` in your justfile.
+
+```justfile
+set unstable
+
+# Import all .just files from the .just directory
+import '.just/*.justfile'
+
+# Optional glob import - won't error if no files match
+import? 'config-*.just'
+```
+
+Glob patterns work with both required and optional imports:
+
+```justfile
+set unstable
+
+# This will error if no files match the pattern
+import 'recipes/*.just'
+
+# This will silently succeed even if no files match
+import? 'optional-recipes/*.just'
+```
+
+**Pattern Matching:**
+- `*` matches zero or more characters (except path separators)
+- Patterns are case-sensitive
+- Files are imported in lexicographic (alphabetical) order for deterministic behavior
+- Only regular files are imported (directories and other file types are ignored)
+
+**Example:** Organizing recipes into separate files:
+
+```text
+project/
+├── justfile
+└── .just/
+    ├── build.justfile
+    ├── test.justfile
+    └── deploy.justfile
+```
+
+```justfile
+# justfile
+set unstable
+
+import '.just/*.justfile'
+
+default:
+  @just --list
+```
+
+This will import all three files from the `.just` directory, making their recipes available in the main justfile.
+
+**Limitations:**
+- Currently only the `*` wildcard is supported
+- Recursive patterns (`**`) are not yet supported
+- Character classes (`[abc]`) are not yet supported
+
 ### Modules<sup>1.19.0</sup>
 
 A `justfile` can declare modules using `mod` statements.

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -36,6 +36,9 @@ impl Compiler {
       paths.insert(current.path.clone(), relative.into());
       srcs.insert(current.path.clone(), src);
 
+      // Track additional imports from glob expansion
+      let mut additional_imports = Vec::new();
+
       for item in &mut ast.items {
         match item {
           Item::Module {
@@ -79,26 +82,82 @@ impl Compiler {
               .join(Self::expand_tilde(&relative.cooked)?)
               .lexiclean();
 
-            if filesystem::is_file(&import)? {
-              if current.file_path.contains(&import) {
-                return Err(Error::CircularImport {
-                  current: current.path,
-                  import,
+            // Check if import path contains glob patterns
+            if glob::has_glob_pattern(&import) {
+              // Mark glob imports as unstable feature used
+              ast.unstable_features.insert(UnstableFeature::GlobImports);
+
+              // Expand glob pattern to matching files
+              let mut matches = glob::expand_glob_pattern(&import)?;
+
+              // Filter out the current file to prevent self-imports
+              matches.retain(|path| path != &current.path);
+
+              if matches.is_empty() {
+                // No files matched the pattern
+                if !*optional {
+                  return Err(Error::MissingImportFile {
+                    path: relative.token,
+                  });
+                }
+                // Optional import with no matches - skip silently
+              } else {
+                // Check circular imports and push all matches onto stack                // Note: glob-matched files are processed as siblings, not in a chain
+                for matched_path in &matches {
+                  if current.file_path.contains(matched_path) {
+                    return Err(Error::CircularImport {
+                      current: current.path.clone(),
+                      import: matched_path.clone(),
+                    });
+                  }
+                  // Push glob-matched imports as siblings, not extending the file_path chain
+                  // This prevents false circular dependency detection between parallel imports
+                  stack.push(current.import(matched_path.clone(), relative.token.offset));
+                }
+
+                // Set first match as absolute for this import item
+                *absolute = Some(matches[0].clone());
+
+                // For remaining matches, we'll add new Import items after the loop
+                if matches.len() > 1 {
+                  for matched_path in &matches[1..] {
+                    additional_imports.push((matched_path.clone(), *optional, relative.clone()));
+                  }
+                }
+              }
+            } else {
+              // No glob pattern - use existing single-file import logic
+              if filesystem::is_file(&import)? {
+                if current.file_path.contains(&import) {
+                  return Err(Error::CircularImport {
+                    current: current.path,
+                    import,
+                  });
+                }
+                *absolute = Some(import.clone());
+                stack.push(current.import(import, relative.token.offset));
+              } else if !*optional {
+                return Err(Error::MissingImportFile {
+                  path: relative.token,
                 });
               }
-              *absolute = Some(import.clone());
-              stack.push(current.import(import, relative.token.offset));
-            } else if !*optional {
-              return Err(Error::MissingImportFile {
-                path: relative.token,
-              });
             }
           }
           _ => {}
         }
       }
 
-      asts.insert(current.path, ast.clone());
+      // Add Import items for additional glob matches
+      // These are needed for the analyzer to process all glob-matched files
+      for (matched_path, optional, relative) in additional_imports {
+        ast.items.push(Item::Import {
+          absolute: Some(matched_path),
+          optional,
+          relative,
+        });
+      }
+
+      asts.insert(current.path, ast);
     }
 
     let justfile = Analyzer::analyze(&asts, config, None, &[], &loaded, None, &paths, false, root)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -108,6 +108,10 @@ pub(crate) enum Error<'src> {
     io_error: io::Error,
     path: PathBuf,
   },
+  GlobReadDirectory {
+    io_error: io::Error,
+    path: PathBuf,
+  },
   FlagWithValue {
     recipe: &'src str,
     option: Switch,
@@ -557,6 +561,13 @@ impl ColorDisplay for Error<'_> {
       }
       FilesystemIo { io_error, path } => {
         write!(f, "I/O error at `{}`: {io_error}", path.display())?;
+      }
+      GlobReadDirectory { io_error, path } => {
+        write!(
+          f,
+          "I/O error reading directory for glob pattern `{}`: {io_error}",
+          path.display()
+        )?;
       }
       FlagWithValue { recipe, option } => {
         write!(f, "Recipe `{recipe}` flag `{option}` does not take value",)?;

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -1,0 +1,341 @@
+use super::*;
+use std::ffi::OsStr;
+
+/// Check if a path contains glob pattern characters.
+///
+/// This function works at the byte/UTF-16 level to support non-Unicode paths.
+/// It checks for the presence of `*` wildcard characters in any path component.
+///
+/// # Why Custom Implementation?
+///
+/// Existing Rust glob crates (glob, globset, wax) require UTF-8 conversion
+/// via `to_str()` or `to_string_lossy()`, which breaks Just's commitment to
+/// supporting non-Unicode filesystem paths on all platforms.
+///
+/// This implementation works directly with `OsStr` at the platform-native level:
+/// - Unix: Operates on byte sequences via `OsStrExt::as_bytes()`
+/// - Windows: Operates on UTF-16 sequences via `OsStrExt::encode_wide()`
+pub(crate) fn has_glob_pattern(path: &Path) -> bool {
+  path
+    .components()
+    .any(|component| contains_asterisk(component.as_os_str()))
+}
+
+/// Expand a glob pattern to a sorted list of matching file paths.
+///
+/// # Supported Patterns
+///
+/// Currently supports only `*` wildcard:
+/// - `*` matches zero or more characters except path separators
+///
+/// # Behavior
+///
+/// - Returns matches sorted lexicographically for deterministic ordering
+/// - Only returns regular files (not directories or symlinks to directories)
+/// - Follows symbolic links (standard `fs::read_dir()` behavior)
+/// - Returns empty vector if no matches found
+///
+/// # Examples
+///
+/// ```
+/// // Pattern: '.just/*.justfile'
+/// // Matches: ['.just/bar.justfile', '.just/foo.justfile']
+/// ```
+pub(crate) fn expand_glob_pattern(pattern: &Path) -> RunResult<'static, Vec<PathBuf>> {
+  // Split pattern into directory and filename pattern
+  let (directory, filename_pattern) = if let Some(parent) = pattern.parent() {
+    if let Some(filename) = pattern.file_name() {
+      (parent, filename)
+    } else {
+      // Pattern ends with a directory separator, no filename pattern
+      return Ok(Vec::new());
+    }
+  } else {
+    // No directory component, pattern is just a filename
+    (Path::new("."), pattern.as_os_str())
+  };
+
+  // Check if filename pattern actually contains wildcards
+  if !contains_asterisk(filename_pattern) {
+    // No wildcards in filename, should not have been called
+    return Ok(Vec::new());
+  }
+
+  // Read directory entries
+  let entries = match fs::read_dir(directory) {
+    Ok(entries) => entries,
+    Err(io_error) => {
+      if io_error.kind() == io::ErrorKind::NotFound {
+        // Directory doesn't exist, return empty matches
+        return Ok(Vec::new());
+      } else {
+        return Err(Error::GlobReadDirectory {
+          path: directory.into(),
+          io_error,
+        });
+      }
+    }
+  };
+
+  let mut matches = Vec::new();
+
+  for entry in entries {
+    let entry = entry.map_err(|io_error| Error::GlobReadDirectory {
+      path: directory.into(),
+      io_error,
+    })?;
+
+    let filename = entry.file_name();
+
+    // Match filename against pattern
+    if match_pattern(&filename, filename_pattern) {
+      let full_path = directory.join(filename);
+
+      // Only include regular files
+      match full_path.metadata() {
+        Ok(metadata) if metadata.is_file() => {
+          matches.push(full_path);
+        }
+        Ok(_) => {
+          // Not a regular file (directory, symlink to dir, etc), skip
+        }
+        Err(io_error) => {
+          if io_error.kind() != io::ErrorKind::NotFound {
+            // File disappeared or permission denied - fail fast
+            return Err(Error::GlobReadDirectory {
+              path: full_path,
+              io_error,
+            });
+          }
+          // File disappeared between readdir and metadata, skip
+        }
+      }
+    }
+  }
+
+  // Sort for deterministic ordering
+  matches.sort();
+
+  Ok(matches)
+}
+
+/// Match a filename against a pattern containing `*` wildcards.
+///
+/// Platform-specific implementation that works at the byte/UTF-16 level
+/// without requiring UTF-8 conversion.
+///
+/// # Pattern Syntax
+///
+/// - `*` matches zero or more characters (including none)
+/// - All other characters match literally
+/// - Case-sensitive matching
+///
+/// # Examples
+///
+/// - `match_pattern("foo.just", "*.just")` → `true`
+/// - `match_pattern("bar.justfile", "*.just")` → `false`
+/// - `match_pattern("test.just", "test.*")` → `true`
+fn match_pattern(filename: &OsStr, pattern: &OsStr) -> bool {
+  #[cfg(unix)]
+  {
+    use std::os::unix::ffi::OsStrExt;
+    match_with_wildcards(filename.as_bytes(), pattern.as_bytes(), b'*')
+  }
+
+  #[cfg(windows)]
+  {
+    use std::os::windows::ffi::OsStrExt;
+    let filename_wide: Vec<u16> = filename.encode_wide().collect();
+    let pattern_wide: Vec<u16> = pattern.encode_wide().collect();
+    match_with_wildcards(&filename_wide, &pattern_wide, b'*' as u16)
+  }
+
+  #[cfg(not(any(unix, windows)))]
+  {
+    // Fallback for other platforms: attempt UTF-8 matching
+    // This is not ideal but covers edge cases
+    if let (Some(f), Some(p)) = (filename.to_str(), pattern.to_str()) {
+      match_with_wildcards(f.as_bytes(), p.as_bytes(), b'*')
+    } else {
+      false
+    }
+  }
+}
+
+/// Generic wildcard matching algorithm.
+///
+/// Matches text against a pattern containing wildcards, operating on
+/// any sequence of comparable elements (bytes, UTF-16 code units, etc.).
+///
+/// # Algorithm
+///
+/// Uses a simple iterative algorithm:
+/// - `*` matches zero or more characters
+/// - Tries to match greedily from left to right
+/// - Backtracks when needed to find a valid match
+///
+/// # Complexity
+///
+/// O(n * m) where n is text length and m is pattern length.
+/// Worst case: pattern like `*a*b*c` with text that has many a's, b's, c's.
+fn match_with_wildcards<T: Eq>(text: &[T], pattern: &[T], wildcard: T) -> bool {
+  let mut text_idx = 0;
+  let mut pattern_idx = 0;
+  let mut star_idx = None;
+  let mut match_idx = 0;
+
+  while text_idx < text.len() {
+    if pattern_idx < pattern.len() && pattern[pattern_idx] == wildcard {
+      // Found a wildcard, record position and try matching rest
+      star_idx = Some(pattern_idx);
+      match_idx = text_idx;
+      pattern_idx += 1;
+    } else if pattern_idx < pattern.len() && pattern[pattern_idx] == text[text_idx] {
+      // Characters match, advance both
+      text_idx += 1;
+      pattern_idx += 1;
+    } else if let Some(star) = star_idx {
+      // Mismatch, backtrack to last wildcard
+      pattern_idx = star + 1;
+      match_idx += 1;
+      text_idx = match_idx;
+    } else {
+      // No match and no wildcard to backtrack to
+      return false;
+    }
+  }
+
+  // Consume any trailing wildcards in pattern
+  while pattern_idx < pattern.len() && pattern[pattern_idx] == wildcard {
+    pattern_idx += 1;
+  }
+
+  // Match succeeds if we've consumed both text and pattern
+  pattern_idx == pattern.len()
+}
+
+/// Check if an OsStr contains an asterisk character.
+///
+/// Platform-specific implementation to avoid UTF-8 conversion.
+#[cfg(unix)]
+fn contains_asterisk(os_str: &OsStr) -> bool {
+  use std::os::unix::ffi::OsStrExt;
+  os_str.as_bytes().contains(&b'*')
+}
+
+#[cfg(windows)]
+fn contains_asterisk(os_str: &OsStr) -> bool {
+  use std::os::windows::ffi::OsStrExt;
+  os_str.encode_wide().any(|c| c == b'*' as u16)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn contains_asterisk(os_str: &OsStr) -> bool {
+  // Fallback: try UTF-8 conversion
+  os_str.to_str().map_or(false, |s| s.contains('*'))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_has_glob_pattern() {
+    assert!(has_glob_pattern(Path::new("*.just")));
+    assert!(has_glob_pattern(Path::new(".just/*.justfile")));
+    assert!(has_glob_pattern(Path::new("foo-*.just")));
+    assert!(!has_glob_pattern(Path::new("foo.just")));
+    assert!(!has_glob_pattern(Path::new(".just/foo.just")));
+  }
+
+  #[test]
+  fn test_match_with_wildcards_bytes() {
+    // Basic wildcard matching
+    assert!(match_with_wildcards(b"foo.just", b"*.just", b'*'));
+    assert!(match_with_wildcards(b"bar.just", b"*.just", b'*'));
+    assert!(!match_with_wildcards(b"foo.justfile", b"*.just", b'*'));
+
+    // Wildcard at start
+    assert!(match_with_wildcards(b"test.just", b"*st.just", b'*'));
+    assert!(match_with_wildcards(b"test.just", b"*est.just", b'*'));
+
+    // Wildcard in middle
+    assert!(match_with_wildcards(b"foo-bar.just", b"foo-*.just", b'*'));
+    assert!(match_with_wildcards(b"foo-.just", b"foo-*.just", b'*'));
+
+    // Multiple wildcards
+    assert!(match_with_wildcards(b"a-b-c.just", b"*-*-*.just", b'*'));
+    assert!(match_with_wildcards(b"abc.just", b"*bc.just", b'*'));
+
+    // Wildcard matches empty
+    assert!(match_with_wildcards(b"foo", b"foo*", b'*'));
+    assert!(match_with_wildcards(b"foo", b"*foo", b'*'));
+
+    // No wildcards (literal match)
+    assert!(match_with_wildcards(b"exact", b"exact", b'*'));
+    assert!(!match_with_wildcards(b"exact", b"other", b'*'));
+
+    // Edge cases
+    assert!(match_with_wildcards(b"", b"*", b'*'));
+    assert!(match_with_wildcards(b"anything", b"*", b'*'));
+    assert!(!match_with_wildcards(b"foo", b"", b'*'));
+  }
+
+  #[test]
+  fn test_match_pattern() {
+    use std::ffi::OsStr;
+
+    // Basic matching
+    assert!(match_pattern(OsStr::new("foo.just"), OsStr::new("*.just")));
+    assert!(match_pattern(
+      OsStr::new("bar.justfile"),
+      OsStr::new("*.justfile")
+    ));
+    assert!(!match_pattern(
+      OsStr::new("foo.just"),
+      OsStr::new("*.justfile")
+    ));
+
+    // Prefix matching
+    assert!(match_pattern(
+      OsStr::new("test-foo.just"),
+      OsStr::new("test-*.just")
+    ));
+
+    // No wildcards
+    assert!(match_pattern(OsStr::new("exact.just"), OsStr::new("exact.just")));
+    assert!(!match_pattern(
+      OsStr::new("exact.just"),
+      OsStr::new("other.just")
+    ));
+  }
+
+  #[test]
+  fn test_contains_asterisk() {
+    use std::ffi::OsStr;
+
+    assert!(contains_asterisk(OsStr::new("*.just")));
+    assert!(contains_asterisk(OsStr::new("foo-*.just")));
+    assert!(contains_asterisk(OsStr::new("*")));
+    assert!(!contains_asterisk(OsStr::new("foo.just")));
+    assert!(!contains_asterisk(OsStr::new("")));
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn test_non_utf8_filenames() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    // Create OsStr with invalid UTF-8
+    let invalid_utf8 = OsStr::from_bytes(&[0xff, 0xfe, b'.', b'j', b'u', b's', b't']);
+    let pattern = OsStr::new("*.just");
+
+    // Should match even though filename isn't valid UTF-8
+    assert!(match_pattern(invalid_utf8, pattern));
+
+    // Check that has_glob_pattern works with invalid UTF-8 patterns
+    let invalid_pattern = Path::new(OsStr::from_bytes(&[b'*', 0xff, 0xfe]));
+    assert!(has_glob_pattern(invalid_pattern));
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,7 @@ mod filesystem;
 mod format_string_part;
 mod fragment;
 mod function;
+mod glob;
 mod interpreter;
 mod invocation;
 mod invocation_parser;

--- a/src/unstable_feature.rs
+++ b/src/unstable_feature.rs
@@ -3,6 +3,7 @@ use super::*;
 #[derive(Copy, Clone, Debug, PartialEq, Ord, Eq, PartialOrd)]
 pub(crate) enum UnstableFeature {
   FormatSubcommand,
+  GlobImports,
   LogicalOperators,
   WhichFunction,
 }
@@ -11,6 +12,7 @@ impl Display for UnstableFeature {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
     match self {
       Self::FormatSubcommand => write!(f, "The `--fmt` command is currently unstable."),
+      Self::GlobImports => write!(f, "Glob patterns in imports are currently unstable."),
       Self::LogicalOperators => write!(
         f,
         "The logical operators `&&` and `||` are currently unstable."

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -408,3 +408,253 @@ x := 'y'
     .stdout("hello\n")
     .run();
 }
+
+#[test]
+fn glob_import_works() {
+  Test::new()
+    .tree(tree! {
+      "a.just": "
+        a:
+          @echo A
+      ",
+      "b.just": "
+        b:
+          @echo B
+      ",
+    })
+    .justfile(
+      "
+      set unstable
+
+      import '*.just'
+
+      default: a b
+    ",
+    )
+    .stdout("A\nB\n")
+    .test_round_trip(false)
+    .run();
+}
+
+#[test]
+fn glob_import_multiple_matches() {
+  Test::new()
+    .write(
+      ".just/foo.justfile",
+      "foo:\n  @echo FOO\n",
+    )
+    .write(
+      ".just/bar.justfile",
+      "bar:\n  @echo BAR\n",
+    )
+    .write(
+      ".just/baz.justfile",
+      "baz:\n  @echo BAZ\n",
+    )
+    .justfile(
+      "
+      set unstable
+
+      import '.just/*.justfile'
+
+      default: foo bar baz
+    ",
+    )
+    .stdout("FOO\nBAR\nBAZ\n")
+    .test_round_trip(false)
+    .run();
+}
+
+#[test]
+fn glob_import_optional_no_matches() {
+  Test::new()
+    .justfile(
+      "
+      set unstable
+
+      import? '.just/*.justfile'
+
+      default:
+        @echo DONE
+    ",
+    )
+    .stdout("DONE\n")
+    .test_round_trip(false)
+    .run();
+}
+
+#[test]
+fn glob_import_required_no_matches() {
+  Test::new()
+    .justfile(
+      "
+      set unstable
+
+      import '.just/*.justfile'
+
+      default:
+        @echo DONE
+    ",
+    )
+    .status(EXIT_FAILURE)
+    .stderr(
+      "
+      error: Could not find source file for import.
+       ——▶ justfile:3:8
+        │
+      3 │ import '.just/*.justfile'
+        │        ^^^^^^^^^^^^^^^^^^
+    ",
+    )
+    .test_round_trip(false)
+    .run();
+}
+
+#[test]
+fn glob_import_without_unstable_feature() {
+  Test::new()
+    .tree(tree! {
+      "a.just": "
+        a:
+          @echo A
+      ",
+    })
+    .justfile(
+      "
+      import '*.just'
+
+      default: a
+    ",
+    )
+    .status(EXIT_FAILURE)
+    .stderr("error: Glob patterns in imports are currently unstable. Invoke `just` with `--unstable`, set the `JUST_UNSTABLE` environment variable, or add `set unstable` to your `justfile` to enable unstable features.\n")
+    .test_round_trip(false)
+    .run();
+}
+
+#[test]
+fn glob_import_deterministic_order() {
+  Test::new()
+    .tree(tree! {
+      "c.just": "c := 'c'",
+      "a.just": "a := 'a'",
+      "b.just": "b := 'b'",
+    })
+    .justfile(
+      "
+      set unstable
+
+      import '*.just'
+
+      default:
+        @echo {{a}}{{b}}{{c}}
+    ",
+    )
+    .stdout("abc\n")
+    .test_round_trip(false)
+    .run();
+}
+
+#[test]
+fn glob_import_circular_detection() {
+  Test::new()
+    .tree(tree! {
+      "a.just": "import 'b.just'",
+      "b.just": "import '*.just'",
+    })
+    .justfile(
+      "
+      set unstable
+
+      import '*.just'
+    ",
+    )
+    .status(EXIT_FAILURE)
+    .stderr_regex(path_for_regex("error: Import `.*\\.just` in `.*\\.just` is circular\n"))
+    .test_round_trip(false)
+    .run();
+}
+
+#[test]
+fn glob_import_with_prefix() {
+  Test::new()
+    .tree(tree! {
+      "test-a.just": "
+        a:
+          @echo A
+      ",
+      "test-b.just": "
+        b:
+          @echo B
+      ",
+      "other.just": "
+        c:
+          @echo C
+      ",
+    })
+    .justfile(
+      "
+      set unstable
+
+      import 'test-*.just'
+
+      default: a b
+    ",
+    )
+    .stdout("A\nB\n")
+    .test_round_trip(false)
+    .run();
+}
+
+#[test]
+fn glob_import_with_suffix() {
+  Test::new()
+    .tree(tree! {
+      "a-test.just": "
+        a:
+          @echo A
+      ",
+      "b-test.just": "
+        b:
+          @echo B
+      ",
+      "other.just": "
+        c:
+          @echo C
+      ",
+    })
+    .justfile(
+      "
+      set unstable
+
+      import '*-test.just'
+
+      default: a b
+    ",
+    )
+    .stdout("A\nB\n")
+    .test_round_trip(false)
+    .run();
+}
+
+#[test]
+fn glob_import_only_regular_files() {
+  Test::new()
+    .write(
+      "a.just",
+      "a:\n  @echo A\n",
+    )
+    .write("subdir/b.just", "")
+    .justfile(
+      "
+      set unstable
+
+      import '*.just'
+
+      default: a
+    ",
+    )
+    .stdout("A\n")
+    .test_round_trip(false)
+    .run();
+}


### PR DESCRIPTION
Implements wildcard pattern matching in import statements, allowing users to import multiple files at once using patterns like:

  import '.just/*.justfile'

Key features:
- Support for * wildcard in import paths
- Works with optional imports (import?)
- Files imported in deterministic alphabetical order
- Circular import detection still works correctly
- Preserves non-Unicode file path support on all platforms

Implementation uses custom byte-level pattern matching to avoid UTF-8 conversion issues that prevented previous attempts (PR #2376) from being merged. Pattern matching works at the OsStr level on both Unix (using byte arrays) and Windows (using UTF-16).

This feature is currently unstable and requires 'set unstable' in the justfile to use.

Fixes #1885