### PR TITLE
Add runtime directory function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2219,6 +2219,7 @@ details.
 - `data_local_directory()` - The local user-specific data directory.
 - `executable_directory()` - The user-specific executable directory.
 - `home_directory()` - The user's home directory.
+- `runtime_directory()` - The user-specific runtime directory.
 
 If you would like to use XDG base directories on all platforms you can use the
 `env(…)` function with the appropriate environment variable and fallback,

--- a/README.md
+++ b/README.md
@@ -2201,7 +2201,8 @@ details.
 - `data_local_directory()` - The local user-specific data directory.
 - `executable_directory()` - The user-specific executable directory.
 - `home_directory()` - The user's home directory.
-- `runtime_directory()` - The user-specific runtime directory.
+- `runtime_directory()` - The user-specific runtime directory. Only defined on
+  Linux.
 
 If you would like to use XDG base directories on all platforms you can use the
 `env(…)` function with the appropriate environment variable and fallback,

--- a/src/function.rs
+++ b/src/function.rs
@@ -87,6 +87,7 @@ pub(crate) fn get(name: &str) -> Option<Function> {
     "replace" => Ternary(replace),
     "replace_regex" => Ternary(replace_regex),
     "require" => Unary(require),
+    "runtime_directory" => Nullary(|_| dir("runtime", dirs::runtime_dir)),
     "semver_matches" => Binary(semver_matches),
     "sha256" => Unary(sha256),
     "sha256_file" => Unary(sha256_file),

--- a/tests/directories.rs
+++ b/tests/directories.rs
@@ -85,9 +85,34 @@ fn home_directory() {
 
 #[test]
 fn runtime_directory() {
+  if cfg!(not(target_os = "linux")) {
+    return;
+  }
+
   Test::new()
     .justfile("x := runtime_directory()")
     .args(["--evaluate", "x"])
     .stdout(dirs::runtime_dir().unwrap_or_default().to_string_lossy())
     .success();
+}
+
+#[test]
+fn runtime_directory_not_found() {
+  if cfg!(target_os = "linux") {
+    return;
+  }
+
+  Test::new()
+    .justfile("x := runtime_directory()")
+    .args(["--evaluate", "x"])
+    .stderr(
+      "
+        error: Call to function `runtime_directory` failed: runtime directory not found
+         ——▶ justfile:1:6
+          │
+        1 │ x := runtime_directory()
+          │      ^^^^^^^^^^^^^^^^^
+      ",
+    )
+    .failure();
 }

--- a/tests/directories.rs
+++ b/tests/directories.rs
@@ -82,3 +82,12 @@ fn home_directory() {
     .stdout(dirs::home_dir().unwrap_or_default().to_string_lossy())
     .success();
 }
+
+#[test]
+fn runtime_directory() {
+  Test::new()
+    .justfile("x := runtime_directory()")
+    .args(["--evaluate", "x"])
+    .stdout(dirs::runtime_dir().unwrap_or_default().to_string_lossy())
+    .success();
+}


### PR DESCRIPTION
Maybe there has been a conscious choice to leave this function out, if so, please do feel free to close this PR. I came across a usecase where I needed this function today so I thought it apt to do the PR myself as it is a very small and easy addition. My current workaround is to read the `XDG_RUNTIME_DIR` folder manually with a fallback as prescribed. 