### PR TITLE
fix: Include module name in verbose messages

### DIFF
--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -207,7 +207,7 @@ impl<'src> Recipe<'src> {
     let suffix = color.suffix();
 
     if context.config.verbosity.loquacious() {
-      eprintln!("{prefix}===> Running recipe `{self.recipe_path()}`...{suffix}");
+      eprintln!("{prefix}===> Running recipe `{}`...{suffix}", self.recipe_path());
     }
 
     if context.config.explain {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -207,7 +207,11 @@ impl<'src> Recipe<'src> {
     let suffix = color.suffix();
 
     if context.config.verbosity.loquacious() {
-      eprintln!("{prefix}===> Running recipe `{}`...{suffix}", self.name);
+      let recipe_path = self
+        .recipe_path
+        .as_ref()
+        .map_or_else(|| self.name.to_string(), ToString::to_string);
+      eprintln!("{prefix}===> Running recipe `{recipe_path}`...{suffix}");
     }
 
     if context.config.explain {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -207,7 +207,10 @@ impl<'src> Recipe<'src> {
     let suffix = color.suffix();
 
     if context.config.verbosity.loquacious() {
-      eprintln!("{prefix}===> Running recipe `{}`...{suffix}", self.recipe_path());
+      eprintln!(
+        "{prefix}===> Running recipe `{}`...{suffix}",
+        self.recipe_path()
+      );
     }
 
     if context.config.explain {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -209,7 +209,7 @@ impl<'src> Recipe<'src> {
     if context.config.verbosity.loquacious() {
       eprintln!(
         "{prefix}===> Running recipe `{}`...{suffix}",
-        self.recipe_path()
+        self.recipe_path(),
       );
     }
 

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -207,11 +207,7 @@ impl<'src> Recipe<'src> {
     let suffix = color.suffix();
 
     if context.config.verbosity.loquacious() {
-      let recipe_path = self
-        .recipe_path
-        .as_ref()
-        .map_or_else(|| self.name.to_string(), ToString::to_string);
-      eprintln!("{prefix}===> Running recipe `{recipe_path}`...{suffix}");
+      eprintln!("{prefix}===> Running recipe `{self.recipe_path()}`...{suffix}");
     }
 
     if context.config.explain {

--- a/tests/modules.rs
+++ b/tests/modules.rs
@@ -1110,3 +1110,49 @@ fn exported_variables_can_be_overridden_in_submodules() {
     .stdout("b\n")
     .success();
 }
+
+#[test]
+fn verbose_message_includes_module_path() {
+  Test::new()
+    .write("foo.just", "bar:\n @echo BAR")
+    .justfile(
+      "
+        mod foo
+      ",
+    )
+    .args(["--verbose", "foo::bar"])
+    .stderr("===> Running recipe `foo::bar`...\necho BAR\n")
+    .stdout("BAR\n")
+    .success();
+}
+
+#[test]
+fn verbose_message_includes_nested_module_path() {
+  Test::new()
+    .write("foo.just", "mod bar")
+    .write("bar.just", "baz:\n @echo BAZ")
+    .justfile(
+      "
+        mod foo
+      ",
+    )
+    .args(["--verbose", "foo::bar::baz"])
+    .stderr("===> Running recipe `foo::bar::baz`...\necho BAZ\n")
+    .stdout("BAZ\n")
+    .success();
+}
+
+#[test]
+fn verbose_message_for_root_recipe_shows_name_only() {
+  Test::new()
+    .justfile(
+      "
+        bar:
+          @echo BAR
+      ",
+    )
+    .args(["--verbose", "bar"])
+    .stderr("===> Running recipe `bar`...\necho BAR\n")
+    .stdout("BAR\n")
+    .success();
+}

--- a/tests/modules.rs
+++ b/tests/modules.rs
@@ -1125,34 +1125,3 @@ fn verbose_message_includes_module_path() {
     .stdout("BAR\n")
     .success();
 }
-
-#[test]
-fn verbose_message_includes_nested_module_path() {
-  Test::new()
-    .write("foo.just", "mod bar")
-    .write("bar.just", "baz:\n @echo BAZ")
-    .justfile(
-      "
-        mod foo
-      ",
-    )
-    .args(["--verbose", "foo::bar::baz"])
-    .stderr("===> Running recipe `foo::bar::baz`...\necho BAZ\n")
-    .stdout("BAZ\n")
-    .success();
-}
-
-#[test]
-fn verbose_message_for_root_recipe_shows_name_only() {
-  Test::new()
-    .justfile(
-      "
-        bar:
-          @echo BAR
-      ",
-    )
-    .args(["--verbose", "bar"])
-    .stderr("===> Running recipe `bar`...\necho BAR\n")
-    .stdout("BAR\n")
-    .success();
-}


### PR DESCRIPTION
For a recipe `baz` under the module path of `foo::bar`, the current behavior of the verbose mode is to print lines like this:

```
===> Running recipe baz...
```

This change puts the full module path in those outputs, to improve visibility, as well as make it easy to re-trigger the same recipe with a copy-paste:

```
===> Running recipe foo::bar::baz...
```