### PR TITLE
docs: fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4657,7 +4657,7 @@ to `just` include:
 - [haku](https://github.com/VladimirMarkelov/haku): A make-like command runner
   written in Rust.
 - [mise](https://mise.jdx.dev/): A development environment tool manager written
-  in Rust supporing tasks in TOML files and standalone scripts.
+  in Rust supporting tasks in TOML files and standalone scripts.
 
 Contributing
 ------------


### PR DESCRIPTION
## Summary
- Fix a spelling typo in the README comparison list.

## Related issue
- N/A (doc typo fix)

## Guideline alignment
- https://github.com/casey/just/blob/master/README.md#contributing

## Validation/testing
- Not run (docs change only)
