### PR TITLE
Fix README signal-handling typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4324,7 +4324,7 @@ for details.
 
 ### Signal Handling
 
-[Signals](https://en.wikipedia.org/wiki/Signal_(IPC)) are messsages sent to
+[Signals](https://en.wikipedia.org/wiki/Signal_(IPC)) are messages sent to
 running programs to trigger specific behavior. For example, `SIGINT` is sent to
 all processes in the terminal forground process group when `CTRL-C` is pressed.
 


### PR DESCRIPTION
Summary

Fix a typo in the README signal handling section by changing "messsages" to "messages".

Related issue

N/A

Guideline alignment

Single-file docs change from master, aligned with CONTRIBUTING.md and the README contribution guidance.

Validation/testing

Not run; docs-only change.