### PR TITLE
docs: fix typo in Zed extension note

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ out of the box, thanks to [tomodachi94](https://github.com/tomodachi94).
 ### Zed
 
 The [zed-just](https://github.com/jackTabsCode/zed-just/) extension by
-[jackTabsCode](https://github.com/jackTabsCode) is avilable on the
+[jackTabsCode](https://github.com/jackTabsCode) is available on the
 [Zed extensions page](https://zed.dev/extensions?query=just).
 
 ### Other Editors


### PR DESCRIPTION
## Summary
- fix "avilable" to "available" in the README Zed extension section

## Related issue
- N/A (trivial docs fix)

## Guideline alignment
- Follows [CONTRIBUTING.md](https://github.com/casey/just/blob/master/CONTRIBUTING.md): single-file docs-only change with no behavior impact

## Validation
- Not run (documentation-only change)
