### PR TITLE
docs: fix signal process group typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4334,7 +4334,7 @@ for details.
 
 [Signals](https://en.wikipedia.org/wiki/Signal_(IPC)) are messages sent to
 running programs to trigger specific behavior. For example, `SIGINT` is sent to
-all processes in the terminal forground process group when `CTRL-C` is pressed.
+all processes in the terminal foreground process group when `CTRL-C` is pressed.
 
 `just` tries to exit when requested by a signal, but it also tries to avoid
 leaving behind running child proccesses, two goals which are somewhat in


### PR DESCRIPTION
## Summary
- fix "forground" -> "foreground" in the signal handling section of the README

## Related issue
- N/A (trivial docs typo fix)

## Guideline alignment
- CONTRIBUTING: https://github.com/casey/just/blob/master/CONTRIBUTING.md
- PR template: N/A

## Validation
- Not run (docs-only change)
