### PR TITLE
Avoid compilation for justfile formatting

### DIFF
--- a/src/compilation.rs
+++ b/src/compilation.rs
@@ -5,15 +5,10 @@ pub(crate) struct Compilation<'src> {
   pub(crate) asts: HashMap<PathBuf, Ast<'src>>,
   pub(crate) justfile: Justfile<'src>,
   pub(crate) root: PathBuf,
-  pub(crate) srcs: HashMap<PathBuf, &'src str>,
 }
 
 impl<'src> Compilation<'src> {
   pub(crate) fn root_ast(&self) -> &Ast<'src> {
     self.asts.get(&self.root).unwrap()
-  }
-
-  pub(crate) fn root_src(&self) -> &'src str {
-    self.srcs.get(&self.root).unwrap()
   }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -241,41 +241,6 @@ mod tests {
   use {super::*, temptree::temptree};
 
   #[test]
-  fn include_justfile() {
-    let justfile_a = r#"
-# A comment at the top of the file
-import "./justfile_b"
-
-#some_recipe: recipe_b
-some_recipe:
-    echo "some recipe"
-"#;
-
-    let justfile_b = r#"import "./subdir/justfile_c"
-
-recipe_b: recipe_c
-    echo "recipe b"
-"#;
-
-    let justfile_c = r#"recipe_c:
-    echo "recipe c"
-"#;
-
-    let tmp = temptree! {
-        justfile: justfile_a,
-        justfile_b: justfile_b,
-        subdir: {
-            justfile_c: justfile_c
-        }
-    };
-
-    let loader = Loader::new();
-
-    let justfile_a_path = tmp.path().join("justfile");
-    Compiler::compile(&Config::default(), &loader, &justfile_a_path).unwrap();
-  }
-
-  #[test]
   fn recursive_includes_fail() {
     let tmp = temptree! {
       justfile: "import './subdir/b'\na: b",

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -11,8 +11,6 @@ impl Compiler {
     let mut asts = HashMap::<PathBuf, Ast>::new();
     let mut loaded = Vec::new();
     let mut paths = HashMap::<PathBuf, PathBuf>::new();
-    let mut srcs = HashMap::<PathBuf, &str>::new();
-
     let mut stack = Vec::new();
     stack.push(Source::root(root));
 
@@ -34,7 +32,6 @@ impl Compiler {
       )?;
 
       paths.insert(current.path.clone(), relative.into());
-      srcs.insert(current.path.clone(), src);
 
       for item in &mut ast.items {
         match item {
@@ -107,7 +104,6 @@ impl Compiler {
       asts,
       justfile,
       root: root.into(),
-      srcs,
     })
   }
 
@@ -276,9 +272,7 @@ recipe_b: recipe_c
     let loader = Loader::new();
 
     let justfile_a_path = tmp.path().join("justfile");
-    let compilation = Compiler::compile(&Config::default(), &loader, &justfile_a_path).unwrap();
-
-    assert_eq!(compilation.root_src(), justfile_a);
+    Compiler::compile(&Config::default(), &loader, &justfile_a_path).unwrap();
   }
 
   #[test]

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -3,6 +3,22 @@ use super::*;
 pub(crate) struct Compiler;
 
 impl Compiler {
+  pub(crate) fn parse<'src>(
+    path: &'src Path,
+    src: &'src str,
+    source: &Source<'src>,
+  ) -> CompileResult<'src, Ast<'src>> {
+    let tokens = Lexer::lex(path, src)?;
+
+    Parser::parse(
+      source.file_depth,
+      &source.import_offsets,
+      source.namepath.as_ref(),
+      &tokens,
+      &source.working_directory,
+    )
+  }
+
   pub(crate) fn compile<'src>(
     config: &Config,
     loader: &'src Loader,
@@ -21,15 +37,7 @@ impl Compiler {
 
       let (relative, src) = loader.load(root, &current.path)?;
       loaded.push(relative.into());
-
-      let tokens = Lexer::lex(relative, src)?;
-      let mut ast = Parser::parse(
-        current.file_depth,
-        &current.import_offsets,
-        current.namepath.as_ref(),
-        &tokens,
-        &current.working_directory,
-      )?;
+      let mut ast = Self::parse(relative, src, &current)?;
 
       paths.insert(current.path.clone(), relative.into());
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -3,22 +3,6 @@ use super::*;
 pub(crate) struct Compiler;
 
 impl Compiler {
-  pub(crate) fn parse<'src>(
-    path: &'src Path,
-    src: &'src str,
-    source: &Source<'src>,
-  ) -> CompileResult<'src, Ast<'src>> {
-    let tokens = Lexer::lex(path, src)?;
-
-    Parser::parse(
-      source.file_depth,
-      &source.import_offsets,
-      source.namepath.as_ref(),
-      &tokens,
-      &source.working_directory,
-    )
-  }
-
   pub(crate) fn compile<'src>(
     config: &Config,
     loader: &'src Loader,
@@ -37,7 +21,7 @@ impl Compiler {
 
       let (relative, src) = loader.load(root, &current.path)?;
       loaded.push(relative.into());
-      let mut ast = Self::parse(relative, src, &current)?;
+      let mut ast = Parser::parse_source(relative, src, &current)?;
 
       paths.insert(current.path.clone(), relative.into());
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -58,6 +58,22 @@ impl<'run, 'src> Parser<'run, 'src> {
     .parse_ast()
   }
 
+  pub(crate) fn parse_source(
+    path: &'src Path,
+    src: &'src str,
+    source: &Source<'src>,
+  ) -> CompileResult<'src, Ast<'src>> {
+    let tokens = Lexer::lex(path, src)?;
+
+    Parser::parse(
+      source.file_depth,
+      &source.import_offsets,
+      source.namepath.as_ref(),
+      &tokens,
+      &source.working_directory,
+    )
+  }
+
   fn error(&self, kind: CompileErrorKind<'src>) -> CompileResult<'src, CompileError<'src>> {
     Ok(self.next()?.error(kind))
   }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -334,7 +334,7 @@ impl Subcommand {
 
     let (path, src) = loader.load(root, &search.justfile)?;
 
-    let ast = Compiler::parse(path, src, &Source::root(&search.justfile))?;
+    let ast = Parser::parse_source(path, src, &Source::root(&search.justfile))?;
 
     let unstable = config.unstable
       || ast.items.iter().any(|item| {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -87,6 +87,10 @@ impl Subcommand {
       return Self::edit(&search);
     }
 
+    if matches!(self, Format) {
+      return Self::format(config, loader, &search);
+    }
+
     let compilation = Self::compile(config, loader, &search)?;
     let justfile = &compilation.justfile;
 
@@ -98,7 +102,6 @@ impl Subcommand {
         justfile.run(config, &search, &[])?;
       }
       Dump => Self::dump(config, compilation)?,
-      Format => Self::format(config, &search, compilation)?,
       Groups => Self::groups(config, justfile),
       List { path } => Self::list(config, justfile, path)?,
       Run { arguments } => Self::run(config, loader, search, compilation, arguments)?,
@@ -106,7 +109,9 @@ impl Subcommand {
       Summary => Self::summary(config, justfile),
       Usage { path } => Self::usage(config, justfile, path)?,
       Variables => Self::variables(justfile),
-      Changelog | Completions { .. } | Edit | Init | Man | Request { .. } => unreachable!(),
+      Changelog | Completions { .. } | Edit | Format | Init | Man | Request { .. } => {
+        unreachable!()
+      }
     }
 
     Ok(())
@@ -324,12 +329,31 @@ impl Subcommand {
     Ok(())
   }
 
-  fn format(config: &Config, search: &Search, compilation: Compilation) -> RunResult<'static> {
-    let justfile = &compilation.justfile;
-    let src = compilation.root_src();
-    let ast = compilation.root_ast();
+  fn format<'src>(config: &Config, loader: &'src Loader, search: &Search) -> RunResult<'src> {
+    let root = search.justfile.parent().unwrap();
 
-    config.require_unstable(justfile, UnstableFeature::FormatSubcommand)?;
+    let (path, src) = loader.load(root, &search.justfile)?;
+
+    let tokens = Lexer::lex(path, src)?;
+
+    let ast = Parser::parse(0, &[], None, &tokens, &search.working_directory)?;
+
+    let unstable = config.unstable
+      || ast.items.iter().any(|item| {
+        matches!(
+          item,
+          Item::Set(Set {
+            value: Setting::Unstable(true),
+            ..
+          })
+        )
+      });
+
+    if !unstable {
+      return Err(Error::UnstableFeature {
+        unstable_feature: UnstableFeature::FormatSubcommand,
+      });
+    }
 
     let formatted = ast.to_string();
 

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -334,9 +334,7 @@ impl Subcommand {
 
     let (path, src) = loader.load(root, &search.justfile)?;
 
-    let tokens = Lexer::lex(path, src)?;
-
-    let ast = Parser::parse(0, &[], None, &tokens, &search.working_directory)?;
+    let ast = Compiler::parse(path, src, &Source::root(&search.justfile))?;
 
     let unstable = config.unstable
       || ast.items.iter().any(|item| {

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1700,3 +1700,21 @@ fn arg_attribute_help() {
     )
     .success();
 }
+
+#[test]
+fn missing_import_file() {
+  Test::new()
+    .args(["--unstable", "--fmt", "--check"])
+    .justfile("import 'foo'\n")
+    .test_round_trip(false)
+    .success();
+}
+
+#[test]
+fn missing_module_file() {
+  Test::new()
+    .args(["--unstable", "--fmt", "--check"])
+    .justfile("mod foo\n")
+    .test_round_trip(false)
+    .success();
+}


### PR DESCRIPTION
`--fmt` only uses the root AST's `Display` impl, but previously went through full compilation, including import and module resolution. This meant `--fmt` would fail with `MissingImportFile` or `MissingModuleFile` errors for files it never needed.

This diff moves `Format` handling to before the `Self::compile()` call, similar to `Edit`, so it loads, lexes, and parses only the root file. The unstable check inspects the AST directly for set unstable rather than going through `Config::require_unstable`, which requires a fully compiled Justfile.