### PR TITLE
docs: fix README grammar for suppressing unstable feature errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ leisure.
 
 Features that aren't yet ready for stabilization are marked as unstable and may
 be changed or removed at any time. Using unstable features produces an error by
-default, which can be suppressed with by passing the `--unstable` flag,
+default, which can be suppressed by passing the `--unstable` flag,
 `set unstable`, or setting the environment variable `JUST_UNSTABLE`, to any
 value other than `false`, `0`, or the empty string.
 


### PR DESCRIPTION
## Problem

In the Backwards Compatibility section, the sentence about unstable features used invalid English: "suppressed with by passing".

## Why this matters

The README is primary documentation; incorrect wording can distract from the actual options (--unstable, set unstable, JUST_UNSTABLE).

## What changed

Removed the stray "with" so it reads "suppressed by passing the --unstable flag".

## Safety

Documentation-only (one line in README.md). No CLI or justfile behavior change. No ```just``` fenced examples were modified (tests/readme.rs only parses those blocks).

## Issue

None (typo fix).
