### PR TITLE
Fix `[no-exit-message]` not suppressing signal error messages

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -298,6 +298,29 @@ impl<'src> Error<'src> {
     }
   }
 
+  /// `Self::Signal` if process was terminated by a signal otherwise
+  /// `Self::UnknownFailure`.
+  pub(crate) fn from_signal(
+    exit_status: ExitStatus,
+    line_number: Option<usize>,
+    print_message: bool,
+    recipe: &'src str,
+  ) -> Self {
+    match Platform::signal_from_exit_status(exit_status) {
+      Some(signal) => Self::Signal {
+        line_number,
+        print_message,
+        recipe,
+        signal,
+      },
+      None => Self::Unknown {
+        line_number,
+        print_message,
+        recipe,
+      },
+    }
+  }
+
   pub(crate) fn internal(message: impl Into<String>) -> Self {
     Self::Internal {
       message: message.into(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -195,10 +195,10 @@ pub(crate) enum Error<'src> {
     recipe: &'src str,
   },
   Signal {
-    recipe: &'src str,
     line_number: Option<usize>,
-    signal: i32,
     print_message: bool,
+    recipe: &'src str,
+    signal: i32,
   },
   #[cfg(windows)]
   SignalHandlerInstall {
@@ -229,9 +229,9 @@ pub(crate) enum Error<'src> {
     io_error: io::Error,
   },
   Unknown {
-    recipe: &'src str,
     line_number: Option<usize>,
     print_message: bool,
+    recipe: &'src str,
   },
   UnknownGroup {
     group: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -198,6 +198,7 @@ pub(crate) enum Error<'src> {
     recipe: &'src str,
     line_number: Option<usize>,
     signal: i32,
+    print_message: bool,
   },
   #[cfg(windows)]
   SignalHandlerInstall {
@@ -230,6 +231,7 @@ pub(crate) enum Error<'src> {
   Unknown {
     recipe: &'src str,
     line_number: Option<usize>,
+    print_message: bool,
   },
   UnknownGroup {
     group: String,
@@ -306,6 +308,12 @@ impl<'src> Error<'src> {
     !matches!(
       self,
       Error::Code {
+        print_message: false,
+        ..
+      } | Error::Signal {
+        print_message: false,
+        ..
+      } | Error::Unknown {
         print_message: false,
         ..
       }
@@ -717,6 +725,7 @@ impl ColorDisplay for Error<'_> {
         recipe,
         line_number,
         signal,
+        ..
       } => {
         if let Some(n) = line_number {
           write!(
@@ -766,6 +775,7 @@ impl ColorDisplay for Error<'_> {
       Unknown {
         recipe,
         line_number,
+        ..
       } => {
         if let Some(n) = line_number {
           write!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -305,19 +305,12 @@ impl<'src> Error<'src> {
   }
 
   pub(crate) fn print_message(&self) -> bool {
-    !matches!(
-      self,
-      Error::Code {
-        print_message: false,
-        ..
-      } | Error::Signal {
-        print_message: false,
-        ..
-      } | Error::Unknown {
-        print_message: false,
-        ..
-      }
-    )
+    match self {
+      Self::Code { print_message, .. }
+      | Self::Signal { print_message, .. }
+      | Self::Unknown { print_message, .. } => *print_message,
+      _ => true,
+    }
   }
 
   fn source(&self) -> Option<&dyn std::error::Error> {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -2,16 +2,23 @@ use super::*;
 
 /// Return a `Error::Signal` if the process was terminated by a signal,
 /// otherwise return an `Error::UnknownFailure`
-fn error_from_signal(recipe: &str, line_number: Option<usize>, exit_status: ExitStatus) -> Error {
+fn error_from_signal(
+  recipe: &str,
+  line_number: Option<usize>,
+  exit_status: ExitStatus,
+  print_message: bool,
+) -> Error {
   match Platform::signal_from_exit_status(exit_status) {
     Some(signal) => Error::Signal {
       recipe,
       line_number,
       signal,
+      print_message,
     },
     None => Error::Unknown {
       recipe,
       line_number,
+      print_message,
     },
   }
 }
@@ -378,6 +385,7 @@ impl<'src, D> Recipe<'src, D> {
               self.name(),
               Some(line_number),
               exit_status,
+              self.print_exit_message(settings),
             ));
           }
         }
@@ -521,7 +529,14 @@ impl<'src, D> Recipe<'src, D> {
 
     match result {
       Ok(exit_status) => exit_status.code().map_or_else(
-        || Err(error_from_signal(self.name(), None, exit_status)),
+        || {
+          Err(error_from_signal(
+            self.name(),
+            None,
+            exit_status,
+            self.print_exit_message(&context.module.settings),
+          ))
+        },
         |code| {
           if code == 0 {
             Ok(())

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -1,28 +1,5 @@
 use super::*;
 
-/// Return a `Error::Signal` if the process was terminated by a signal,
-/// otherwise return an `Error::UnknownFailure`
-fn error_from_signal(
-  exit_status: ExitStatus,
-  line_number: Option<usize>,
-  print_message: bool,
-  recipe: &str,
-) -> Error {
-  match Platform::signal_from_exit_status(exit_status) {
-    Some(signal) => Error::Signal {
-      line_number,
-      print_message,
-      recipe,
-      signal,
-    },
-    None => Error::Unknown {
-      line_number,
-      print_message,
-      recipe,
-    },
-  }
-}
-
 /// A recipe, e.g. `foo: bar baz`
 #[derive(PartialEq, Debug, Clone, Serialize)]
 pub(crate) struct Recipe<'src, D = Dependency<'src>> {
@@ -381,7 +358,7 @@ impl<'src, D> Recipe<'src, D> {
               }
             }
           } else if !infallible {
-            return Err(error_from_signal(
+            return Err(Error::from_signal(
               exit_status,
               Some(line_number),
               self.print_exit_message(settings),
@@ -530,7 +507,7 @@ impl<'src, D> Recipe<'src, D> {
     match result {
       Ok(exit_status) => exit_status.code().map_or_else(
         || {
-          Err(error_from_signal(
+          Err(Error::from_signal(
             exit_status,
             None,
             self.print_exit_message(&context.module.settings),

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -3,22 +3,22 @@ use super::*;
 /// Return a `Error::Signal` if the process was terminated by a signal,
 /// otherwise return an `Error::UnknownFailure`
 fn error_from_signal(
-  recipe: &str,
-  line_number: Option<usize>,
   exit_status: ExitStatus,
+  line_number: Option<usize>,
   print_message: bool,
+  recipe: &str,
 ) -> Error {
   match Platform::signal_from_exit_status(exit_status) {
     Some(signal) => Error::Signal {
-      recipe,
       line_number,
-      signal,
       print_message,
+      recipe,
+      signal,
     },
     None => Error::Unknown {
-      recipe,
       line_number,
       print_message,
+      recipe,
     },
   }
 }
@@ -382,10 +382,10 @@ impl<'src, D> Recipe<'src, D> {
             }
           } else if !infallible {
             return Err(error_from_signal(
-              self.name(),
-              Some(line_number),
               exit_status,
+              Some(line_number),
               self.print_exit_message(settings),
+              self.name(),
             ));
           }
         }
@@ -531,10 +531,10 @@ impl<'src, D> Recipe<'src, D> {
       Ok(exit_status) => exit_status.code().map_or_else(
         || {
           Err(error_from_signal(
-            self.name(),
-            None,
             exit_status,
+            None,
             self.print_exit_message(&context.module.settings),
+            self.name(),
           ))
         },
         |code| {

--- a/tests/no_exit_message.rs
+++ b/tests/no_exit_message.rs
@@ -263,9 +263,6 @@ fn exit_message_and_no_exit_message_compile_forbidden() {
     .failure();
 }
 
-/// `[no-exit-message]` should suppress the error when a recipe is killed by a
-/// signal. The shebang script sends SIGTERM to itself so just sees the child
-/// exit with a signal status rather than an exit code.
 #[test]
 #[cfg(unix)]
 fn signal_exit_message_suppressed() {
@@ -281,7 +278,6 @@ fn signal_exit_message_suppressed() {
     .status(128 + 15); // 128 + SIGTERM
 }
 
-/// Without `[no-exit-message]`, the signal error should still be printed.
 #[test]
 #[cfg(unix)]
 fn signal_exit_message_not_suppressed() {
@@ -297,7 +293,6 @@ fn signal_exit_message_not_suppressed() {
     .status(128 + 15);
 }
 
-/// `set no-exit-message` should also suppress signal errors.
 #[test]
 #[cfg(unix)]
 fn signal_exit_message_setting_suppressed() {

--- a/tests/no_exit_message.rs
+++ b/tests/no_exit_message.rs
@@ -275,7 +275,7 @@ fn signal_exit_message_suppressed() {
           kill -TERM $$
       ",
     )
-    .status(128 + 15); // 128 + SIGTERM
+    .status(128 + 15);
 }
 
 #[test]

--- a/tests/no_exit_message.rs
+++ b/tests/no_exit_message.rs
@@ -1,17 +1,5 @@
 use super::*;
 
-#[cfg(unix)]
-use {
-  nix::{sys::signal::Signal, unistd::Pid},
-  std::process::{Child, Stdio},
-  std::time::Duration,
-};
-
-#[cfg(unix)]
-fn kill(child: &Child, signal: Signal) {
-  nix::sys::signal::kill(Pid::from_raw(child.id().try_into().unwrap()), signal).unwrap();
-}
-
 #[test]
 fn recipe_exit_message_suppressed() {
   Test::new()
@@ -275,129 +263,53 @@ fn exit_message_and_no_exit_message_compile_forbidden() {
     .failure();
 }
 
-/// Verify that `[no-exit-message]` suppresses the error printed when a recipe
-/// is terminated by a signal.
+/// `[no-exit-message]` should suppress the error when a recipe is killed by a
+/// signal. The shebang script sends SIGTERM to itself so just sees the child
+/// exit with a signal status rather than an exit code.
 #[test]
-#[ignore]
 #[cfg(unix)]
 fn signal_exit_message_suppressed() {
-  let tmp = tempdir();
-
-  fs::write(
-    tmp.path().join("justfile"),
-    unindent(
+  Test::new()
+    .justfile(
       "
         [no-exit-message]
         default:
-          @sleep 1
+          #!/usr/bin/env sh
+          kill -TERM $$
       ",
-    ),
-  )
-  .unwrap();
-
-  let start = std::time::Instant::now();
-
-  let mut child = Command::new(JUST)
-    .current_dir(&tmp)
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped())
-    .spawn()
-    .expect("just invocation failed");
-
-  while start.elapsed() < Duration::from_millis(500) {}
-
-  kill(&child, Signal::SIGINT);
-
-  let output = child.wait_with_output().unwrap();
-  let stderr = str::from_utf8(&output.stderr).unwrap();
-
-  assert_eq!(
-    stderr, "",
-    "[no-exit-message] should suppress signal error, got: {stderr:?}"
-  );
-  assert_eq!(output.status.code(), Some(130));
+    )
+    .status(128 + 15); // 128 + SIGTERM
 }
 
-/// Verify that without `[no-exit-message]` the signal error IS printed.
+/// Without `[no-exit-message]`, the signal error should still be printed.
 #[test]
-#[ignore]
 #[cfg(unix)]
 fn signal_exit_message_not_suppressed() {
-  let tmp = tempdir();
-
-  fs::write(
-    tmp.path().join("justfile"),
-    unindent(
+  Test::new()
+    .justfile(
       "
         default:
-          @sleep 1
+          #!/usr/bin/env sh
+          kill -TERM $$
       ",
-    ),
-  )
-  .unwrap();
-
-  let start = std::time::Instant::now();
-
-  let mut child = Command::new(JUST)
-    .current_dir(&tmp)
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped())
-    .spawn()
-    .expect("just invocation failed");
-
-  while start.elapsed() < Duration::from_millis(500) {}
-
-  kill(&child, Signal::SIGINT);
-
-  let output = child.wait_with_output().unwrap();
-  let stderr = str::from_utf8(&output.stderr).unwrap();
-
-  assert!(
-    stderr.contains("was terminated"),
-    "expected signal error message, got: {stderr:?}"
-  );
-  assert_eq!(output.status.code(), Some(130));
+    )
+    .stderr("error: Recipe `default` was terminated by signal 15\n")
+    .status(128 + 15);
 }
 
-/// Verify that `set no-exit-message` also suppresses signal errors.
+/// `set no-exit-message` should also suppress signal errors.
 #[test]
-#[ignore]
 #[cfg(unix)]
 fn signal_exit_message_setting_suppressed() {
-  let tmp = tempdir();
-
-  fs::write(
-    tmp.path().join("justfile"),
-    unindent(
+  Test::new()
+    .justfile(
       "
         set no-exit-message
 
         default:
-          @sleep 1
+          #!/usr/bin/env sh
+          kill -TERM $$
       ",
-    ),
-  )
-  .unwrap();
-
-  let start = std::time::Instant::now();
-
-  let mut child = Command::new(JUST)
-    .current_dir(&tmp)
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped())
-    .spawn()
-    .expect("just invocation failed");
-
-  while start.elapsed() < Duration::from_millis(500) {}
-
-  kill(&child, Signal::SIGINT);
-
-  let output = child.wait_with_output().unwrap();
-  let stderr = str::from_utf8(&output.stderr).unwrap();
-
-  assert_eq!(
-    stderr, "",
-    "`set no-exit-message` should suppress signal error, got: {stderr:?}"
-  );
-  assert_eq!(output.status.code(), Some(130));
+    )
+    .status(128 + 15);
 }

--- a/tests/no_exit_message.rs
+++ b/tests/no_exit_message.rs
@@ -1,5 +1,17 @@
 use super::*;
 
+#[cfg(unix)]
+use {
+  nix::{sys::signal::Signal, unistd::Pid},
+  std::process::{Child, Stdio},
+  std::time::Duration,
+};
+
+#[cfg(unix)]
+fn kill(child: &Child, signal: Signal) {
+  nix::sys::signal::kill(Pid::from_raw(child.id().try_into().unwrap()), signal).unwrap();
+}
+
 #[test]
 fn recipe_exit_message_suppressed() {
   Test::new()
@@ -261,4 +273,131 @@ fn exit_message_and_no_exit_message_compile_forbidden() {
       ",
     )
     .failure();
+}
+
+/// Verify that `[no-exit-message]` suppresses the error printed when a recipe
+/// is terminated by a signal.
+#[test]
+#[ignore]
+#[cfg(unix)]
+fn signal_exit_message_suppressed() {
+  let tmp = tempdir();
+
+  fs::write(
+    tmp.path().join("justfile"),
+    unindent(
+      "
+        [no-exit-message]
+        default:
+          @sleep 1
+      ",
+    ),
+  )
+  .unwrap();
+
+  let start = std::time::Instant::now();
+
+  let mut child = Command::new(JUST)
+    .current_dir(&tmp)
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .expect("just invocation failed");
+
+  while start.elapsed() < Duration::from_millis(500) {}
+
+  kill(&child, Signal::SIGINT);
+
+  let output = child.wait_with_output().unwrap();
+  let stderr = str::from_utf8(&output.stderr).unwrap();
+
+  assert_eq!(
+    stderr, "",
+    "[no-exit-message] should suppress signal error, got: {stderr:?}"
+  );
+  assert_eq!(output.status.code(), Some(130));
+}
+
+/// Verify that without `[no-exit-message]` the signal error IS printed.
+#[test]
+#[ignore]
+#[cfg(unix)]
+fn signal_exit_message_not_suppressed() {
+  let tmp = tempdir();
+
+  fs::write(
+    tmp.path().join("justfile"),
+    unindent(
+      "
+        default:
+          @sleep 1
+      ",
+    ),
+  )
+  .unwrap();
+
+  let start = std::time::Instant::now();
+
+  let mut child = Command::new(JUST)
+    .current_dir(&tmp)
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .expect("just invocation failed");
+
+  while start.elapsed() < Duration::from_millis(500) {}
+
+  kill(&child, Signal::SIGINT);
+
+  let output = child.wait_with_output().unwrap();
+  let stderr = str::from_utf8(&output.stderr).unwrap();
+
+  assert!(
+    stderr.contains("was terminated"),
+    "expected signal error message, got: {stderr:?}"
+  );
+  assert_eq!(output.status.code(), Some(130));
+}
+
+/// Verify that `set no-exit-message` also suppresses signal errors.
+#[test]
+#[ignore]
+#[cfg(unix)]
+fn signal_exit_message_setting_suppressed() {
+  let tmp = tempdir();
+
+  fs::write(
+    tmp.path().join("justfile"),
+    unindent(
+      "
+        set no-exit-message
+
+        default:
+          @sleep 1
+      ",
+    ),
+  )
+  .unwrap();
+
+  let start = std::time::Instant::now();
+
+  let mut child = Command::new(JUST)
+    .current_dir(&tmp)
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .expect("just invocation failed");
+
+  while start.elapsed() < Duration::from_millis(500) {}
+
+  kill(&child, Signal::SIGINT);
+
+  let output = child.wait_with_output().unwrap();
+  let stderr = str::from_utf8(&output.stderr).unwrap();
+
+  assert_eq!(
+    stderr, "",
+    "`set no-exit-message` should suppress signal error, got: {stderr:?}"
+  );
+  assert_eq!(output.status.code(), Some(130));
 }


### PR DESCRIPTION
Fixes #2895.

`[no-exit-message]` and `set no-exit-message` silence the error printed when a recipe exits with a non-zero code, but had no effect when a recipe was terminated by a signal — Ctrl+C on a recipe with `[no-exit-message]` would still print `error: Recipe 'run' was terminated by signal 2`.

The root cause is that `Error::Signal` and `Error::Unknown` had no `print_message` field, so `print_message()` always returned `true` for them regardless of the attribute. The fix adds the field to both variants, threads it through `error_from_signal()`, and passes `print_exit_message()` at both call sites in `run_linewise` and `run_script` — the same plumbing that already works for exit-code errors.

Three Unix-only tests are included: one confirming the error is suppressed with the attribute, one confirming it still appears without, and one for `set no-exit-message`. Tests use a self-signaling shebang (`kill -TERM $$`) so they run in normal CI with no timing sensitivity.