### PR TITLE
Force UTF-8 with BOM for Windows PowerShell shebang recipes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub(crate) use {
     expression::Expression,
     format_string_part::FormatStringPart,
     fragment::Fragment,
+    fs::File,
     function::Function,
     interpreter::Interpreter,
     invocation::Invocation,

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -467,10 +467,24 @@ impl<'src, D> Recipe<'src, D> {
       eprintln!("{}", config.color.doc().stderr().paint(&script));
     }
 
-    fs::write(&path, script).map_err(|error| Error::TempdirIo {
-      recipe: self.name(),
-      io_error: error,
-    })?;
+    let interpreter = match &executor {
+      Executor::Shebang(shebang) => shebang.interpreter,
+      Executor::Command(command) => command.command.as_str(),
+    };
+    let preamble = match interpreter.to_lowercase().as_str() {
+      "powershell" | "powershell.exe" => "\u{FEFF}",
+      _ => "",
+    };
+
+    File::create(&path)
+      .and_then(|mut f| {
+        f.write_all(preamble.as_ref())?;
+        f.write_all(script.as_ref())
+      })
+      .map_err(|error| Error::TempdirIo {
+        recipe: self.name(),
+        io_error: error,
+      })?;
 
     let mut command = executor.command(
       config,


### PR DESCRIPTION
As explained in #3094, Windows PowerShell support is not full due to encoding issues.

The default encoding (codepage) used by `conhost.exe` (Console Window Host) may vary depending on the display language and region of the system (e.g. 437 for US English, 850 for Western European languages), but it's certainly never 65001 for UTF-8 (still an experimental feature). Moreover, even if UTF-8 was the default codepage, correct execution should not depend on system-wide settings that can potentially be changed.

Forcing the UTF-8 Byte Order Mark to be present when the shebang recipe is for Windows PowerShell fixes most (if not all) output encoding issues.