### PR TITLE
docs: fix signal handling typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4342,7 +4342,7 @@ running programs to trigger specific behavior. For example, `SIGINT` is sent to
 all processes in the terminal foreground process group when `CTRL-C` is pressed.
 
 `just` tries to exit when requested by a signal, but it also tries to avoid
-leaving behind running child proccesses, two goals which are somewhat in
+leaving behind running child processes, two goals which are somewhat in
 conflict.
 
 If `just` exits leaving behind child processes, the user will have no recourse


### PR DESCRIPTION
## Summary
- fix "proccesses" -> "processes" in the signal handling section of the README

## Related issue
- N/A (trivial docs typo fix)

## Guideline alignment
- CONTRIBUTING: https://github.com/casey/just/blob/master/CONTRIBUTING.md
- PR template: N/A

## Validation
- Not run (docs-only change)
