### PR TITLE
Exclude omitted option defaults from positional arguments

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -530,7 +530,9 @@ impl<'src, 'run> Evaluator<'src, 'run> {
       let values = if group.is_empty() {
         if let Some(ref default) = parameter.default {
           let value = evaluator.evaluate_expression(default)?;
-          positional.push(value.clone());
+          if !parameter.is_option() {
+            positional.push(value.clone());
+          }
           vec![value]
         } else if parameter.kind == ParameterKind::Star {
           Vec::new()

--- a/tests/positional_arguments.rs
+++ b/tests/positional_arguments.rs
@@ -162,6 +162,68 @@ fn default_arguments() {
 }
 
 #[test]
+fn omitted_default_long_option_is_not_passed_to_linewise_positional_arguments() {
+  Test::new()
+    .arg("foo")
+    .justfile(
+      r#"
+    set positional-arguments
+
+    [arg('bar', long='bar')]
+    foo bar='BAR' baz='BAZ':
+      echo $0
+      echo $1
+      echo ${2-missing}
+      echo "$@"
+  "#,
+    )
+    .stdout("foo\nBAZ\nmissing\nBAZ\n")
+    .stderr("echo $0\necho $1\necho ${2-missing}\necho \"$@\"\n")
+    .success();
+}
+
+#[test]
+fn omitted_default_long_option_is_not_passed_to_shebang_positional_arguments() {
+  Test::new()
+    .arg("foo")
+    .justfile(
+      r#"
+    set positional-arguments
+
+    [arg('bar', long='bar')]
+    foo bar='BAR' baz='BAZ':
+      #!/bin/sh
+      echo $1
+      echo ${2-missing}
+      echo "$@"
+  "#,
+    )
+    .stdout("BAZ\nmissing\nBAZ\n")
+    .success();
+}
+
+#[test]
+fn omitted_default_short_option_is_not_passed_to_linewise_positional_arguments() {
+  Test::new()
+    .arg("foo")
+    .justfile(
+      r#"
+    set positional-arguments
+
+    [arg('bar', short='b')]
+    foo bar='BAR' baz='BAZ':
+      echo $0
+      echo $1
+      echo ${2-missing}
+      echo "$@"
+  "#,
+    )
+    .stdout("foo\nBAZ\nmissing\nBAZ\n")
+    .stderr("echo $0\necho $1\necho ${2-missing}\necho \"$@\"\n")
+    .success();
+}
+
+#[test]
 fn empty_variadic_is_undefined() {
   Test::new()
     .justfile(


### PR DESCRIPTION
This fixes an interaction between `set positional-arguments` and omitted defaulted option parameters.

Before this change, if a recipe option had a default value and the option was omitted, that default value was still injected into the shell positional argument list. This caused omitted option defaults to appear in `$@` for linewise and shebang recipes.

This change keeps omitted defaulted options available for parameter evaluation, but excludes them from positional shell arguments. Explicitly passed options already worked, so their behavior is unchanged.

Tests:
- Omitted defaulted options are not passed to positional arguments