### PR TITLE
docs: fix signal handling typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4347,7 +4347,7 @@ conflict.
 
 If `just` exits leaving behind child processes, the user will have no recourse
 but to `ps aux | grep` for the children and manually `kill` them, a tedious
-endevour.
+endeavour.
 
 #### Fatal Signals
 

--- a/README.md
+++ b/README.md
@@ -4347,7 +4347,7 @@ conflict.
 
 If `just` exits leaving behind child processes, the user will have no recourse
 but to `ps aux | grep` for the children and manually `kill` them, a tedious
-endeavour.
+endeavor.
 
 #### Fatal Signals
 


### PR DESCRIPTION
## Summary
- fix "endevour" -> "endeavour" in the signal handling section of the README

## Related issue
- N/A (trivial docs typo fix)

## Guideline alignment
- CONTRIBUTING: https://github.com/casey/just/blob/master/CONTRIBUTING.md
- PR template: N/A

## Validation
- Not run (docs-only change)
