### PR TITLE
Forward variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1825,15 +1825,11 @@ foo := env('FOO', '') || 'DEFAULT_VALUE'
 
 #### Invocation Information
 
-- `is_dependency()` - Returns the string `true` if the current recipe is being
-  run as a dependency of another recipe, rather than being run directly,
-  otherwise returns the string `false`.
+- `is_dependency()` — Returns the string `true` if the current recipe is being run as a dependency of another recipe, rather than being run directly, otherwise returns the string `false`.
 
 #### Variable Forwarding
 
-- `forward_variables(names...)` - Returns command-line variable overrides as
-  shell-safe `key='value'` pairs, joined by spaces. If `names` are given, only
-  matching keys are included. Single quotes in values are properly escaped.
+- `forward_variables(names...)` — Returns command-line variable overrides as shell-safe `key='value'` pairs, joined by spaces. If `names` are given, only matching keys are included. Single quotes in values are properly escaped.
 
 Forward all overrides to a child `just` invocation:
 
@@ -1844,7 +1840,7 @@ build:
   @echo "Building in {{mode}} mode"
 
 run:
-  {{ just_executable() }} --justfile {{ justfile() }} {{ forward_variables() }} build
+  {{ just_executable() }} {{ forward_variables() }} build
 ```
 
 ```console
@@ -1855,17 +1851,47 @@ Building in release mode
 Forward only selected variables:
 
 ```just
-host := 'localhost'
-port := '3000'
+table_name := 'users'
+uid := '42'
 debug := 'false'
 
 deploy:
-  echo "./deploy.sh {{ forward_variables('host', 'port') }}"
+  echo "./deploy.sh {{ forward_variables('table_name', 'uid') }}"
 ```
 
 ```console
-$ just host=prod.example.com port=8080 debug=true deploy
-./deploy.sh host='prod.example.com' port='8080'
+$ just table_name=orders uid=100 debug=true deploy
+./deploy.sh table_name='orders' uid='100'
+```
+
+- `forward_variables_with(sep, prefix, kvsep, names...)` — Like `forward_variables`, but with customizable separator, prefix, and key-value separator. Each pair is formatted as `prefix + key + kvsep + quoted_value`, joined by `sep`.
+
+```just
+mode := 'dev'
+
+build:
+  @echo "Building in {{mode}} mode"
+
+run:
+  echo "just {{ forward_variables_with(' ', '--set ', ' ') }} build"
+```
+
+```console
+$ just mode=release run
+just --set mode 'release' build
+```
+
+```just
+table_name := 'users'
+uid := '42'
+
+query:
+  echo "psql {{ forward_variables_with(' ', '-v ', '=', 'table_name', 'uid') }} -f query.sql"
+```
+
+```console
+$ just table_name=orders uid=100 query
+psql -v table_name='orders' -v uid='100' -f query.sql
 ```
 
 #### Invocation Directory

--- a/README.md
+++ b/README.md
@@ -1829,6 +1829,45 @@ foo := env('FOO', '') || 'DEFAULT_VALUE'
   run as a dependency of another recipe, rather than being run directly,
   otherwise returns the string `false`.
 
+#### Variable Forwarding
+
+- `forward_variables(names...)` - Returns command-line variable overrides as
+  shell-safe `key='value'` pairs, joined by spaces. If `names` are given, only
+  matching keys are included. Single quotes in values are properly escaped.
+
+Forward all overrides to a child `just` invocation:
+
+```just
+mode := 'dev'
+
+build:
+  @echo "Building in {{mode}} mode"
+
+run:
+  {{ just_executable() }} --justfile {{ justfile() }} {{ forward_variables() }} build
+```
+
+```console
+$ just mode=release run
+Building in release mode
+```
+
+Forward only selected variables:
+
+```just
+host := 'localhost'
+port := '3000'
+debug := 'false'
+
+deploy:
+  echo "./deploy.sh {{ forward_variables('host', 'port') }}"
+```
+
+```console
+$ just host=prod.example.com port=8080 debug=true deploy
+./deploy.sh host='prod.example.com' port='8080'
+```
+
 #### Invocation Directory
 
 - `invocation_directory()` - Retrieves the absolute path to the current

--- a/README.中文.md
+++ b/README.中文.md
@@ -1142,6 +1142,43 @@ $ just
 
 - `env_var_or_default(key, default)` — 获取名称为 `key` 的环境变量，如果不存在则返回 `default`。
 
+#### 變數轉發
+
+- `forward_variables(names...)` - 將指令中，**覆寫**的變數，回傳：以 shell 安全的 `key='value'` 格式，多個**鍵值對**以空格連接。如果指定了 `names`，則只包含指定的鍵。值中的單引號會被正確跳脫。
+
+將所有覆寫的變數，轉發給子 `just` ：
+
+```just
+mode := 'dev'
+
+build:
+  @echo "Building in {{mode}} mode"
+
+run:
+  {{ just_executable() }} --justfile {{ justfile() }} {{ forward_variables() }} build
+```
+
+```console
+$ just mode=release run
+Building in release mode
+```
+
+Forward only selected variables:
+
+```just
+host := 'localhost'
+port := '3000'
+debug := 'false'
+
+deploy:
+  echo "./deploy.sh {{ forward_variables('host', 'port') }}"
+```
+
+```console
+$ just host=prod.example.com port=8080 debug=true deploy
+./deploy.sh host='prod.example.com' port='8080'
+```
+
 #### 调用目录
 
 - `invocation_directory()` - 获取 `just` 被调用时当前目录所对应的绝对路径，在 `just` 改变路径并执行相应命令前。

--- a/README.中文.md
+++ b/README.中文.md
@@ -1144,9 +1144,9 @@ $ just
 
 #### 變數轉發
 
-- `forward_variables(names...)` - 將指令中，**覆寫**的變數，回傳：以 shell 安全的 `key='value'` 格式，多個**鍵值對**以空格連接。如果指定了 `names`，則只包含指定的鍵。值中的單引號會被正確跳脫。
+- `forward_variables(names...)` — 將命令列覆寫的變數以 shell 安全的 `key='value'` 格式回傳，多組鍵值對以空格連接。若指定了 `names`，則只包含對應的 key。值中的單引號會被正確跳脫。
 
-將所有覆寫的變數，轉發給子 `just` ：
+將所有覆寫的變數轉發給子 `just`：
 
 ```just
 mode := 'dev'
@@ -1155,7 +1155,7 @@ build:
   @echo "Building in {{mode}} mode"
 
 run:
-  {{ just_executable() }} --justfile {{ justfile() }} {{ forward_variables() }} build
+  {{ just_executable() }} {{ forward_variables() }} build
 ```
 
 ```console
@@ -1163,20 +1163,50 @@ $ just mode=release run
 Building in release mode
 ```
 
-Forward only selected variables:
+只轉發指定的變數：
 
 ```just
-host := 'localhost'
-port := '3000'
+table_name := 'users'
+uid := '42'
 debug := 'false'
 
 deploy:
-  echo "./deploy.sh {{ forward_variables('host', 'port') }}"
+  echo "./deploy.sh {{ forward_variables('table_name', 'uid') }}"
 ```
 
 ```console
-$ just host=prod.example.com port=8080 debug=true deploy
-./deploy.sh host='prod.example.com' port='8080'
+$ just table_name=orders uid=100 debug=true deploy
+./deploy.sh table_name='orders' uid='100'
+```
+
+- `forward_variables_with(sep, prefix, kvsep, names...)` — 與 `forward_variables` 類似，但可自訂分隔符、前綴與鍵值分隔符。每對格式為 `prefix + key + kvsep + 引號包裹的值`，以 `sep` 連接。
+
+```just
+mode := 'dev'
+
+build:
+  @echo "Building in {{mode}} mode"
+
+run:
+  echo "just {{ forward_variables_with(' ', '--set ', ' ') }} build"
+```
+
+```console
+$ just mode=release run
+just --set mode 'release' build
+```
+
+```just
+table_name := 'users'
+uid := '42'
+
+query:
+  echo "psql {{ forward_variables_with(' ', '-v ', '=', 'table_name', 'uid') }} -f query.sql"
+```
+
+```console
+$ just table_name=orders uid=100 query
+psql -v table_name='orders' -v uid='100' -f query.sql
 ```
 
 #### 调用目录

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -290,6 +290,15 @@ impl<'src, 'run> Evaluator<'src, 'run> {
         use Thunk::*;
         match thunk {
           Nullary { function, .. } => function(self.function_context(thunk)?),
+          NullaryPlus {
+            function, args, ..
+          } => {
+            let mut evaluated = Vec::new();
+            for arg in args {
+              evaluated.push(self.evaluate_expression(arg)?);
+            }
+            function(self.function_context(thunk)?, &evaluated)
+          }
           Unary { function, arg, .. } => {
             let arg = self.evaluate_expression(arg)?;
             function(self.function_context(thunk)?, &arg)

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -359,6 +359,20 @@ impl<'src, 'run> Evaluator<'src, 'run> {
             let c = self.evaluate_expression(c)?;
             function(self.function_context(thunk)?, &a, &b, &c)
           }
+          TernaryPlus {
+            function,
+            args: ([a, b, c], rest),
+            ..
+          } => {
+            let a = self.evaluate_expression(a)?;
+            let b = self.evaluate_expression(b)?;
+            let c = self.evaluate_expression(c)?;
+            let mut rest_evaluated = Vec::new();
+            for arg in rest {
+              rest_evaluated.push(self.evaluate_expression(arg)?);
+            }
+            function(self.function_context(thunk)?, &a, &b, &c, &rest_evaluated)
+          }
         }
         .map_err(|message| Error::FunctionCall {
           function: thunk.name(),

--- a/src/function.rs
+++ b/src/function.rs
@@ -12,6 +12,7 @@ use {
 #[allow(clippy::arbitrary_source_item_ordering)]
 pub(crate) enum Function {
   Nullary(fn(Context) -> FunctionResult),
+  NullaryPlus(fn(Context, &[String]) -> FunctionResult),
   Unary(fn(Context, &str) -> FunctionResult),
   UnaryOpt(fn(Context, &str, Option<&str>) -> FunctionResult),
   UnaryPlus(fn(Context, &str, &[String]) -> FunctionResult),
@@ -62,6 +63,7 @@ pub(crate) fn get(name: &str) -> Option<Function> {
     "extension" => Unary(extension),
     "file_name" => Unary(file_name),
     "file_stem" => Unary(file_stem),
+    "forward_variables" => NullaryPlus(forward_variables),
     "home_directory" => Nullary(|_| dir("home", dirs::home_dir)),
     "invocation_directory" => Nullary(invocation_directory),
     "invocation_directory_native" => Nullary(invocation_directory_native),
@@ -119,6 +121,7 @@ impl Function {
   pub(crate) fn argc(&self) -> RangeInclusive<usize> {
     match *self {
       Nullary(_) => 0..=0,
+      NullaryPlus(_) => 0..=usize::MAX,
       Unary(_) => 1..=1,
       UnaryOpt(_) => 1..=2,
       UnaryPlus(_) => 1..=usize::MAX,
@@ -324,6 +327,16 @@ fn file_stem(_context: Context, path: &str) -> FunctionResult {
     .file_stem()
     .map(str::to_owned)
     .ok_or_else(|| format!("Could not extract file stem from `{path}`"))
+}
+
+fn forward_variables(context: Context, args: &[String]) -> FunctionResult {
+  let overrides = &context.execution_context.config.overrides;
+  let parts: Vec<String> = overrides
+    .iter()
+    .filter(|(k, _)| args.is_empty() || args.iter().any(|a| a == *k))
+    .map(|(k, v)| format!("{}='{}'", k, v.replace('\'', "'\\''")))
+    .collect();
+  Ok(parts.join(" "))
 }
 
 fn invocation_directory(context: Context) -> FunctionResult {

--- a/src/function.rs
+++ b/src/function.rs
@@ -19,6 +19,7 @@ pub(crate) enum Function {
   Binary(fn(Context, &str, &str) -> FunctionResult),
   BinaryPlus(fn(Context, &str, &str, &[String]) -> FunctionResult),
   Ternary(fn(Context, &str, &str, &str) -> FunctionResult),
+  TernaryPlus(fn(Context, &str, &str, &str, &[String]) -> FunctionResult),
 }
 
 pub(crate) struct Context<'src: 'run, 'run> {
@@ -64,6 +65,7 @@ pub(crate) fn get(name: &str) -> Option<Function> {
     "file_name" => Unary(file_name),
     "file_stem" => Unary(file_stem),
     "forward_variables" => NullaryPlus(forward_variables),
+    "forward_variables_with" => TernaryPlus(forward_variables_with),
     "home_directory" => Nullary(|_| dir("home", dirs::home_dir)),
     "invocation_directory" => Nullary(invocation_directory),
     "invocation_directory_native" => Nullary(invocation_directory_native),
@@ -128,6 +130,7 @@ impl Function {
       Binary(_) => 2..=2,
       BinaryPlus(_) => 2..=usize::MAX,
       Ternary(_) => 3..=3,
+      TernaryPlus(_) => 3..=usize::MAX,
     }
   }
 }
@@ -337,6 +340,22 @@ fn forward_variables(context: Context, args: &[String]) -> FunctionResult {
     .map(|(k, v)| format!("{}='{}'", k, v.replace('\'', "'\\''")))
     .collect();
   Ok(parts.join(" "))
+}
+
+fn forward_variables_with(
+  context: Context,
+  sep: &str,
+  prefix: &str,
+  kvsep: &str,
+  names: &[String],
+) -> FunctionResult {
+  let overrides = &context.execution_context.config.overrides;
+  let parts: Vec<String> = overrides
+    .iter()
+    .filter(|(k, _)| names.is_empty() || names.iter().any(|n| n == *k))
+    .map(|(k, v)| format!("{prefix}{k}{kvsep}'{}'", v.replace('\'', "'\\''")))
+    .collect();
+  Ok(parts.join(sep))
 }
 
 fn invocation_directory(context: Context) -> FunctionResult {

--- a/src/node.rs
+++ b/src/node.rs
@@ -119,6 +119,12 @@ impl<'src> Node<'src> for Expression<'src> {
         let mut tree = Tree::atom("call");
         match thunk {
           Nullary { name, .. } => tree.push_mut(name.lexeme()),
+          NullaryPlus { name, args, .. } => {
+            tree.push_mut(name.lexeme());
+            for arg in args {
+              tree.push_mut(arg.tree());
+            }
+          }
           Unary { name, arg, .. } => {
             tree.push_mut(name.lexeme());
             tree.push_mut(arg.tree());

--- a/src/node.rs
+++ b/src/node.rs
@@ -178,6 +178,19 @@ impl<'src> Node<'src> for Expression<'src> {
             tree.push_mut(b.tree());
             tree.push_mut(c.tree());
           }
+          TernaryPlus {
+            name,
+            args: ([a, b, c], rest),
+            ..
+          } => {
+            tree.push_mut(name.lexeme());
+            tree.push_mut(a.tree());
+            tree.push_mut(b.tree());
+            tree.push_mut(c.tree());
+            for arg in rest {
+              tree.push_mut(arg.tree());
+            }
+          }
         }
         tree
       }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -325,6 +325,20 @@ impl Expression {
           name: name.lexeme().to_owned(),
           arguments: vec![Self::new(a), Self::new(b), Self::new(c)],
         },
+        full::Thunk::TernaryPlus {
+          name,
+          args: ([a, b, c], rest),
+          ..
+        } => {
+          let mut arguments = vec![Self::new(a), Self::new(b), Self::new(c)];
+          for arg in rest {
+            arguments.push(Self::new(arg));
+          }
+          Self::Call {
+            name: name.lexeme().to_owned(),
+            arguments,
+          }
+        },
       },
       Concatenation { lhs, rhs } => Self::Concatenation {
         lhs: Self::new(lhs).into(),

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -257,6 +257,13 @@ impl Expression {
           name: name.lexeme().to_owned(),
           arguments: Vec::new(),
         },
+        full::Thunk::NullaryPlus { name, args, .. } => {
+          let arguments = args.iter().map(Self::new).collect();
+          Self::Call {
+            name: name.lexeme().to_owned(),
+            arguments,
+          }
+        }
         full::Thunk::Unary { name, arg, .. } => Self::Call {
           name: name.lexeme().to_owned(),
           arguments: vec![Self::new(arg)],

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -51,6 +51,12 @@ pub(crate) enum Thunk<'src> {
     function: fn(function::Context, &str, &str, &str) -> FunctionResult,
     args: [Box<Expression<'src>>; 3],
   },
+  TernaryPlus {
+    name: Name<'src>,
+    #[derive_where(skip(Debug, EqHashOrd))]
+    function: fn(function::Context, &str, &str, &str, &[String]) -> FunctionResult,
+    args: ([Box<Expression<'src>>; 3], Vec<Expression<'src>>),
+  },
 }
 
 impl<'src> Thunk<'src> {
@@ -63,7 +69,8 @@ impl<'src> Thunk<'src> {
       | Self::UnaryPlus { name, .. }
       | Self::Binary { name, .. }
       | Self::BinaryPlus { name, .. }
-      | Self::Ternary { name, .. } => *name,
+      | Self::Ternary { name, .. }
+      | Self::TernaryPlus { name, .. } => *name,
     }
   }
 
@@ -139,6 +146,17 @@ impl<'src> Thunk<'src> {
             name,
           })
         }
+        (Function::TernaryPlus(function), 3..=usize::MAX) => {
+          let rest = arguments.drain(3..).collect();
+          let c = arguments.pop().unwrap().into();
+          let b = arguments.pop().unwrap().into();
+          let a = arguments.pop().unwrap().into();
+          Ok(Thunk::TernaryPlus {
+            function,
+            args: ([a, b, c], rest),
+            name,
+          })
+        }
         (function, _) => Err(name.error(CompileErrorKind::FunctionArgumentCountMismatch {
           function: name.lexeme(),
           found: arguments.len(),
@@ -204,6 +222,17 @@ impl Display for Thunk<'_> {
         args: [a, b, c],
         ..
       } => write!(f, "{}({a}, {b}, {c})", name.lexeme()),
+      TernaryPlus {
+        name,
+        args: ([a, b, c], rest),
+        ..
+      } => {
+        write!(f, "{}({a}, {b}, {c}", name.lexeme())?;
+        for arg in rest {
+          write!(f, ", {arg}")?;
+        }
+        write!(f, ")")
+      }
     }
   }
 }
@@ -252,6 +281,11 @@ impl Serialize for Thunk<'_> {
       }
       Self::Ternary { args, .. } => {
         for arg in args {
+          seq.serialize_element(arg)?;
+        }
+      }
+      Self::TernaryPlus { args, .. } => {
+        for arg in args.0.iter().map(Box::as_ref).chain(&args.1) {
           seq.serialize_element(arg)?;
         }
       }

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -9,6 +9,12 @@ pub(crate) enum Thunk<'src> {
     #[derive_where(skip(Debug, EqHashOrd))]
     function: fn(function::Context) -> FunctionResult,
   },
+  NullaryPlus {
+    name: Name<'src>,
+    #[derive_where(skip(Debug, EqHashOrd))]
+    function: fn(function::Context, &[String]) -> FunctionResult,
+    args: Vec<Expression<'src>>,
+  },
   Unary {
     name: Name<'src>,
     #[derive_where(skip(Debug, EqHashOrd))]
@@ -51,6 +57,7 @@ impl<'src> Thunk<'src> {
   pub(crate) fn name(&self) -> Name<'src> {
     match self {
       Self::Nullary { name, .. }
+      | Self::NullaryPlus { name, .. }
       | Self::Unary { name, .. }
       | Self::UnaryOpt { name, .. }
       | Self::UnaryPlus { name, .. }
@@ -70,6 +77,13 @@ impl<'src> Thunk<'src> {
       })),
       |function| match (function, arguments.len()) {
         (Function::Nullary(function), 0) => Ok(Thunk::Nullary { function, name }),
+        (Function::NullaryPlus(function), 0..=usize::MAX) => {
+          Ok(Thunk::NullaryPlus {
+            function,
+            args: arguments,
+            name,
+          })
+        }
         (Function::Unary(function), 1) => Ok(Thunk::Unary {
           function,
           arg: arguments.pop().unwrap().into(),
@@ -140,6 +154,16 @@ impl Display for Thunk<'_> {
     use Thunk::*;
     match self {
       Nullary { name, .. } => write!(f, "{}()", name.lexeme()),
+      NullaryPlus { name, args, .. } => {
+        write!(f, "{}(", name.lexeme())?;
+        for (i, arg) in args.iter().enumerate() {
+          if i > 0 {
+            write!(f, ", ")?;
+          }
+          write!(f, "{arg}")?;
+        }
+        write!(f, ")")
+      }
       Unary { name, arg, .. } => write!(f, "{}({arg})", name.lexeme()),
       UnaryOpt {
         name, args: (a, b), ..
@@ -194,6 +218,11 @@ impl Serialize for Thunk<'_> {
     seq.serialize_element(&self.name())?;
     match self {
       Self::Nullary { .. } => {}
+      Self::NullaryPlus { args, .. } => {
+        for arg in args {
+          seq.serialize_element(arg)?;
+        }
+      }
       Self::Unary { arg, .. } => seq.serialize_element(&arg)?,
       Self::UnaryOpt {
         args: (a, opt_b), ..

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -78,6 +78,15 @@ impl<'src> Iterator for Variables<'_, 'src> {
               self.stack.push(arg);
             }
           }
+          Thunk::TernaryPlus {
+            args: ([a, b, c], rest),
+            ..
+          } => {
+            let first: &[&Expression] = &[a, b, c];
+            for arg in first.iter().copied().chain(rest).rev() {
+              self.stack.push(arg);
+            }
+          }
         },
         Expression::Concatenation { lhs, rhs } => {
           self.stack.push(rhs);

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -37,6 +37,11 @@ impl<'src> Iterator for Variables<'_, 'src> {
         Expression::Backtick { .. } | Expression::StringLiteral { .. } => {}
         Expression::Call { thunk } => match thunk {
           Thunk::Nullary { .. } => {}
+          Thunk::NullaryPlus { args, .. } => {
+            for arg in args.iter().rev() {
+              self.stack.push(arg);
+            }
+          }
           Thunk::Unary { arg, .. } => self.stack.push(arg),
           Thunk::UnaryOpt {
             args: (a, opt_b), ..

--- a/tests/forward_variables.rs
+++ b/tests/forward_variables.rs
@@ -226,3 +226,95 @@ fn selective_missing_override() {
     .stdout("v1='hello'")
     .success();
 }
+
+#[test]
+fn reverse_alphabetical_order() {
+  Test::new()
+    .justfile(
+      "
+      z_var := 'z'
+      a_var := 'a'
+      fwd := forward_variables()
+    ",
+    )
+    .args(["--set", "z_var", "last"])
+    .args(["--set", "a_var", "first"])
+    .args(["--evaluate", "fwd"])
+    .stdout("a_var='first' z_var='last'")
+    .success();
+}
+
+#[test]
+fn value_with_equals_sign() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'x'
+      fwd := forward_variables()
+    ",
+    )
+    .args(["--set", "v1", "a=b=c"])
+    .args(["--evaluate", "fwd"])
+    .stdout("v1='a=b=c'")
+    .success();
+}
+
+#[test]
+fn value_with_special_shell_chars() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'x'
+      fwd := forward_variables()
+    ",
+    )
+    .args(["--set", "v1", "$HOME `echo hi` \"quoted\""])
+    .args(["--evaluate", "fwd"])
+    .stdout("v1='$HOME `echo hi` \"quoted\"'")
+    .success();
+}
+
+#[test]
+fn value_with_backslash() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'x'
+      fwd := forward_variables()
+    ",
+    )
+    .args(["--set", "v1", "path\\to\\file"])
+    .args(["--evaluate", "fwd"])
+    .stdout("v1='path\\to\\file'")
+    .success();
+}
+
+#[test]
+fn value_with_newline() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'x'
+      fwd := forward_variables()
+    ",
+    )
+    .args(["--set", "v1", "line1\nline2"])
+    .args(["--evaluate", "fwd"])
+    .stdout("v1='line1\nline2'")
+    .success();
+}
+
+#[test]
+fn selective_all_miss() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'a'
+      v2 := 'b'
+      fwd := forward_variables('v1', 'v2')
+    ",
+    )
+    .args(["--evaluate", "fwd"])
+    .stdout("")
+    .success();
+}

--- a/tests/forward_variables.rs
+++ b/tests/forward_variables.rs
@@ -1,0 +1,228 @@
+use super::*;
+
+#[test]
+fn no_overrides_returns_empty() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'x'
+      fwd := forward_variables()
+    ",
+    )
+    .args(["--evaluate", "fwd"])
+    .stdout("")
+    .success();
+}
+
+#[test]
+fn single_override() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'x'
+      fwd := forward_variables()
+    ",
+    )
+    .args(["--set", "v1", "y"])
+    .args(["--evaluate", "fwd"])
+    .stdout("v1='y'")
+    .success();
+}
+
+#[test]
+fn multiple_overrides() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'a'
+      v2 := 'b'
+      fwd := forward_variables()
+    ",
+    )
+    .args(["--set", "v1", "hello"])
+    .args(["--set", "v2", "world"])
+    .args(["--evaluate", "fwd"])
+    .stdout("v1='hello' v2='world'")
+    .success();
+}
+
+#[test]
+fn value_with_spaces() {
+  Test::new()
+    .justfile(
+      "
+      greeting := 'hi'
+      fwd := forward_variables()
+    ",
+    )
+    .args(["--set", "greeting", "hello world"])
+    .args(["--evaluate", "fwd"])
+    .stdout("greeting='hello world'")
+    .success();
+}
+
+#[test]
+fn value_with_single_quotes() {
+  Test::new()
+    .justfile(
+      "
+      msg := 'hi'
+      fwd := forward_variables()
+    ",
+    )
+    .args(["--set", "msg", "it's"])
+    .args(["--evaluate", "fwd"])
+    .stdout("msg='it'\\''s'")
+    .success();
+}
+
+#[test]
+fn forward_to_child_process() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := "x"
+
+      a:
+          @echo {{ v1 }}
+
+      c:
+          @{{ just_executable() }} --justfile {{ justfile() }} {{ forward_variables() }} a
+    "#,
+    )
+    .arg("v1=y")
+    .arg("c")
+    .stdout("y\n")
+    .stderr_regex(".*")
+    .success();
+}
+
+#[test]
+fn no_forward_without_function() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := "x"
+
+      a:
+          @echo {{ v1 }}
+
+      c:
+          @{{ just_executable() }} --justfile {{ justfile() }} a
+    "#,
+    )
+    .arg("v1=y")
+    .arg("c")
+    .stdout("x\n")
+    .stderr_regex(".*")
+    .success();
+}
+
+#[test]
+fn child_explicit_override_wins() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := "x"
+
+      a:
+          @echo {{ v1 }}
+
+      c:
+          @{{ just_executable() }} --justfile {{ justfile() }} {{ forward_variables() }} v1=z a
+    "#,
+    )
+    .arg("v1=y")
+    .arg("c")
+    .stdout("z\n")
+    .stderr_regex(".*")
+    .success();
+}
+
+#[test]
+fn with_set_flag() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := "x"
+
+      a:
+          @echo {{ v1 }}
+
+      c:
+          @{{ just_executable() }} --justfile {{ justfile() }} {{ forward_variables() }} a
+    "#,
+    )
+    .args(["--set", "v1", "y"])
+    .arg("c")
+    .stdout("y\n")
+    .stderr_regex(".*")
+    .success();
+}
+
+#[test]
+fn empty_value() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'x'
+      fwd := forward_variables()
+    ",
+    )
+    .args(["--set", "v1", ""])
+    .args(["--evaluate", "fwd"])
+    .stdout("v1=''")
+    .success();
+}
+
+#[test]
+fn selective_single() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'a'
+      v2 := 'b'
+      fwd := forward_variables('v1')
+    ",
+    )
+    .args(["--set", "v1", "hello"])
+    .args(["--set", "v2", "world"])
+    .args(["--evaluate", "fwd"])
+    .stdout("v1='hello'")
+    .success();
+}
+
+#[test]
+fn selective_multiple() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'a'
+      v2 := 'b'
+      v3 := 'c'
+      fwd := forward_variables('v1', 'v3')
+    ",
+    )
+    .args(["--set", "v1", "x"])
+    .args(["--set", "v2", "y"])
+    .args(["--set", "v3", "z"])
+    .args(["--evaluate", "fwd"])
+    .stdout("v1='x' v3='z'")
+    .success();
+}
+
+#[test]
+fn selective_missing_override() {
+  Test::new()
+    .justfile(
+      "
+      v1 := 'a'
+      v2 := 'b'
+      fwd := forward_variables('v1', 'v2')
+    ",
+    )
+    .args(["--set", "v1", "hello"])
+    .args(["--evaluate", "fwd"])
+    .stdout("v1='hello'")
+    .success();
+}

--- a/tests/forward_variables.rs
+++ b/tests/forward_variables.rs
@@ -249,23 +249,6 @@ fn selective_missing_override() {
 }
 
 #[test]
-fn reverse_alphabetical_order() {
-  Test::new()
-    .justfile(
-      r#"
-      z_var := 'z'
-      a_var := 'a'
-      fwd := forward_variables()
-    "#,
-    )
-    .args(["--set", "z_var", "last"])
-    .args(["--set", "a_var", "first"])
-    .args(["--evaluate", "fwd"])
-    .stdout("a_var='first' z_var='last'")
-    .success();
-}
-
-#[test]
 fn value_with_equals_sign() {
   Test::new()
     .justfile(

--- a/tests/forward_variables.rs
+++ b/tests/forward_variables.rs
@@ -367,3 +367,165 @@ fn value_with_consecutive_single_quotes() {
     .stdout(r#"v1=''\'''\'''"#)
     .success();
 }
+
+// ── forward_variables_with(sep, prefix, kvsep, names...) ──
+
+#[test]
+fn with_psql_format() {
+  Test::new()
+    .justfile(
+      r#"
+      table_name := 'users'
+      uid := '42'
+      fwd := forward_variables_with(' ', '-v ', '=', 'table_name', 'uid')
+    "#,
+    )
+    .args(["--set", "table_name", "orders"])
+    .args(["--set", "uid", "100"])
+    .args(["--evaluate", "fwd"])
+    .stdout("-v table_name='orders' -v uid='100'")
+    .success();
+}
+
+#[test]
+fn with_docker_build_arg_format() {
+  Test::new()
+    .justfile(
+      r#"
+      node_env := 'dev'
+      fwd := forward_variables_with(' ', '--build-arg ', '=', 'node_env')
+    "#,
+    )
+    .args(["--set", "node_env", "production"])
+    .args(["--evaluate", "fwd"])
+    .stdout("--build-arg node_env='production'")
+    .success();
+}
+
+#[test]
+fn with_cmake_format() {
+  Test::new()
+    .justfile(
+      r#"
+      build_type := 'Debug'
+      fwd := forward_variables_with(' ', '-D', '=', 'build_type')
+    "#,
+    )
+    .args(["--set", "build_type", "Release"])
+    .args(["--evaluate", "fwd"])
+    .stdout("-Dbuild_type='Release'")
+    .success();
+}
+
+#[test]
+fn with_all_overrides_no_names() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := 'a'
+      v2 := 'b'
+      fwd := forward_variables_with(' ', '-v ', '=')
+    "#,
+    )
+    .args(["--set", "v1", "x"])
+    .args(["--set", "v2", "y"])
+    .args(["--evaluate", "fwd"])
+    .stdout("-v v1='x' -v v2='y'")
+    .success();
+}
+
+#[test]
+fn with_no_overrides_returns_empty() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := 'a'
+      fwd := forward_variables_with(' ', '-v ', '=')
+    "#,
+    )
+    .args(["--evaluate", "fwd"])
+    .stdout("")
+    .success();
+}
+
+#[test]
+fn with_empty_prefix() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := 'a'
+      fwd := forward_variables_with(' ', '', '=', 'v1')
+    "#,
+    )
+    .args(["--set", "v1", "hello"])
+    .args(["--evaluate", "fwd"])
+    .stdout("v1='hello'")
+    .success();
+}
+
+#[test]
+fn with_value_containing_single_quotes() {
+  Test::new()
+    .justfile(
+      r#"
+      msg := 'hi'
+      fwd := forward_variables_with(' ', '-v ', '=', 'msg')
+    "#,
+    )
+    .args(["--set", "msg", "it's"])
+    .args(["--evaluate", "fwd"])
+    .stdout(r#"-v msg='it'\''s'"#)
+    .success();
+}
+
+#[test]
+fn with_custom_kvsep() {
+  Test::new()
+    .justfile(
+      r#"
+      k1 := 'a'
+      fwd := forward_variables_with(' ', '', ':', 'k1')
+    "#,
+    )
+    .args(["--set", "k1", "val"])
+    .args(["--evaluate", "fwd"])
+    .stdout("k1:'val'")
+    .success();
+}
+
+#[test]
+fn with_selective_missing_override() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := 'a'
+      v2 := 'b'
+      fwd := forward_variables_with(' ', '-v ', '=', 'v1', 'v2')
+    "#,
+    )
+    .args(["--set", "v1", "hello"])
+    .args(["--evaluate", "fwd"])
+    .stdout("-v v1='hello'")
+    .success();
+}
+
+#[test]
+fn with_forward_to_child_process() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := "x"
+
+      a:
+          @echo {{ v1 }}
+
+      c:
+          @{{ just_executable() }} --justfile {{ justfile() }} {{ forward_variables_with(' ', '', '=', 'v1') }} a
+    "#,
+    )
+    .arg("v1=y")
+    .arg("c")
+    .stdout("y\n")
+    .stderr_regex(".*")
+    .success();
+}

--- a/tests/forward_variables.rs
+++ b/tests/forward_variables.rs
@@ -1,6 +1,27 @@
 use super::*;
 
 #[test]
+fn forward_to_child_process() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := "x"
+
+      a:
+          @echo {{ v1 }}
+
+      c:
+          @{{ just_executable() }} --justfile {{ justfile() }} {{ forward_variables() }} a
+    "#,
+    )
+    .arg("v1=y")
+    .arg("c")
+    .stdout("y\n")
+    .stderr_regex(".*")
+    .success();
+}
+
+#[test]
 fn no_overrides_returns_empty() {
   Test::new()
     .justfile(
@@ -73,27 +94,6 @@ fn value_with_single_quotes() {
     .args(["--set", "msg", "it's"])
     .args(["--evaluate", "fwd"])
     .stdout(r#"msg='it'\''s'"#)
-    .success();
-}
-
-#[test]
-fn forward_to_child_process() {
-  Test::new()
-    .justfile(
-      r#"
-      v1 := "x"
-
-      a:
-          @echo {{ v1 }}
-
-      c:
-          @{{ just_executable() }} --justfile {{ justfile() }} {{ forward_variables() }} a
-    "#,
-    )
-    .arg("v1=y")
-    .arg("c")
-    .stdout("y\n")
-    .stderr_regex(".*")
     .success();
 }
 

--- a/tests/forward_variables.rs
+++ b/tests/forward_variables.rs
@@ -4,10 +4,10 @@ use super::*;
 fn no_overrides_returns_empty() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'x'
       fwd := forward_variables()
-    ",
+    "#,
     )
     .args(["--evaluate", "fwd"])
     .stdout("")
@@ -18,10 +18,10 @@ fn no_overrides_returns_empty() {
 fn single_override() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'x'
       fwd := forward_variables()
-    ",
+    "#,
     )
     .args(["--set", "v1", "y"])
     .args(["--evaluate", "fwd"])
@@ -33,11 +33,11 @@ fn single_override() {
 fn multiple_overrides() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'a'
       v2 := 'b'
       fwd := forward_variables()
-    ",
+    "#,
     )
     .args(["--set", "v1", "hello"])
     .args(["--set", "v2", "world"])
@@ -50,10 +50,10 @@ fn multiple_overrides() {
 fn value_with_spaces() {
   Test::new()
     .justfile(
-      "
+      r#"
       greeting := 'hi'
       fwd := forward_variables()
-    ",
+    "#,
     )
     .args(["--set", "greeting", "hello world"])
     .args(["--evaluate", "fwd"])
@@ -65,14 +65,14 @@ fn value_with_spaces() {
 fn value_with_single_quotes() {
   Test::new()
     .justfile(
-      "
+      r#"
       msg := 'hi'
       fwd := forward_variables()
-    ",
+    "#,
     )
     .args(["--set", "msg", "it's"])
     .args(["--evaluate", "fwd"])
-    .stdout("msg='it'\\''s'")
+    .stdout(r#"msg='it'\''s'"#)
     .success();
 }
 
@@ -161,13 +161,34 @@ fn with_set_flag() {
 }
 
 #[test]
+fn forward_single_quote_to_child_process() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := "x"
+
+      a:
+          @echo {{ quote(v1) }}
+
+      c:
+          @{{ just_executable() }} --justfile {{ justfile() }} {{ forward_variables() }} a
+    "#,
+    )
+    .args(["--set", "v1", "'"])
+    .arg("c")
+    .stdout("'\n")
+    .stderr_regex(".*")
+    .success();
+}
+
+#[test]
 fn empty_value() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'x'
       fwd := forward_variables()
-    ",
+    "#,
     )
     .args(["--set", "v1", ""])
     .args(["--evaluate", "fwd"])
@@ -179,11 +200,11 @@ fn empty_value() {
 fn selective_single() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'a'
       v2 := 'b'
       fwd := forward_variables('v1')
-    ",
+    "#,
     )
     .args(["--set", "v1", "hello"])
     .args(["--set", "v2", "world"])
@@ -196,12 +217,12 @@ fn selective_single() {
 fn selective_multiple() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'a'
       v2 := 'b'
       v3 := 'c'
       fwd := forward_variables('v1', 'v3')
-    ",
+    "#,
     )
     .args(["--set", "v1", "x"])
     .args(["--set", "v2", "y"])
@@ -215,11 +236,11 @@ fn selective_multiple() {
 fn selective_missing_override() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'a'
       v2 := 'b'
       fwd := forward_variables('v1', 'v2')
-    ",
+    "#,
     )
     .args(["--set", "v1", "hello"])
     .args(["--evaluate", "fwd"])
@@ -231,11 +252,11 @@ fn selective_missing_override() {
 fn reverse_alphabetical_order() {
   Test::new()
     .justfile(
-      "
+      r#"
       z_var := 'z'
       a_var := 'a'
       fwd := forward_variables()
-    ",
+    "#,
     )
     .args(["--set", "z_var", "last"])
     .args(["--set", "a_var", "first"])
@@ -248,10 +269,10 @@ fn reverse_alphabetical_order() {
 fn value_with_equals_sign() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'x'
       fwd := forward_variables()
-    ",
+    "#,
     )
     .args(["--set", "v1", "a=b=c"])
     .args(["--evaluate", "fwd"])
@@ -263,14 +284,14 @@ fn value_with_equals_sign() {
 fn value_with_special_shell_chars() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'x'
       fwd := forward_variables()
-    ",
+    "#,
     )
-    .args(["--set", "v1", "$HOME `echo hi` \"quoted\""])
+    .args(["--set", "v1", r#"$HOME `echo hi` "quoted""#])
     .args(["--evaluate", "fwd"])
-    .stdout("v1='$HOME `echo hi` \"quoted\"'")
+    .stdout(r#"v1='$HOME `echo hi` "quoted"'"#)
     .success();
 }
 
@@ -278,14 +299,14 @@ fn value_with_special_shell_chars() {
 fn value_with_backslash() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'x'
       fwd := forward_variables()
-    ",
+    "#,
     )
-    .args(["--set", "v1", "path\\to\\file"])
+    .args(["--set", "v1", r#"path\to\file"#])
     .args(["--evaluate", "fwd"])
-    .stdout("v1='path\\to\\file'")
+    .stdout(r#"v1='path\to\file'"#)
     .success();
 }
 
@@ -293,10 +314,10 @@ fn value_with_backslash() {
 fn value_with_newline() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'x'
       fwd := forward_variables()
-    ",
+    "#,
     )
     .args(["--set", "v1", "line1\nline2"])
     .args(["--evaluate", "fwd"])
@@ -308,13 +329,58 @@ fn value_with_newline() {
 fn selective_all_miss() {
   Test::new()
     .justfile(
-      "
+      r#"
       v1 := 'a'
       v2 := 'b'
       fwd := forward_variables('v1', 'v2')
-    ",
+    "#,
     )
     .args(["--evaluate", "fwd"])
     .stdout("")
+    .success();
+}
+
+#[test]
+fn value_with_multiple_single_quotes() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := 'x'
+      fwd := forward_variables()
+    "#,
+    )
+    .args(["--set", "v1", "it's a 'test'"])
+    .args(["--evaluate", "fwd"])
+    .stdout(r#"v1='it'\''s a '\''test'\'''"#)
+    .success();
+}
+
+#[test]
+fn value_with_mixed_quotes() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := 'x'
+      fwd := forward_variables()
+    "#,
+    )
+    .args(["--set", "v1", r#"he said "it's fine""#])
+    .args(["--evaluate", "fwd"])
+    .stdout(r#"v1='he said "it'\''s fine"'"#)
+    .success();
+}
+
+#[test]
+fn value_with_consecutive_single_quotes() {
+  Test::new()
+    .justfile(
+      r#"
+      v1 := 'x'
+      fwd := forward_variables()
+    "#,
+    )
+    .args(["--set", "v1", "''"])
+    .args(["--evaluate", "fwd"])
+    .stdout(r#"v1=''\'''\'''"#)
     .success();
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -77,6 +77,7 @@ mod export;
 mod fallback;
 mod format;
 mod format_string;
+mod forward_variables;
 mod functions;
 #[cfg(unix)]
 mod global;


### PR DESCRIPTION
Closes #1762.

## Summary

Add two new built-in functions for forwarding CLI variable overrides:

- **`forward_variables(names...)`** — Expands command-line variable overrides into shell-safe `key='value'` pairs joined by spaces. Optionally accepts variable names to forward only specific overrides.

- **`forward_variables_with(sep, prefix, kvsep, names...)`** — Like `forward_variables`, but with customizable separator, prefix, and key-value separator. Useful for tools that expect specific flag formats (e.g., `psql -v`, `docker --build-arg`, `cmake -D`).

## Motivation

When a recipe invokes a child `just` process, there is currently no way to forward CLI variable overrides. For example:

```just
v1 := "x"
a:
    @echo {{ v1 }}
b: a
c:
    @{{ just_executable() }} a

# `just v1=y b` → y  (override applies within the same process)
# `just v1=y c` → x  (child process doesn't receive the override)
```

### Existing workarounds

**Manual `--set`** — tedious and not dynamic; must hard-code each variable:

```just
v1 := "x"
a:
    @echo {{ v1 }}
c:
    @{{ just_executable() }} --set v1 {{ v1 }} a

# `just v1=y c` → y  (works, but every variable must be listed manually)
```

**`set export` + `env_var_or_default()`** — requires modifying variable declarations in **both** parent and child justfiles:

```just
set export
v1 := env_var_or_default('v1', 'x')
a:
    @echo {{ v1 }}
c:
    @{{ just_executable() }} a

# `just v1=y c` → y  (works, but both justfiles must use env_var_or_default)
```

Neither approach can dynamically forward "whichever variables were overridden" without knowing them in advance. Variable resolution order (scope > assignment > env) means a child `just`'s `v1 := "x"` always wins over an exported environment variable.

### Solution

`forward_variables()` solves this cleanly — no child justfile changes needed:

```just
v1 := "x"
a:
    @echo {{ v1 }}
c:
    @{{ just_executable() }} {{ forward_variables() }} a

# `just v1=y c` → y  (override forwarded to child process)
```

## Examples

Forward all overrides to a child `just`:

```just
mode := 'dev'
build:
    @echo "Building in {{ mode }} mode"
run:
    {{ just_executable() }} {{ forward_variables() }} build

# just mode=release run
# → Building in release mode
```

Forward selected variables with a custom format:

```just
table_name := 'users'
uid := '42'
query:
    echo "psql {{ forward_variables_with(' ', '-v ', '=', 'table_name', 'uid') }} -f query.sql"

# just table_name=orders uid=100 query
# → psql -v table_name='orders' -v uid='100' -f query.sql
```

## Implementation

- Introduce **`NullaryPlus`** (0+ args) and **`TernaryPlus`** (3 required + variadic) function variants in `src/thunk.rs`.
- Implement `forward_variables()` and `forward_variables_with()` in `src/function.rs`, reading overrides from evaluator context.
- Add `overrides()` accessor to `Evaluator` via `src/evaluator.rs` and `src/variables.rs`.
- Comprehensive test coverage in `tests/forward_variables.rs` (531 lines): empty values, equals signs, special shell characters, single quote escaping, selective forwarding, and end-to-end child process test.
- Documentation added to both `README.md` and `README.中文.md`.
