### PR TITLE
docs: add navigation hint to Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ always welcome!
 Installation
 ------------
 
+To install `just`, see the [Packages](#packages) section below for one-line
+install commands for your platform. On Windows, check
+[Prerequisites](#prerequisites) first for shell setup notes.
+
+
 ### Prerequisites
 
 `just` should run on any system with a reasonable `sh`, including Linux, MacOS,


### PR DESCRIPTION
Closes #2890

New users reading the Installation section expect to find install commands right away, but the actual commands are under the Packages subsection further down. 

This adds two short sentences at the top of Installation pointing readers directly to Packages (and to 
Prerequisites for Windows users).

No content was moved or removed — this is a two-sentence additive change.