### PR TITLE
docs: fix README grammar around integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4741,7 +4741,7 @@ of tricky edge cases which are easy to exercise with unit tests that call
 Integration tests are useful for making sure that the final behavior of the
 `just` binary is correct. `unindent()` is also covered by integration tests
 which make sure that evaluating a triple-quoted string produces the correct
-unindented value. However, there are not integration tests for all possible
+unindented value. However, there are no integration tests for all possible
 cases. These are covered by faster, more concise unit tests that call
 `unindent()` directly.
 


### PR DESCRIPTION
## Summary
- fix the README sentence about integration test coverage
- keep the change limited to one file with no behavior impact

## Related issue
- N/A

## Guideline alignment
- Minimal docs-only change following the repo contribution guidance: https://github.com/casey/just/blob/master/README.md#contributing

## Validation/testing
- Not run; README-only change
