### PR TITLE
fix(completions): use `--completions` flag for compatibility with older just versions

### DIFF
--- a/completions/just.bash
+++ b/completions/just.bash
@@ -1,1 +1,1 @@
-source <(JUST_COMPLETE=bash just)
+source <(just --completions bash)

--- a/completions/just.elvish
+++ b/completions/just.elvish
@@ -1,1 +1,1 @@
-eval (E:JUST_COMPLETE=elvish just | slurp)
+eval (just --completions elvish | slurp)

--- a/completions/just.fish
+++ b/completions/just.fish
@@ -1,1 +1,1 @@
-JUST_COMPLETE=fish just | source
+just --completions fish | source

--- a/completions/just.powershell
+++ b/completions/just.powershell
@@ -1,3 +1,1 @@
-$env:JUST_COMPLETE = "powershell"
-just | Out-String | Invoke-Expression
-Remove-Item Env:\JUST_COMPLETE
+just --completions powershell | Out-String | Invoke-Expression

--- a/completions/just.zsh
+++ b/completions/just.zsh
@@ -1,1 +1,1 @@
-source <(JUST_COMPLETE=zsh just)
+source <(just --completions zsh)


### PR DESCRIPTION
Mitigates: https://github.com/casey/just/issues/3188

