### PR TITLE
Add --cheatsheet subcommand

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -1,0 +1,193 @@
+# `just` Cheat Sheet
+
+Quick reference for `just` syntax and features. For full docs, see the [book](https://just.systems/man/en/).
+
+## Recipes
+
+```just
+# Run with: just build
+build:
+  cargo build
+
+# Parameters
+test target tests="all":
+  cargo test {{target}} -- {{tests}}
+
+# Variadic: one or more (+) or zero or more (*)
+backup +files:
+  scp {{files}} server:
+
+commit msg *flags:
+  git commit {{flags}} -m "{{msg}}"
+
+# Export parameter as env var
+serve $port:
+  node server.js
+
+# Default recipe
+default:
+  @just --list
+```
+
+## Variables & Expressions
+
+```just
+version := "1.0.0"
+export DB_URL := env("DATABASE_URL", "sqlite://local.db")
+
+# Backtick evaluation
+git_hash := `git rev-parse --short HEAD`
+
+# String types
+a := "escaped\n"       # double-quoted: \n \t \\ \"
+b := 'literal\n'       # single-quoted: no escapes
+c := '''               # indented: common whitespace stripped
+  multi
+  line
+'''
+
+# Conditionals
+mode := if env("CI", "") != "" { "release" } else { "debug" }
+
+# Concatenation and path joining
+full := version + "-beta"
+path := "src" / "main.rs"
+```
+
+## Dependencies
+
+```just
+# Prior dependencies (run before)
+all: build test lint
+
+# Subsequent dependencies (run after, with &&)
+deploy: test && notify clean
+
+# Pass arguments to dependencies
+default: (build "release")
+
+build target:
+  cargo build --profile {{target}}
+```
+
+## Attributes
+
+```just
+[private]                    # hide from --list
+[confirm("Delete everything?")]  # require confirmation
+[no-cd]                      # don't cd to justfile dir
+[no-exit-message]            # suppress error output
+[linux] [macos] [windows]    # OS-specific recipes
+[group('dev')]               # group in --list output
+[script('python3')]          # run as script
+
+[doc("Run the full test suite")]
+test:
+  cargo test
+```
+
+## Shebang Recipes
+
+```just
+analyze:
+  #!/usr/bin/env python3
+  import json
+  print(json.dumps({"status": "ok"}))
+
+setup:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "ready"
+```
+
+## Settings
+
+```just
+set shell := ["bash", "-uc"]
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+set dotenv-load                  # load .env file
+set export                       # export all variables
+set positional-arguments         # $1, $2, $@ in recipes
+set quiet                        # don't echo recipe lines
+set fallback                     # search parent dirs
+set ignore-comments              # ignore # in recipe bodies
+set allow-duplicate-recipes      # later recipes override
+set working-directory := "/tmp"
+set tempdir := "/tmp"
+```
+
+## Modules & Imports
+
+```just
+# Import: inline another file
+import 'ci.just'
+import? 'local.just'       # optional (no error if missing)
+
+# Module: namespaced subcommand
+mod deploy                  # loads deploy.just or deploy/mod.just
+mod? staging                # optional
+
+# Run with: just deploy build
+# Or: just deploy::build
+```
+
+## Line Prefixes
+
+| Prefix | Effect |
+|--------|--------|
+| `@` | Suppress echo (quiet line) |
+| `-` | Ignore errors |
+| `-@` / `@-` | Both |
+
+## Common Built-in Functions
+
+**System:** `arch()` `os()` `os_family()` `num_cpus()`
+
+**Environment:** `env(key)` `env(key, default)`
+
+**Paths:** `justfile()` `justfile_dir()` `invocation_dir()` `source_file()` `source_dir()`
+
+**Path ops:** `absolute_path(p)` `canonicalize(p)` `extension(p)` `file_name(p)` `file_stem(p)` `parent_dir(p)` `without_extension(p)` `join(a, b)` `clean(p)`
+
+**Strings:** `replace(s, from, to)` `replace_regex(s, re, to)` `trim(s)` `trim_start(s)` `trim_end(s)` `quote(s)` `uppercase(s)` `lowercase(s)` `capitalize(s)`
+
+**Case:** `snakecase(s)` `kebabcase(s)` `uppercamelcase(s)` `lowercamelcase(s)` `titlecase(s)` `shoutysnakecase(s)`
+
+**Hashing:** `sha256(s)` `sha256_file(p)` `blake3(s)` `blake3_file(p)`
+
+**Misc:** `uuid()` `choose(n, alphabet)` `datetime(fmt)` `datetime_utc(fmt)` `error(msg)` `shell(cmd, args...)` `require(name)` `path_exists(p)` `read(p)` `is_dependency()`
+
+**Constants:** `HEX` `HEXLOWER` `HEXUPPER` `PATH_SEP` `BOLD` `RED` `GREEN` `YELLOW` `BLUE` `NORMAL` (and more ANSI codes)
+
+## CLI Quick Reference
+
+```sh
+just                     # run default recipe
+just recipe arg1 arg2    # run recipe with args
+just --list              # list recipes
+just --list --unsorted   # list in justfile order
+just --summary           # recipe names only
+just --show recipe       # print recipe source
+just --evaluate          # print all variables
+just --evaluate var      # print one variable
+just --fmt               # format justfile
+just --check             # syntax check only
+just --dry-run recipe    # print without running
+just --choose            # interactive picker (fzf)
+just --groups            # list recipe groups
+just --dump              # print parsed justfile
+just --yes recipe        # auto-confirm [confirm]
+just VAR=val recipe      # override variable
+just dir/recipe          # run from subdirectory
+just mod::recipe         # run module recipe
+```
+
+## Aliases
+
+```just
+alias b := build
+alias t := test
+
+[private]
+alias c := check
+```

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,7 @@ pub(crate) struct Config {
 
 mod cmd {
   pub(crate) const CHANGELOG: &str = "CHANGELOG";
+  pub(crate) const CHEATSHEET: &str = "CHEATSHEET";
   pub(crate) const CHOOSE: &str = "CHOOSE";
   pub(crate) const COMMAND: &str = "COMMAND";
   pub(crate) const COMPLETIONS: &str = "COMPLETIONS";
@@ -69,6 +70,7 @@ mod cmd {
 
   pub(crate) const ALL: &[&str] = &[
     CHANGELOG,
+    CHEATSHEET,
     CHOOSE,
     COMMAND,
     COMPLETIONS,
@@ -86,7 +88,7 @@ mod cmd {
   ];
 
   pub(crate) const ARGLESS: &[&str] =
-    &[CHANGELOG, DUMP, EDIT, FORMAT, INIT, MAN, SUMMARY, VARIABLES];
+    &[CHANGELOG, CHEATSHEET, DUMP, EDIT, FORMAT, INIT, MAN, SUMMARY, VARIABLES];
 
   pub(crate) const HEADING: &str = "Commands";
 }
@@ -470,6 +472,13 @@ impl Config {
           .help_heading(cmd::HEADING),
       )
       .arg(
+        Arg::new(cmd::CHEATSHEET)
+          .long("cheatsheet")
+          .action(ArgAction::SetTrue)
+          .help("Print cheatsheet")
+          .help_heading(cmd::HEADING),
+      )
+      .arg(
         Arg::new(cmd::CHOOSE)
           .long("choose")
           .action(ArgAction::SetTrue)
@@ -732,6 +741,8 @@ impl Config {
 
     let subcommand = if matches.get_flag(cmd::CHANGELOG) {
       Subcommand::Changelog
+    } else if matches.get_flag(cmd::CHEATSHEET) {
+      Subcommand::Cheatsheet
     } else if matches.get_flag(cmd::CHOOSE) {
       Subcommand::Choose {
         chooser: matches.get_one::<String>(arg::CHOOSER).map(Into::into),

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -12,6 +12,7 @@ static BACKTICK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("(`.*?`)|(`[^`
 #[derive(PartialEq, Clone, Debug)]
 pub(crate) enum Subcommand {
   Changelog,
+  Cheatsheet,
   Choose {
     chooser: Option<String>,
   },
@@ -67,6 +68,10 @@ impl Subcommand {
         Self::changelog();
         return Ok(());
       }
+      Cheatsheet => {
+        Self::cheatsheet();
+        return Ok(());
+      }
       Completions { shell } => {
         Self::completions(*shell);
         return Ok(());
@@ -106,7 +111,7 @@ impl Subcommand {
       Summary => Self::summary(config, justfile),
       Usage { path } => Self::usage(config, justfile, path)?,
       Variables => Self::variables(justfile),
-      Changelog | Completions { .. } | Edit | Init | Man | Request { .. } => unreachable!(),
+      Changelog | Cheatsheet | Completions { .. } | Edit | Init | Man | Request { .. } => unreachable!(),
     }
 
     Ok(())
@@ -197,6 +202,10 @@ impl Subcommand {
 
   fn changelog() {
     write!(io::stdout(), "{}", include_str!("../CHANGELOG.md")).ok();
+  }
+
+  fn cheatsheet() {
+    write!(io::stdout(), "{}", include_str!("../CHEATSHEET.md")).ok();
   }
 
   fn choose<'src>(

--- a/tests/cheatsheet.rs
+++ b/tests/cheatsheet.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+#[test]
+fn print_cheatsheet() {
+  Test::new()
+    .args(["--cheatsheet"])
+    .stdout(fs::read_to_string("CHEATSHEET.md").unwrap())
+    .success();
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -55,6 +55,7 @@ mod backticks;
 mod byte_order_mark;
 mod ceiling;
 mod changelog;
+mod cheatsheet;
 mod choose;
 mod command;
 mod completions;


### PR DESCRIPTION
Add `just --cheatsheet` to print a quick-reference guide, following the same `include_str!` pattern as `--changelog`. Closes #3108.

- `CHEATSHEET.md` at repo root, embedded at compile time
- Covers recipes, variables, dependencies, attributes, settings, modules, built-ins, and CLI flags
- Test follows the `changelog` test pattern