### PR TITLE
Fix `--set` missing value error message path interpolation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -183,7 +183,7 @@ impl Config {
         Self::parse_override(path)?,
         values
           .next()
-          .ok_or_else(|| ConfigError::internal("--set for `{path}` did not have value"))?
+          .ok_or_else(|| ConfigError::internal(format!("--set for `{path}` did not have value")))?
           .into(),
       );
     }


### PR DESCRIPTION
When `--set` was used without a value, the internal error string contained a literal `{path}` instead of the actual config path because the message was not formatted with `format!`.

This change interpolates `path` so the error is actionable.