### PR TITLE
docs: fix README grammar for suppressing unstable feature errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ leisure.
 
 Features that aren't yet ready for stabilization are marked as unstable and may
 be changed or removed at any time. Using unstable features produces an error by
-default, which can be suppressed with by passing the `--unstable` flag,
+default, which can be suppressed by passing the `--unstable` flag,
 `set unstable`, or setting the environment variable `JUST_UNSTABLE`, to any
 value other than `false`, `0`, or the empty string.
 


### PR DESCRIPTION
## Problem

In the **Backwards Compatibility** section, the sentence describing how to allow unstable features mixes two constructions, producing invalid English: *"suppressed with by passing"*.

## Why this matters

Readers rely on the README as primary documentation linked from the repo homepage. Awkward or incorrect wording can obscure the actual mechanism (`--unstable`, `set unstable`, or `JUST_UNSTABLE`).

## What changed

- Single-word fix: remove the stray *"with"* so the phrase reads *"suppressed by passing the \`--unstable\` flag"*.

## Safety / risk

- Documentation-only change (one line in `README.md`).
- No impact on CLI behavior, defaults, or `justfile` semantics.
- Does not touch any ```just``` fenced examples exercised by `tests/readme.rs`.

## Behavior impact

None.

## Issue

None filed; this is a straightforward typo noticed while reading the documentation.

Made with [Cursor](https://cursor.com)