### PR TITLE
Correct spelling typos in `/src`.

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -114,10 +114,10 @@ impl<'src, 'run> Evaluator<'src, 'run> {
           settings.quiet = value;
         }
         Setting::ScriptInterpreter(value) => {
-          settings.script_interpreter = Some(self.evaluate_intepreter(&value)?);
+          settings.script_interpreter = Some(self.evaluate_interpreter(&value)?);
         }
         Setting::Shell(value) => {
-          settings.shell = Some(self.evaluate_intepreter(&value)?);
+          settings.shell = Some(self.evaluate_interpreter(&value)?);
         }
         Setting::Unstable(value) => {
           settings.unstable = value;
@@ -126,7 +126,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
           settings.windows_powershell = value;
         }
         Setting::WindowsShell(value) => {
-          settings.windows_shell = Some(self.evaluate_intepreter(&value)?);
+          settings.windows_shell = Some(self.evaluate_interpreter(&value)?);
         }
         Setting::Tempdir(value) => {
           settings.tempdir = Some(self.evaluate_expression(&value)?);
@@ -140,7 +140,7 @@ impl<'src, 'run> Evaluator<'src, 'run> {
     Ok(settings)
   }
 
-  pub(crate) fn evaluate_intepreter(
+  pub(crate) fn evaluate_interpreter(
     &mut self,
     interpreter: &Interpreter<Expression<'src>>,
   ) -> RunResult<'src, Interpreter<String>> {

--- a/src/output_error.rs
+++ b/src/output_error.rs
@@ -35,7 +35,7 @@ impl Display for OutputError {
       Self::Code(code) => write!(f, "Process exited with status code {code}"),
       Self::Interrupted(signal) => write!(
         f,
-        "Process succeded but `just` was interrupted by signal {signal}"
+        "Process succeeded but `just` was interrupted by signal {signal}"
       ),
       Self::Io(ref io_error) => write!(f, "Error executing process: {io_error}"),
       Self::Signal(signal) => write!(f, "Process terminated by signal {signal}"),

--- a/src/recipe_resolver.rs
+++ b/src/recipe_resolver.rs
@@ -125,7 +125,7 @@ impl<'src: 'run, 'run> RecipeResolver<'src, 'run> {
     let name = dependency.recipe.last().lexeme();
 
     if dependency.recipe.components() > 1 {
-      // recipe is in a submodule and is thus already resovled
+      // recipe is in a submodule and is thus already resolved
       Ok(Analyzer::resolve_recipe(
         &dependency.recipe,
         self.modules,


### PR DESCRIPTION
- The command `uvx typos` was used to identify issues.
  - https://docs.astral.sh/uv/guides/tools/
  - https://github.com/crate-ci/typos
- The variable name change `evaluate_intepreter` to `evaluate_interpreter` was done with LSP rename to ensure all references visible to LSP were made consistently.
- Another change was fixing a spelling typo in a string.
- One change was made to a comment, which should not have any functional change.

This is my first PR to this repo so please provide feedback if there are requirements that this PR has not satisfied.