### PR TITLE
Fix zsh completion in nested modules

### DIFF
--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -100,19 +100,7 @@ _just() {
             curcontext="${curcontext%:*}-${words[2]}:"
 
             local lastarg=${words[${#words}]}
-            local recipe
-
-            local cmds; cmds=(
-                ${(s: :)$(_call_program commands just --summary)}
-            )
-
-            # Find first recipe name
-            for ((i = 2; i < $#words; i++ )) do
-                if [[ ${cmds[(I)${words[i]}]} -gt 0 ]]; then
-                    recipe=${words[i]}
-                    break
-                fi
-            done
+            local recipe=$(_just_recipe_path)
 
             if [[ $lastarg = */* ]]; then
                 # Arguments contain slash would be recognised as a file
@@ -123,10 +111,8 @@ _just() {
             elif [[ $recipe ]]; then
                 # Show usage message
                 _message "`just --show $recipe`"
-                # Or complete with other commands
-                #_arguments -s -S $common '*:: :_just_commands'
             else
-                _arguments -s -S $common '*:: :_just_commands'
+                _just_commands
             fi
         ;;
     esac
@@ -142,8 +128,9 @@ _just_commands() {
     local variables; variables=(
         ${(s: :)$(_call_program commands just --variables)}
     )
+    local module=$(_just_module_path)
     local commands; commands=(
-        ${${${(M)"${(f)$(_call_program commands just --list)}":#    *}/ ##/}/ ##/:Args: }
+        ${(@f)$(_just_command_names "$module")}
     )
 
     if compset -P '*='; then
@@ -155,6 +142,77 @@ _just_commands() {
         _describe -t commands 'just commands' commands "$@"
     fi
 
+}
+
+(( $+functions[_just_command_names] )) ||
+_just_command_names() {
+    local module=$1
+    local output
+
+    if [[ -n $module ]]; then
+        output=$(_call_program commands just --list "$module") || return 1
+    else
+        output=$(_call_program commands just --list) || return 1
+    fi
+
+    local -a commands=()
+    local line
+
+    for line in "${(@f)output}"; do
+        [[ $line == "    "* ]] || continue
+        line=${line#"    "}
+        commands+=("${line%%[[:space:]]*}")
+    done
+
+    print -rl -- "${commands[@]}"
+}
+
+(( $+functions[_just_module_path] )) ||
+_just_module_path() {
+    local -a modules=()
+    local module=""
+    local i
+
+    for ((i = 2; i < CURRENT; i++)); do
+        [[ -z ${words[i]} || ${words[i]} == -* || ${words[i]} == *=* ]] && continue
+        modules+=("${words[i]}")
+    done
+
+    for i in "${modules[@]}"; do
+        if [[ -n $module ]]; then
+            module="${module}::${i}"
+        else
+            module="${i}"
+        fi
+    done
+
+    print -r -- "$module"
+}
+
+(( $+functions[_just_recipe_path] )) ||
+_just_recipe_path() {
+    local -a recipes=(
+        ${(s: :)$(_call_program commands just --summary)}
+    )
+    local -a path=()
+    local candidate=""
+    local i
+
+    for ((i = 2; i < CURRENT; i++)); do
+        [[ -z ${words[i]} || ${words[i]} == -* || ${words[i]} == *=* ]] && continue
+        path+=("${words[i]}")
+        if [[ -n $candidate ]]; then
+            candidate="${candidate}::${words[i]}"
+        else
+            candidate="${words[i]}"
+        fi
+        if [[ ${recipes[(I)$candidate]} -gt 0 ]]; then
+            print -r -- "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
 }
 
 if [ "$funcstack[1]" = "_just" ]; then

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -161,19 +161,7 @@ complete -c just -a '(__fish_just_complete_recipes)'
             curcontext="${curcontext%:*}-${words[2]}:"
 
             local lastarg=${words[${#words}]}
-            local recipe
-
-            local cmds; cmds=(
-                ${(s: :)$(_call_program commands just --summary)}
-            )
-
-            # Find first recipe name
-            for ((i = 2; i < $#words; i++ )) do
-                if [[ ${cmds[(I)${words[i]}]} -gt 0 ]]; then
-                    recipe=${words[i]}
-                    break
-                fi
-            done
+            local recipe=$(_just_recipe_path)
 
             if [[ $lastarg = */* ]]; then
                 # Arguments contain slash would be recognised as a file
@@ -184,10 +172,8 @@ complete -c just -a '(__fish_just_complete_recipes)'
             elif [[ $recipe ]]; then
                 # Show usage message
                 _message "`just --show $recipe`"
-                # Or complete with other commands
-                #_arguments -s -S $common '*:: :_just_commands'
             else
-                _arguments -s -S $common '*:: :_just_commands'
+                _just_commands
             fi
         ;;
     esac
@@ -202,8 +188,9 @@ complete -c just -a '(__fish_just_complete_recipes)'
     local variables; variables=(
         ${(s: :)$(_call_program commands just --variables)}
     )
+    local module=$(_just_module_path)
     local commands; commands=(
-        ${${${(M)"${(f)$(_call_program commands just --list)}":#    *}/ ##/}/ ##/:Args: }
+        ${(@f)$(_just_command_names "$module")}
     )
 "#,
     ),
@@ -218,6 +205,81 @@ complete -c just -a '(__fish_just_complete_recipes)'
         _describe -t commands 'just commands' commands "$@"
     fi
 "#,
+    ),
+    (
+      r#"if [ "$funcstack[1]" = "_just" ]; then"#,
+      r#"(( $+functions[_just_command_names] )) ||
+_just_command_names() {
+    local module=$1
+    local output
+
+    if [[ -n $module ]]; then
+        output=$(_call_program commands just --list "$module") || return 1
+    else
+        output=$(_call_program commands just --list) || return 1
+    fi
+
+    local -a commands=()
+    local line
+
+    for line in "${(@f)output}"; do
+        [[ $line == "    "* ]] || continue
+        line=${line#"    "}
+        commands+=("${line%%[[:space:]]*}")
+    done
+
+    print -rl -- "${commands[@]}"
+}
+
+(( $+functions[_just_module_path] )) ||
+_just_module_path() {
+    local -a modules=()
+    local module=""
+    local i
+
+    for ((i = 2; i < CURRENT; i++)); do
+        [[ -z ${words[i]} || ${words[i]} == -* || ${words[i]} == *=* ]] && continue
+        modules+=("${words[i]}")
+    done
+
+    for i in "${modules[@]}"; do
+        if [[ -n $module ]]; then
+            module="${module}::${i}"
+        else
+            module="${i}"
+        fi
+    done
+
+    print -r -- "$module"
+}
+
+(( $+functions[_just_recipe_path] )) ||
+_just_recipe_path() {
+    local -a recipes=(
+        ${(s: :)$(_call_program commands just --summary)}
+    )
+    local -a path=()
+    local candidate=""
+    local i
+
+    for ((i = 2; i < CURRENT; i++)); do
+        [[ -z ${words[i]} || ${words[i]} == -* || ${words[i]} == *=* ]] && continue
+        path+=("${words[i]}")
+        if [[ -n $candidate ]]; then
+            candidate="${candidate}::${words[i]}"
+        else
+            candidate="${words[i]}"
+        fi
+        if [[ ${recipes[(I)$candidate]} -gt 0 ]]; then
+            print -r -- "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+if [ "$funcstack[1]" = "_just" ]; then"#,
     ),
     (
       r#"_just "$@""#,

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -29,6 +29,36 @@ fn bash() {
 }
 
 #[test]
+fn zsh() {
+  if which("zsh").is_err() {
+    return;
+  }
+
+  let output = Command::new(JUST)
+    .args(["--completions", "zsh"])
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
+
+  let script = str::from_utf8(&output.stdout).unwrap();
+
+  let tempdir = tempdir();
+
+  let path = tempdir.path().join("just.zsh");
+
+  fs::write(&path, script).unwrap();
+
+  let status = Command::new("zsh")
+    .arg("./tests/completions/just.zsh")
+    .arg(path)
+    .status()
+    .unwrap();
+
+  assert!(status.success());
+}
+
+#[test]
 fn replacements() {
   for shell in ["bash", "elvish", "fish", "nushell", "powershell", "zsh"] {
     let output = Command::new(JUST)

--- a/tests/completions/just.zsh
+++ b/tests/completions/just.zsh
@@ -1,0 +1,74 @@
+#!/usr/bin/env zsh
+
+reply_equals() {
+  local actual=$1
+  local expected=$2
+
+  if [[ "$actual" == "$expected" ]]; then
+    echo "${funcstack[2]}: ok"
+  else
+    exit_code=1
+    echo >&2 "${funcstack[2]}: failed!"
+    echo >&2 "expected: $expected"
+    echo >&2 "actual:   $actual"
+  fi
+}
+
+compdef() { :; }
+_call_program() {
+  shift
+  "$@"
+}
+
+source "$1"
+cargo build >/dev/null
+PATH="$(git rev-parse --show-toplevel)/target/debug:$PATH"
+tmpdir=$(mktemp -d)
+cd "$tmpdir"
+cat <<'EOF' > justfile
+mod repo "repo.just"
+EOF
+cat <<'EOF' > repo.just
+mod open "open.just"
+EOF
+cat <<'EOF' > open.just
+codex:
+  @:
+
+vscode:
+  @:
+EOF
+exit_code=0
+
+test_nested_module_names() {
+  local actual
+  actual=$(_just_command_names repo::open | tr '\n' ' ' | sed 's/ $//')
+  reply_equals "$actual" "codex vscode"
+}
+test_nested_module_names
+
+test_module_path() {
+  words=(just repo open co)
+  CURRENT=4
+  local actual
+  actual=$(_just_module_path)
+  reply_equals "$actual" "repo::open"
+}
+test_module_path
+
+test_recipe_path() {
+  words=(just repo open codex "")
+  CURRENT=5
+  local actual
+  actual=$(_just_recipe_path)
+  reply_equals "$actual" "repo::open::codex"
+}
+test_recipe_path
+
+if [[ $exit_code -eq 0 ]]; then
+  echo "All tests passed."
+else
+  echo "Some test[s] failed."
+fi
+
+exit $exit_code


### PR DESCRIPTION
Fixes #2912.

This updates zsh completion so it can continue completing commands inside modules, instead of stopping after the first module segment.

What changed:
- resolve the current module path from the words already typed by the user
- use `just --list <module>` to complete names at the current module level
- detect fully-qualified recipe paths with `just --summary`
- add a zsh regression test covering nested modules

Before this change, completion could stop after the first module name in cases like the one described in #2912, where a command should continue completing deeper module recipes.