### PR TITLE
Allow to link to Installations documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ always welcome!
 Installation
 ------------
 
+This section will guide you on how to install Just on your system.
+
 ### Prerequisites
 
 `just` should run on any system with a reasonable `sh`, including Linux, MacOS,


### PR DESCRIPTION
Add a way to link to https://just.systems/man/en/installation.html

I'd like to be able to point to the `just` installation instructions in the doc, but 
https://just.systems/man/en/installation.html
does not exist.

In https://just.systems/man/en the Installation section can't be accessed / clicked on.
<img width="567" height="304" alt="image" src="https://github.com/user-attachments/assets/771cb755-bc3b-4ef2-ab55-7959ee8806d8" />

The only way to link to the installation instruction is to use: https://github.com/casey/just/blob/master/README.md#installation \
But It's a pity not to point to just.systems, which looks nicer.



I think the issue is because there is no text in the Installation section, so I'm adding some.
(see e.g. https://just.systems/man/en/examples.html which has text there and where it works).

Note: 
other sections have the same problem:
* https://github.com/casey/just/blob/master/README.md?plain=1#L715
* https://github.com/casey/just/blob/master/README.md?plain=1#L4293
* https://github.com/casey/just/blob/master/README.md?plain=1#L4748

I can add similar updates if the idea sounds good.