### PR TITLE
Add attribute support for other BSD variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -2148,6 +2148,9 @@ change their behavior.
 | `[no-exit-message]`<sup>1.7.0</sup> | recipe | Don't print an error message if recipe fails. |
 | `[no-quiet]`<sup>1.23.0</sup> | recipe | Override globally quiet recipes and always echo out the recipe. |
 | `[openbsd]`<sup>1.38.0</sup> | recipe | Enable recipe on OpenBSD. |
+| `[freebsd]`<sup>master</sup> | recipe | Enable recipe on FreeBSD. |
+| `[dragonfly]`<sup>master</sup> | recipe | Enable recipe on Dragonfly. |
+| `[netbsd]`<sup>master</sup> | recipe | Enable recipe on NetBSD. |
 | `[parallel]`<sup>1.42.0</sup> | recipe | Run this recipe's dependencies in parallel. |
 | `[positional-arguments]`<sup>1.29.0</sup> | recipe | Turn on [positional arguments](#positional-arguments) for this recipe. |
 | `[private]`<sup>1.10.0</sup> | alias, recipe | Make recipe, alias, or variable private. See [Private Recipes](#private-recipes). |

--- a/crates-io-readme.md
+++ b/crates-io-readme.md
@@ -19,6 +19,6 @@ test TEST: build
 `just` produces detailed error messages and avoids `make`'s idiosyncrasies, so
 debugging a justfile is easier and less surprising than debugging a makefile.
 
-It works on all operating systems supported by Rust.
+It works on Linux, MacOS, Windows, and BSD variants OpenBSD, FreeBSD, Dragonfly, and NetBSD.
 
 Read more on [GitHub](https://github.com/casey/just).

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -33,6 +33,9 @@ pub(crate) enum Attribute<'src> {
   NoExitMessage,
   NoQuiet,
   Openbsd,
+  Freebsd,
+  Dragonfly,
+  Netbsd,
   Parallel,
   PositionalArguments,
   Private,
@@ -53,6 +56,9 @@ impl AttributeDiscriminant {
       | Self::NoExitMessage
       | Self::NoQuiet
       | Self::Openbsd
+      | Self::Freebsd
+      | Self::Dragonfly
+      | Self::Netbsd
       | Self::Parallel
       | Self::PositionalArguments
       | Self::Private
@@ -189,6 +195,9 @@ impl<'src> Attribute<'src> {
       AttributeDiscriminant::NoExitMessage => Self::NoExitMessage,
       AttributeDiscriminant::NoQuiet => Self::NoQuiet,
       AttributeDiscriminant::Openbsd => Self::Openbsd,
+      AttributeDiscriminant::Freebsd => Self::Freebsd,
+      AttributeDiscriminant::Dragonfly => Self::Dragonfly,
+      AttributeDiscriminant::Netbsd => Self::Netbsd,
       AttributeDiscriminant::Parallel => Self::Parallel,
       AttributeDiscriminant::PositionalArguments => Self::PositionalArguments,
       AttributeDiscriminant::Private => Self::Private,
@@ -296,6 +305,9 @@ impl Display for Attribute<'_> {
       | Self::NoExitMessage
       | Self::NoQuiet
       | Self::Openbsd
+      | Self::Freebsd
+      | Self::Dragonfly
+      | Self::Netbsd
       | Self::Parallel
       | Self::PositionalArguments
       | Self::Private

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -157,13 +157,19 @@ impl<'src, D> Recipe<'src, D> {
     let linux = self.attributes.contains(AttributeDiscriminant::Linux);
     let macos = self.attributes.contains(AttributeDiscriminant::Macos);
     let openbsd = self.attributes.contains(AttributeDiscriminant::Openbsd);
+    let freebsd = self.attributes.contains(AttributeDiscriminant::Freebsd);
+    let dragonfly = self.attributes.contains(AttributeDiscriminant::Dragonfly);
+    let netbsd = self.attributes.contains(AttributeDiscriminant::Netbsd);
     let unix = self.attributes.contains(AttributeDiscriminant::Unix);
     let windows = self.attributes.contains(AttributeDiscriminant::Windows);
 
-    (!windows && !linux && !macos && !openbsd && !unix)
+    (!windows && !linux && !macos && !openbsd && !freebsd && !dragonfly && !netbsd && !unix)
       || (cfg!(target_os = "linux") && (linux || unix))
       || (cfg!(target_os = "macos") && (macos || unix))
       || (cfg!(target_os = "openbsd") && (openbsd || unix))
+      || (cfg!(target_os = "freebsd") && (freebsd || unix))
+      || (cfg!(target_os = "dragonfly") && (dragonfly || unix))
+      || (cfg!(target_os = "netbsd") && (netbsd || unix))
       || (cfg!(target_os = "windows") && windows)
       || (cfg!(unix) && unix)
       || (cfg!(windows) && windows)

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -8,6 +8,9 @@ fn all() {
       [macos]
       [linux]
       [openbsd]
+      [freebsd]
+      [dragonfly]
+      [netbsd]
       [unix]
       [windows]
       [no-exit-message]
@@ -47,7 +50,7 @@ fn multiple_attributes_one_line() {
   Test::new()
     .justfile(
       "
-      [macos,windows,linux,openbsd]
+      [macos,windows,linux,openbsd,freebsd,dragonfly,netbsd]
       [no-exit-message]
       foo:
         exit 1
@@ -62,7 +65,7 @@ fn multiple_attributes_one_line_error_message() {
   Test::new()
     .justfile(
       "
-      [macos,windows linux,openbsd]
+      [macos,windows linux,openbsd,freebsd,dragonfly,netbsd]
       [no-exit-message]
       foo:
         exit 1
@@ -73,7 +76,7 @@ fn multiple_attributes_one_line_error_message() {
         error: Expected ']', ':', ',', or '(', but found identifier
          ——▶ justfile:1:16
           │
-        1 │ [macos,windows linux,openbsd]
+        1 │ [macos,windows linux,openbsd,freebsd,dragonfly,netbsd]
           │                ^^^^^
           ",
     )
@@ -85,7 +88,7 @@ fn multiple_attributes_one_line_duplicate_check() {
   Test::new()
     .justfile(
       "
-      [macos, windows, linux, openbsd]
+      [macos, windows, linux, openbsd, freebsd, dragonfly, netbsd]
       [linux]
       foo:
         exit 1

--- a/tests/os_attributes.rs
+++ b/tests/os_attributes.rs
@@ -51,6 +51,18 @@ fn os() {
       [openbsd]
       foo:
         echo bob
+
+      [freebsd]
+      foo:
+        echo corge
+
+      [dragonfly]
+      foo:
+        echo grault
+
+      [netbsd]
+      foo:
+        echo garply
     ",
     )
     .stdout(if cfg!(target_os = "macos") {
@@ -61,6 +73,12 @@ fn os() {
       "quxx\n"
     } else if cfg!(target_os = "openbsd") {
       "bob\n"
+    } else if cfg!(target_os = "freebsd") {
+      "corge\n"
+    } else if cfg!(target_os = "dragonfly") {
+      "grault\n"
+    } else if cfg!(target_os = "netbsd") {
+      "garply\n"
     } else {
       panic!("unexpected os family")
     })
@@ -72,6 +90,12 @@ fn os() {
       "echo quxx\n"
     } else if cfg!(target_os = "openbsd") {
       "echo bob\n"
+    } else if cfg!(target_os = "freebsd") {
+      "echo corge\n"
+    } else if cfg!(target_os = "dragonfly") {
+      "echo grault\n"
+    } else if cfg!(target_os = "netbsd") {
+      "echo garply\n"
     } else {
       panic!("unexpected os family")
     })
@@ -86,6 +110,9 @@ fn all() {
       [linux]
       [macos]
       [openbsd]
+      [freebsd]
+      [dragonfly]
+      [netbsd]
       [unix]
       [windows]
       foo:


### PR DESCRIPTION
Support BSD variants FreeBSD, Dragonfly, and NetBSD.  These are the remaining main BSD variants listed [in the Rust documentation for `target_os`](https://doc.rust-lang.org/reference/conditional-compilation.html#target_os).

See also #2497, which added support for OpenBSD.

This may also help towards a complete solution for #1682.