### PR TITLE
Support expressions in confirm attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -2295,7 +2295,7 @@ change their behavior.
 | `[arg(ARG, pattern="PATTERN")]`<sup>1.45.0</sup> | recipe | Require values of argument `ARG` to match regular expression `PATTERN`. |
 | `[arg(ARG, short="S")]`<sup>1.46.0</sup> | recipe | Require values of argument `ARG` to be passed as short `-S` option. |
 | `[arg(ARG, value="VALUE")]`<sup>1.46.0</sup> | recipe | Makes option `ARG` a flag which does not take a value. |
-| `[confirm(EXPRESSION)]`<sup>1.23.0</sup> | recipe | Require confirmation prior to executing recipe with a custom prompt expression. |
+| `[confirm(PROMPT)]`<sup>1.23.0</sup> | recipe | Require confirmation prior to executing recipe with a custom prompt.  |
 | `[confirm]`<sup>1.17.0</sup> | recipe | Require confirmation prior to executing recipe. |
 | `[default]`<sup>1.43.0</sup> | recipe | Use recipe as module's default recipe. |
 | `[doc(DOC)]`<sup>1.27.0</sup> | module, recipe | Set recipe or module's [documentation comment](#documentation-comments) to `DOC`. |
@@ -2410,7 +2410,7 @@ delete-all:
 #### Custom Confirmation Prompt
 
 The default confirmation prompt can be overridden with
-`[confirm(EXPRESSION)]`<sup>1.23.0</sup>:
+`[confirm(PROMPT)]`<sup>1.23.0</sup>:
 
 ```just
 [confirm("Are you sure you want to delete everything?")]
@@ -2418,18 +2418,8 @@ delete-everything:
   rm -rf *
 ```
 
-The confirmation prompt accepts any expression, so you can use variables,
-concatenation, and function calls:
-
-```just
-target := "production"
-
-[confirm("Deploy to " + target + "?")]
-deploy:
-  echo 'Deploying...'
-```
-
-Recipe parameters can also be used in confirmation prompts:
+The confirmation prompt may also be an expression<sup>master</sup> which may
+reference assignments or recipe arguments:
 
 ```just
 [confirm("Deploy to " + env + "?")]

--- a/README.md
+++ b/README.md
@@ -2225,7 +2225,7 @@ change their behavior.
 | `[arg(ARG, pattern="PATTERN")]`<sup>1.45.0</sup> | recipe | Require values of argument `ARG` to match regular expression `PATTERN`. |
 | `[arg(ARG, short="S")]`<sup>1.46.0</sup> | recipe | Require values of argument `ARG` to be passed as short `-S` option. |
 | `[arg(ARG, value="VALUE")]`<sup>1.46.0</sup> | recipe | Makes option `ARG` a flag which does not take a value. |
-| `[confirm(PROMPT)]`<sup>1.23.0</sup> | recipe | Require confirmation prior to executing recipe with a custom prompt. |
+| `[confirm(EXPRESSION)]`<sup>1.23.0</sup> | recipe | Require confirmation prior to executing recipe with a custom prompt expression. |
 | `[confirm]`<sup>1.17.0</sup> | recipe | Require confirmation prior to executing recipe. |
 | `[default]`<sup>1.43.0</sup> | recipe | Use recipe as module's default recipe. |
 | `[doc(DOC)]`<sup>1.27.0</sup> | module, recipe | Set recipe or module's [documentation comment](#documentation-comments) to `DOC`. |
@@ -2340,12 +2340,31 @@ delete-all:
 #### Custom Confirmation Prompt
 
 The default confirmation prompt can be overridden with
-`[confirm(PROMPT)]`<sup>1.23.0</sup>:
+`[confirm(EXPRESSION)]`<sup>1.23.0</sup>:
 
 ```just
 [confirm("Are you sure you want to delete everything?")]
 delete-everything:
   rm -rf *
+```
+
+The confirmation prompt accepts any expression, so you can use variables,
+concatenation, and function calls:
+
+```just
+target := "production"
+
+[confirm("Deploy to " + target + "?")]
+deploy:
+  echo 'Deploying...'
+```
+
+Recipe parameters can also be used in confirmation prompts:
+
+```just
+[confirm("Deploy to " + env + "?")]
+deploy env:
+  echo 'Deploying to {{env}}...'
 ```
 
 #### Metadata

--- a/README.md
+++ b/README.md
@@ -2295,7 +2295,7 @@ change their behavior.
 | `[arg(ARG, pattern="PATTERN")]`<sup>1.45.0</sup> | recipe | Require values of argument `ARG` to match regular expression `PATTERN`. |
 | `[arg(ARG, short="S")]`<sup>1.46.0</sup> | recipe | Require values of argument `ARG` to be passed as short `-S` option. |
 | `[arg(ARG, value="VALUE")]`<sup>1.46.0</sup> | recipe | Makes option `ARG` a flag which does not take a value. |
-| `[confirm(PROMPT)]`<sup>1.23.0</sup> | recipe | Require confirmation prior to executing recipe with a custom prompt.  |
+| `[confirm(PROMPT)]`<sup>1.23.0</sup> | recipe | Require confirmation prior to executing recipe with a custom prompt. |
 | `[confirm]`<sup>1.17.0</sup> | recipe | Require confirmation prior to executing recipe. |
 | `[default]`<sup>1.43.0</sup> | recipe | Use recipe as module's default recipe. |
 | `[doc(DOC)]`<sup>1.27.0</sup> | module, recipe | Set recipe or module's [documentation comment](#documentation-comments) to `DOC`. |

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -47,6 +47,10 @@ pub(crate) enum Attribute<'src> {
 }
 
 impl AttributeDiscriminant {
+  pub(crate) fn accepts_keyword_arguments(self) -> bool {
+    matches!(self, Self::Arg)
+  }
+
   fn argument_range(self) -> RangeInclusive<usize> {
     match self {
       Self::Default
@@ -100,18 +104,10 @@ impl<'src> Attribute<'src> {
 
   pub(crate) fn new(
     name: Name<'src>,
-    arguments: Vec<StringLiteral<'src>>,
+    discriminant: AttributeDiscriminant,
+    arguments: Vec<(Token<'src>, Expression<'src>)>,
     mut keyword_arguments: BTreeMap<&'src str, (Name<'src>, Option<StringLiteral<'src>>)>,
   ) -> CompileResult<'src, Self> {
-    let discriminant = name
-      .lexeme()
-      .parse::<AttributeDiscriminant>()
-      .map_err(|_| {
-        name.error(CompileErrorKind::UnknownAttribute {
-          attribute: name.lexeme(),
-        })
-      })?;
-
     let found = arguments.len();
     let range = discriminant.argument_range();
     if !range.contains(&found) {
@@ -124,6 +120,35 @@ impl<'src> Attribute<'src> {
         }),
       );
     }
+
+    if matches!(discriminant, AttributeDiscriminant::Confirm) {
+      if let Some((_name, (keyword_name, _literal))) = keyword_arguments.into_iter().next() {
+        return Err(
+          keyword_name.error(CompileErrorKind::UnknownAttributeKeyword {
+            attribute: name.lexeme(),
+            keyword: keyword_name.lexeme(),
+          }),
+        );
+      }
+
+      return Ok(Self::Confirm(
+        arguments.into_iter().next().map(|(_, expr)| expr),
+      ));
+    }
+
+    let arguments = arguments
+      .into_iter()
+      .map(|(token, argument)| {
+        let Expression::StringLiteral { string_literal } = argument else {
+          return Err(
+            token.error(CompileErrorKind::AttributeArgumentNotStringLiteral {
+              attribute: name.lexeme(),
+            }),
+          );
+        };
+        Ok(string_literal)
+      })
+      .collect::<CompileResult<'src, Vec<_>>>()?;
 
     let attribute = match discriminant {
       AttributeDiscriminant::Arg => {
@@ -184,12 +209,7 @@ impl<'src> Attribute<'src> {
           value,
         }
       }
-      AttributeDiscriminant::Confirm => Self::Confirm(
-        arguments
-          .into_iter()
-          .next()
-          .map(|string_literal| Expression::StringLiteral { string_literal }),
-      ),
+      AttributeDiscriminant::Confirm => unreachable!(),
       AttributeDiscriminant::Default => Self::Default,
       AttributeDiscriminant::Doc => Self::Doc(arguments.into_iter().next()),
       AttributeDiscriminant::Dragonfly => Self::Dragonfly,

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -367,8 +367,9 @@ impl Ord for Attribute<'_> {
     // most once, so Equal is correct.
     match (self, other) {
       (Self::Env(k1, v1), Self::Env(k2, v2)) => (k1, v1).cmp(&(k2, v2)),
-      (Self::Arg { name: a, .. }, Self::Arg { name: b, .. })
-      | (Self::Group(a), Self::Group(b)) => a.cmp(b),
+      (Self::Arg { name: a, .. }, Self::Arg { name: b, .. }) | (Self::Group(a), Self::Group(b)) => {
+        a.cmp(b)
+      }
       (Self::Metadata(a), Self::Metadata(b)) => a.cmp(b),
       _ => Ordering::Equal,
     }

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -366,9 +366,9 @@ impl Ord for Attribute<'_> {
     // in BTreeSet. Non-repeatable attributes (including Confirm) appear at
     // most once, so Equal is correct.
     match (self, other) {
-      (Self::Arg { name: a, .. }, Self::Arg { name: b, .. }) => a.cmp(b),
       (Self::Env(k1, v1), Self::Env(k2, v2)) => (k1, v1).cmp(&(k2, v2)),
-      (Self::Group(a), Self::Group(b)) => a.cmp(b),
+      (Self::Arg { name: a, .. }, Self::Arg { name: b, .. })
+      | (Self::Group(a), Self::Group(b)) => a.cmp(b),
       (Self::Metadata(a), Self::Metadata(b)) => a.cmp(b),
       _ => Ordering::Equal,
     }

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 #[allow(clippy::large_enum_variant)]
-#[derive(EnumDiscriminants, PartialEq, Debug, Clone, Serialize, IntoStaticStr)]
+#[derive(
+  EnumDiscriminants, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Serialize, IntoStaticStr,
+)]
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
 #[strum_discriminants(name(AttributeDiscriminant))]
@@ -343,36 +345,6 @@ impl Display for Attribute<'_> {
     }
 
     Ok(())
-  }
-}
-
-impl Eq for Attribute<'_> {}
-
-impl PartialOrd for Attribute<'_> {
-  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-    Some(self.cmp(other))
-  }
-}
-
-impl Ord for Attribute<'_> {
-  fn cmp(&self, other: &Self) -> Ordering {
-    let disc_cmp = self.discriminant().cmp(&other.discriminant());
-
-    if disc_cmp != Ordering::Equal {
-      return disc_cmp;
-    }
-
-    // For repeatable attributes, compare inner values to distinguish them
-    // in BTreeSet. Non-repeatable attributes (including Confirm) appear at
-    // most once, so Equal is correct.
-    match (self, other) {
-      (Self::Env(k1, v1), Self::Env(k2, v2)) => (k1, v1).cmp(&(k2, v2)),
-      (Self::Arg { name: a, .. }, Self::Arg { name: b, .. }) | (Self::Group(a), Self::Group(b)) => {
-        a.cmp(b)
-      }
-      (Self::Metadata(a), Self::Metadata(b)) => a.cmp(b),
-      _ => Ordering::Equal,
-    }
   }
 }
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,9 +1,7 @@
 use super::*;
 
 #[allow(clippy::large_enum_variant)]
-#[derive(
-  EnumDiscriminants, PartialEq, Debug, Clone, Serialize, Ord, PartialOrd, Eq, IntoStaticStr,
-)]
+#[derive(EnumDiscriminants, PartialEq, Debug, Clone, Serialize, IntoStaticStr)]
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
 #[strum_discriminants(name(AttributeDiscriminant))]
@@ -20,7 +18,7 @@ pub(crate) enum Attribute<'src> {
     short: Option<StringLiteral<'src>>,
     value: Option<StringLiteral<'src>>,
   },
-  Confirm(Option<StringLiteral<'src>>),
+  Confirm(Option<Expression<'src>>),
   Default,
   Doc(Option<StringLiteral<'src>>),
   Dragonfly,
@@ -184,7 +182,12 @@ impl<'src> Attribute<'src> {
           value,
         }
       }
-      AttributeDiscriminant::Confirm => Self::Confirm(arguments.into_iter().next()),
+      AttributeDiscriminant::Confirm => Self::Confirm(
+        arguments
+          .into_iter()
+          .next()
+          .map(|string_literal| Expression::StringLiteral { string_literal }),
+      ),
       AttributeDiscriminant::Default => Self::Default,
       AttributeDiscriminant::Doc => Self::Doc(arguments.into_iter().next()),
       AttributeDiscriminant::Dragonfly => Self::Dragonfly,
@@ -320,8 +323,8 @@ impl Display for Attribute<'_> {
       | Self::Script(None)
       | Self::Unix
       | Self::Windows => {}
-      Self::Confirm(Some(argument))
-      | Self::Doc(Some(argument))
+      Self::Confirm(Some(argument)) => write!(f, "({argument})")?,
+      Self::Doc(Some(argument))
       | Self::Extension(argument)
       | Self::Group(argument)
       | Self::WorkingDirectory(argument) => write!(f, "({argument})")?,
@@ -340,6 +343,35 @@ impl Display for Attribute<'_> {
     }
 
     Ok(())
+  }
+}
+
+impl Eq for Attribute<'_> {}
+
+impl PartialOrd for Attribute<'_> {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+impl Ord for Attribute<'_> {
+  fn cmp(&self, other: &Self) -> Ordering {
+    let disc_cmp = self.discriminant().cmp(&other.discriminant());
+
+    if disc_cmp != Ordering::Equal {
+      return disc_cmp;
+    }
+
+    // For repeatable attributes, compare inner values to distinguish them
+    // in BTreeSet. Non-repeatable attributes (including Confirm) appear at
+    // most once, so Equal is correct.
+    match (self, other) {
+      (Self::Arg { name: a, .. }, Self::Arg { name: b, .. }) => a.cmp(b),
+      (Self::Env(k1, v1), Self::Env(k2, v2)) => (k1, v1).cmp(&(k2, v2)),
+      (Self::Group(a), Self::Group(b)) => a.cmp(b),
+      (Self::Metadata(a), Self::Metadata(b)) => a.cmp(b),
+      _ => Ordering::Equal,
+    }
   }
 }
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -122,13 +122,11 @@ impl<'src> Attribute<'src> {
     }
 
     if matches!(discriminant, AttributeDiscriminant::Confirm) {
-      if let Some((_name, (keyword_name, _literal))) = keyword_arguments.into_iter().next() {
-        return Err(
-          keyword_name.error(CompileErrorKind::UnknownAttributeKeyword {
-            attribute: name.lexeme(),
-            keyword: keyword_name.lexeme(),
-          }),
-        );
+      if let Some((_name, (keyword, _literal))) = keyword_arguments.into_iter().next() {
+        return Err(keyword.error(CompileErrorKind::UnknownAttributeKeyword {
+          attribute: name.lexeme(),
+          keyword: keyword.lexeme(),
+        }));
       }
 
       return Ok(Self::Confirm(
@@ -140,15 +138,13 @@ impl<'src> Attribute<'src> {
       .into_iter()
       .map(|(token, argument)| {
         let Expression::StringLiteral { string_literal } = argument else {
-          return Err(
-            token.error(CompileErrorKind::AttributeArgumentNotStringLiteral {
-              attribute: name.lexeme(),
-            }),
-          );
+          return Err(token.error(CompileErrorKind::AttributeArgumentExpression {
+            attribute: name.lexeme(),
+          }));
         };
         Ok(string_literal)
       })
-      .collect::<CompileResult<'src, Vec<_>>>()?;
+      .collect::<CompileResult<Vec<StringLiteral>>>()?;
 
     let attribute = match discriminant {
       AttributeDiscriminant::Arg => {

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -69,6 +69,12 @@ impl Display for CompileError<'_> {
           write!(f, "at most {max} {}", Count("argument", *max))
         }
       }
+      AttributeArgumentNotStringLiteral { attribute } => {
+        write!(
+          f,
+          "Attribute `{attribute}` arguments must be string literals"
+        )
+      }
       AttributePositionalFollowsKeyword => {
         write!(
           f,

--- a/src/compile_error.rs
+++ b/src/compile_error.rs
@@ -69,7 +69,7 @@ impl Display for CompileError<'_> {
           write!(f, "at most {max} {}", Count("argument", *max))
         }
       }
-      AttributeArgumentNotStringLiteral { attribute } => {
+      AttributeArgumentExpression { attribute } => {
         write!(
           f,
           "Attribute `{attribute}` arguments must be string literals"

--- a/src/compile_error_kind.rs
+++ b/src/compile_error_kind.rs
@@ -12,7 +12,7 @@ pub(crate) enum CompileErrorKind<'src> {
     min: usize,
     max: usize,
   },
-  AttributeArgumentNotStringLiteral {
+  AttributeArgumentExpression {
     attribute: &'src str,
   },
   AttributeKeyMissingValue {

--- a/src/compile_error_kind.rs
+++ b/src/compile_error_kind.rs
@@ -12,6 +12,9 @@ pub(crate) enum CompileErrorKind<'src> {
     min: usize,
     max: usize,
   },
+  AttributeArgumentNotStringLiteral {
+    attribute: &'src str,
+  },
   AttributeKeyMissingValue {
     key: Name<'src>,
   },

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Ord, PartialOrd)]
 pub(crate) struct Condition<'src> {
   pub(crate) lhs: Box<Expression<'src>>,
   pub(crate) operator: ConditionalOperator,

--- a/src/conditional_operator.rs
+++ b/src/conditional_operator.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// A conditional expression operator.
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Ord, PartialOrd)]
 pub(crate) enum ConditionalOperator {
   /// `==`
   Equality,

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -6,7 +6,7 @@ use super::*;
 /// parenthetical groups).
 ///
 /// The parser parses both values and expressions into `Expression`s.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Ord, PartialOrd)]
 pub(crate) enum Expression<'src> {
   /// `lhs && rhs`
   And { lhs: Box<Self>, rhs: Box<Self> },

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -350,12 +350,6 @@ impl<'src> Justfile<'src> {
       return Ok(());
     }
 
-    if !config.yes && !recipe.confirm()? {
-      return Err(Error::NotConfirmed {
-        recipe: recipe.name(),
-      });
-    }
-
     let (module, scope) = scopes
       .get(recipe.module_path())
       .expect("failed to retrieve scope for module");
@@ -379,6 +373,12 @@ impl<'src> Justfile<'src> {
     let scope = outer.child();
 
     let mut evaluator = Evaluator::new(&context, BTreeMap::new(), true, &scope);
+
+    if !config.yes && !recipe.confirm(&mut evaluator)? {
+      return Err(Error::NotConfirmed {
+        recipe: recipe.name(),
+      });
+    }
 
     Self::run_dependencies(
       config,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1447,18 +1447,19 @@ impl<'run, 'src> Parser<'run, 'src> {
         } else if self.accepted(ParenL)? {
           if !self.next_is(ParenR) {
             loop {
-              if !accepts_expressions
+              if self.next_are(&[Identifier, Equals]) && !self.next_is_shell_expanded_string() {
+                let key = self.parse_name()?;
+                self.expect(Equals)?;
+                let value = self.parse_string_literal()?;
+
+                keyword_arguments.insert(key.lexeme(), (key, Some(value)));
+              } else if !accepts_expressions
                 && self.next_is(Identifier)
                 && !self.next_is_shell_expanded_string()
               {
                 let key = self.parse_name()?;
 
-                let value = self
-                  .accepted(Equals)?
-                  .then(|| self.parse_string_literal())
-                  .transpose()?;
-
-                keyword_arguments.insert(key.lexeme(), (key, value));
+                keyword_arguments.insert(key.lexeme(), (key, None));
               } else {
                 let token = self.next()?;
                 let expression = self.parse_expression()?;
@@ -1480,6 +1481,14 @@ impl<'run, 'src> Parser<'run, 'src> {
         }
 
         let attribute = if accepts_expressions {
+          if let Some((_, (keyword_name, _))) = keyword_arguments.into_iter().next() {
+            return Err(
+              keyword_name.error(CompileErrorKind::UnknownAttributeKeyword {
+                attribute: name.lexeme(),
+                keyword: keyword_name.lexeme(),
+              }),
+            );
+          }
           Attribute::Confirm(arguments.into_iter().next())
         } else {
           let string_arguments = arguments

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1437,30 +1437,20 @@ impl<'run, 'src> Parser<'run, 'src> {
       loop {
         let name = self.parse_name()?;
 
-        let attribute = if name.lexeme() == "confirm" {
-          let expression = if self.accepted(Colon)? {
-            Some(self.parse_expression()?)
-          } else if self.accepted(ParenL)? {
-            let expr = if self.next_is(ParenR) {
-              None
-            } else {
-              Some(self.parse_expression()?)
-            };
-            self.expect(ParenR)?;
-            expr
-          } else {
-            None
-          };
-          Attribute::Confirm(expression)
-        } else {
-          let mut arguments = Vec::new();
-          let mut keyword_arguments = BTreeMap::new();
+        let accepts_expressions = name.lexeme() == "confirm";
 
-          if self.accepted(Colon)? {
-            arguments.push(self.parse_string_literal()?);
-          } else if self.accepted(ParenL)? {
+        let mut arguments = Vec::new();
+        let mut keyword_arguments = BTreeMap::new();
+
+        if self.accepted(Colon)? {
+          arguments.push(self.parse_expression()?);
+        } else if self.accepted(ParenL)? {
+          if !self.next_is(ParenR) {
             loop {
-              if self.next_is(Identifier) && !self.next_is_shell_expanded_string() {
+              if !accepts_expressions
+                && self.next_is(Identifier)
+                && !self.next_is_shell_expanded_string()
+              {
                 let key = self.parse_name()?;
 
                 let value = self
@@ -1470,28 +1460,41 @@ impl<'run, 'src> Parser<'run, 'src> {
 
                 keyword_arguments.insert(key.lexeme(), (key, value));
               } else {
-                let literal = self.parse_string_literal()?;
+                let token = self.next()?;
+                let expression = self.parse_expression()?;
 
                 if !keyword_arguments.is_empty() {
-                  return Err(
-                    literal
-                      .token
-                      .error(CompileErrorKind::AttributePositionalFollowsKeyword),
-                  );
+                  return Err(token.error(CompileErrorKind::AttributePositionalFollowsKeyword));
                 }
 
-                arguments.push(literal);
+                arguments.push(expression);
               }
 
               if !self.accepted(Comma)? || self.next_is(ParenR) {
                 break;
               }
             }
-
-            self.expect(ParenR)?;
           }
 
-          Attribute::new(name, arguments, keyword_arguments)?
+          self.expect(ParenR)?;
+        }
+
+        let attribute = if accepts_expressions {
+          Attribute::Confirm(arguments.into_iter().next())
+        } else {
+          let string_arguments = arguments
+            .into_iter()
+            .map(|expression| match expression {
+              Expression::StringLiteral { string_literal } => Ok(string_literal),
+              _ => Err(
+                name.error(CompileErrorKind::AttributeArgumentNotStringLiteral {
+                  attribute: name.lexeme(),
+                }),
+              ),
+            })
+            .collect::<CompileResult<'src, Vec<_>>>()?;
+
+          Attribute::new(name, string_arguments, keyword_arguments)?
         };
 
         let first = if attribute.repeatable() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1437,29 +1437,37 @@ impl<'run, 'src> Parser<'run, 'src> {
       loop {
         let name = self.parse_name()?;
 
-        let accepts_expressions = name.lexeme() == "confirm";
+        let discriminant = name
+          .lexeme()
+          .parse::<AttributeDiscriminant>()
+          .map_err(|_| {
+            name.error(CompileErrorKind::UnknownAttribute {
+              attribute: name.lexeme(),
+            })
+          })?;
 
         let mut arguments = Vec::new();
         let mut keyword_arguments = BTreeMap::new();
 
         if self.accepted(Colon)? {
-          arguments.push(self.parse_expression()?);
+          let token = self.next()?;
+          let expression = self.parse_expression()?;
+          arguments.push((token, expression));
         } else if self.accepted(ParenL)? {
           if !self.next_is(ParenR) {
             loop {
-              if self.next_are(&[Identifier, Equals]) && !self.next_is_shell_expanded_string() {
-                let key = self.parse_name()?;
-                self.expect(Equals)?;
-                let value = self.parse_string_literal()?;
-
-                keyword_arguments.insert(key.lexeme(), (key, Some(value)));
-              } else if !accepts_expressions
+              if discriminant.accepts_keyword_arguments()
                 && self.next_is(Identifier)
                 && !self.next_is_shell_expanded_string()
               {
                 let key = self.parse_name()?;
 
-                keyword_arguments.insert(key.lexeme(), (key, None));
+                let value = self
+                  .accepted(Equals)?
+                  .then(|| self.parse_string_literal())
+                  .transpose()?;
+
+                keyword_arguments.insert(key.lexeme(), (key, value));
               } else {
                 let token = self.next()?;
                 let expression = self.parse_expression()?;
@@ -1468,7 +1476,7 @@ impl<'run, 'src> Parser<'run, 'src> {
                   return Err(token.error(CompileErrorKind::AttributePositionalFollowsKeyword));
                 }
 
-                arguments.push(expression);
+                arguments.push((token, expression));
               }
 
               if !self.accepted(Comma)? || self.next_is(ParenR) {
@@ -1480,31 +1488,7 @@ impl<'run, 'src> Parser<'run, 'src> {
           self.expect(ParenR)?;
         }
 
-        let attribute = if accepts_expressions {
-          if let Some((_, (keyword_name, _))) = keyword_arguments.into_iter().next() {
-            return Err(
-              keyword_name.error(CompileErrorKind::UnknownAttributeKeyword {
-                attribute: name.lexeme(),
-                keyword: keyword_name.lexeme(),
-              }),
-            );
-          }
-          Attribute::Confirm(arguments.into_iter().next())
-        } else {
-          let string_arguments = arguments
-            .into_iter()
-            .map(|expression| match expression {
-              Expression::StringLiteral { string_literal } => Ok(string_literal),
-              _ => Err(
-                name.error(CompileErrorKind::AttributeArgumentNotStringLiteral {
-                  attribute: name.lexeme(),
-                }),
-              ),
-            })
-            .collect::<CompileResult<'src, Vec<_>>>()?;
-
-          Attribute::new(name, string_arguments, keyword_arguments)?
-        };
+        let attribute = Attribute::new(name, discriminant, arguments, keyword_arguments)?;
 
         let first = if attribute.repeatable() {
           None

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1437,45 +1437,62 @@ impl<'run, 'src> Parser<'run, 'src> {
       loop {
         let name = self.parse_name()?;
 
-        let mut arguments = Vec::new();
-        let mut keyword_arguments = BTreeMap::new();
-
-        if self.accepted(Colon)? {
-          arguments.push(self.parse_string_literal()?);
-        } else if self.accepted(ParenL)? {
-          loop {
-            if self.next_is(Identifier) && !self.next_is_shell_expanded_string() {
-              let key = self.parse_name()?;
-
-              let value = self
-                .accepted(Equals)?
-                .then(|| self.parse_string_literal())
-                .transpose()?;
-
-              keyword_arguments.insert(key.lexeme(), (key, value));
+        let attribute = if name.lexeme() == "confirm" {
+          let expression = if self.accepted(Colon)? {
+            Some(self.parse_expression()?)
+          } else if self.accepted(ParenL)? {
+            let expr = if self.next_is(ParenR) {
+              None
             } else {
-              let literal = self.parse_string_literal()?;
+              Some(self.parse_expression()?)
+            };
+            self.expect(ParenR)?;
+            expr
+          } else {
+            None
+          };
+          Attribute::Confirm(expression)
+        } else {
+          let mut arguments = Vec::new();
+          let mut keyword_arguments = BTreeMap::new();
 
-              if !keyword_arguments.is_empty() {
-                return Err(
-                  literal
-                    .token
-                    .error(CompileErrorKind::AttributePositionalFollowsKeyword),
-                );
+          if self.accepted(Colon)? {
+            arguments.push(self.parse_string_literal()?);
+          } else if self.accepted(ParenL)? {
+            loop {
+              if self.next_is(Identifier) && !self.next_is_shell_expanded_string() {
+                let key = self.parse_name()?;
+
+                let value = self
+                  .accepted(Equals)?
+                  .then(|| self.parse_string_literal())
+                  .transpose()?;
+
+                keyword_arguments.insert(key.lexeme(), (key, value));
+              } else {
+                let literal = self.parse_string_literal()?;
+
+                if !keyword_arguments.is_empty() {
+                  return Err(
+                    literal
+                      .token
+                      .error(CompileErrorKind::AttributePositionalFollowsKeyword),
+                  );
+                }
+
+                arguments.push(literal);
               }
 
-              arguments.push(literal);
+              if !self.accepted(Comma)? || self.next_is(ParenR) {
+                break;
+              }
             }
 
-            if !self.accepted(Comma)? || self.next_is(ParenR) {
-              break;
-            }
+            self.expect(ParenR)?;
           }
 
-          self.expect(ParenR)?;
-        }
-
-        let attribute = Attribute::new(name, arguments, keyword_arguments)?;
+          Attribute::new(name, arguments, keyword_arguments)?
+        };
 
         let first = if attribute.repeatable() {
           None

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -104,10 +104,14 @@ impl<'src, D> Recipe<'src, D> {
     self.name.line
   }
 
-  pub(crate) fn confirm(&self) -> RunResult<'src, bool> {
+  pub(crate) fn confirm(
+    &self,
+    evaluator: &mut Evaluator<'src, '_>,
+  ) -> RunResult<'src, bool> {
     if let Some(Attribute::Confirm(prompt)) = self.attributes.get(AttributeDiscriminant::Confirm) {
-      if let Some(prompt) = prompt {
-        eprint!("{} ", prompt.cooked);
+      if let Some(expression) = prompt {
+        let message = evaluator.evaluate_expression(expression)?;
+        eprint!("{message} ");
       } else {
         eprint!("Run recipe `{}`? ", self.name);
       }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -117,8 +117,7 @@ impl<'src> Recipe<'src> {
   pub(crate) fn confirm(&self, evaluator: &mut Evaluator<'src, '_>) -> RunResult<'src, bool> {
     if let Some(Attribute::Confirm(prompt)) = self.attributes.get(AttributeDiscriminant::Confirm) {
       if let Some(expression) = prompt {
-        let message = evaluator.evaluate_expression(expression)?;
-        eprint!("{message} ");
+        eprint!("{} ", evaluator.evaluate_expression(expression)?);
       } else {
         eprint!("Run recipe `{}`? ", self.name);
       }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -104,10 +104,7 @@ impl<'src, D> Recipe<'src, D> {
     self.name.line
   }
 
-  pub(crate) fn confirm(
-    &self,
-    evaluator: &mut Evaluator<'src, '_>,
-  ) -> RunResult<'src, bool> {
+  pub(crate) fn confirm(&self, evaluator: &mut Evaluator<'src, '_>) -> RunResult<'src, bool> {
     if let Some(Attribute::Confirm(prompt)) = self.attributes.get(AttributeDiscriminant::Confirm) {
       if let Some(expression) = prompt {
         let message = evaluator.evaluate_expression(expression)?;

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[allow(clippy::arbitrary_source_item_ordering)]
-#[derive_where(Debug, PartialEq)]
+#[derive_where(Debug, PartialEq, Eq, Ord, PartialOrd)]
 #[derive(Clone)]
 pub(crate) enum Thunk<'src> {
   Nullary {

--- a/src/unresolved_recipe.rs
+++ b/src/unresolved_recipe.rs
@@ -46,6 +46,19 @@ impl<'src> UnresolvedRecipe<'src> {
       }
     }
 
+    for attribute in &self.attributes {
+      if let Attribute::Confirm(Some(expression)) = attribute {
+        for variable in expression.variables() {
+          Self::resolve_variable(
+            assignments,
+            &self.parameters,
+            &variable,
+            &mut variable_references,
+          )?;
+        }
+      }
+    }
+
     for line in &self.body {
       if line.is_comment() && settings.ignore_comments {
         continue;

--- a/tests/confirm.rs
+++ b/tests/confirm.rs
@@ -1,6 +1,28 @@
 use super::*;
 
 #[test]
+fn confirm_recipe_with_prompt_too_many_args() {
+  Test::new()
+    .justfile(
+      r#"
+        [confirm("PROMPT","EXTRA")]
+        requires_confirmation:
+            echo confirmed
+      "#,
+    )
+    .stderr(
+      r#"
+        error: Attribute `confirm` got 2 arguments but takes at most 1 argument
+         ——▶ justfile:1:2
+          │
+        1 │ [confirm("PROMPT","EXTRA")]
+          │  ^^^^^^^
+      "#,
+    )
+    .failure();
+}
+
+#[test]
 fn confirm_recipe_arg() {
   Test::new()
     .arg("--yes")

--- a/tests/confirm.rs
+++ b/tests/confirm.rs
@@ -7,12 +7,11 @@ fn confirm_recipe_arg() {
     .justfile(
       "
         [confirm]
-        requires_confirmation:
-            echo confirmed
-        ",
+        @foo:
+          echo FOO
+      ",
     )
-    .stderr("echo confirmed\n")
-    .stdout("confirmed\n")
+    .stdout("FOO\n")
     .success();
 }
 
@@ -22,16 +21,15 @@ fn recipe_with_confirm_recipe_dependency_arg() {
     .arg("--yes")
     .justfile(
       "
-        dep_confirmation: requires_confirmation
-            echo confirmed2
+        @bar: foo
+          echo BAR
 
         [confirm]
-        requires_confirmation:
-            echo confirmed
-        ",
+        @foo:
+          echo FOO
+      ",
     )
-    .stderr("echo confirmed\necho confirmed2\n")
-    .stdout("confirmed\nconfirmed2\n")
+    .stdout("FOO\nBAR\n")
     .success();
 }
 
@@ -41,12 +39,12 @@ fn confirm_recipe() {
     .justfile(
       "
         [confirm]
-        requires_confirmation:
-            echo confirmed
-        ",
+        @foo:
+          echo FOO
+      ",
     )
-    .stderr("Run recipe `requires_confirmation`? echo confirmed\n")
-    .stdout("confirmed\n")
+    .stderr("Run recipe `foo`? ")
+    .stdout("FOO\n")
     .stdin("y")
     .success();
 }
@@ -56,16 +54,16 @@ fn recipe_with_confirm_recipe_dependency() {
   Test::new()
     .justfile(
       "
-        dep_confirmation: requires_confirmation
-            echo confirmed2
+        @bar: foo
+          echo BAR
 
         [confirm]
-        requires_confirmation:
-            echo confirmed
-        ",
+        @foo:
+          echo FOO
+      ",
     )
-    .stderr("Run recipe `requires_confirmation`? echo confirmed\necho confirmed2\n")
-    .stdout("confirmed\nconfirmed2\n")
+    .stderr("Run recipe `foo`? ")
+    .stdout("FOO\nBAR\n")
     .stdin("y")
     .success();
 }
@@ -76,11 +74,11 @@ fn do_not_confirm_recipe() {
     .justfile(
       "
         [confirm]
-        requires_confirmation:
-            echo confirmed
-        ",
+        @foo:
+          echo FOO
+      ",
     )
-    .stderr("Run recipe `requires_confirmation`? error: Recipe `requires_confirmation` was not confirmed\n")
+    .stderr("Run recipe `foo`? error: Recipe `foo` was not confirmed\n")
     .failure();
 }
 
@@ -89,15 +87,15 @@ fn do_not_confirm_recipe_with_confirm_recipe_dependency() {
   Test::new()
     .justfile(
       "
-        dep_confirmation: requires_confirmation
-            echo mistake
+        bar: foo
+          echo BAR
 
         [confirm]
-        requires_confirmation:
-            echo confirmed
-        ",
+        @foo:
+          echo FOO
+      ",
     )
-    .stderr("Run recipe `requires_confirmation`? error: Recipe `requires_confirmation` was not confirmed\n")
+    .stderr("Run recipe `foo`? error: Recipe `foo` was not confirmed\n")
     .failure();
 }
 
@@ -106,13 +104,13 @@ fn confirm_recipe_with_prompt() {
   Test::new()
     .justfile(
       "
-        [confirm(\"This is dangerous - are you sure you want to run it?\")]
-        requires_confirmation:
-            echo confirmed
-        ",
+        [confirm('Sure?')]
+        @foo:
+            echo FOO
+      ",
     )
-    .stderr("This is dangerous - are you sure you want to run it? echo confirmed\n")
-    .stdout("confirmed\n")
+    .stderr("Sure? ")
+    .stdout("FOO\n")
     .stdin("y")
     .success();
 }
@@ -121,18 +119,17 @@ fn confirm_recipe_with_prompt() {
 fn confirm_recipe_with_prompt_too_many_args() {
   Test::new()
     .justfile(
-      r#"
-        [confirm("PROMPT","EXTRA")]
-        requires_confirmation:
-            echo confirmed
-      "#,
+      "
+        [confirm('A', 'B')]
+        foo:
+      ",
     )
     .stderr(
       r#"
         error: Attribute `confirm` got 2 arguments but takes at most 1 argument
          ——▶ justfile:1:2
           │
-        1 │ [confirm("PROMPT","EXTRA")]
+        1 │ [confirm('A', 'B')]
           │  ^^^^^^^
       "#,
     )
@@ -149,39 +146,26 @@ fn confirm_attribute_is_formatted_correctly() {
       ",
     )
     .arg("--dump")
-    .stdout("[confirm('prompt')]\nfoo:\n")
-    .success();
-}
-
-#[test]
-fn confirm_with_variable() {
-  Test::new()
-    .justfile(
-      r#"
-        target := "production"
-
-        [confirm(target)]
-        deploy:
-            echo deployed
-      "#,
+    .stdout(
+      "
+        [confirm('prompt')]
+        foo:
+      ",
     )
-    .stdin("y")
-    .stderr("production echo deployed\n")
-    .stdout("deployed\n")
     .success();
 }
 
 #[test]
-fn confirm_with_concatenation() {
+fn confirm_with_expression() {
   Test::new()
     .justfile(
-      r#"
-        target := "production"
+      "
+        target := 'production'
 
-        [confirm("Deploy to " + target + "?")]
+        [confirm('Deploy to ' + target + '?')]
         deploy:
             echo deployed
-      "#,
+      ",
     )
     .stdin("y")
     .stderr("Deploy to production? echo deployed\n")
@@ -190,55 +174,19 @@ fn confirm_with_concatenation() {
 }
 
 #[test]
-fn confirm_with_expression_and_yes_flag() {
-  Test::new()
-    .justfile(
-      r#"
-        target := "production"
-
-        [confirm("Deploy to " + target + "?")]
-        deploy:
-            echo deployed
-      "#,
-    )
-    .arg("--yes")
-    .stderr("echo deployed\n")
-    .stdout("deployed\n")
-    .success();
-}
-
-#[test]
 fn confirm_with_recipe_parameter() {
   Test::new()
     .justfile(
-      r#"
-        [confirm("Deploy to " + target + "?")]
+      "
+        [confirm('Deploy to ' + target + '?')]
         deploy target:
-            echo "deployed to {{target}}"
-      "#,
+            echo 'deployed to {{target}}'
+      ",
     )
     .args(["deploy", "staging"])
     .stdin("y")
-    .stderr("Deploy to staging? echo \"deployed to staging\"\n")
+    .stderr("Deploy to staging? echo 'deployed to staging'\n")
     .stdout("deployed to staging\n")
-    .success();
-}
-
-#[test]
-fn confirm_with_function_call() {
-  Test::new()
-    .justfile(
-      r#"
-        target := "production"
-
-        [confirm("Deploy to " + uppercase(target) + "?")]
-        deploy:
-            echo deployed
-      "#,
-    )
-    .stdin("y")
-    .stderr("Deploy to PRODUCTION? echo deployed\n")
-    .stdout("deployed\n")
     .success();
 }
 
@@ -246,17 +194,23 @@ fn confirm_with_function_call() {
 fn confirm_expression_dump() {
   Test::new()
     .justfile(
-      r#"
-        target := "production"
+      "
+        target := 'production'
 
-        [confirm("Deploy to " + target + "?")]
+        [confirm('Deploy to ' + target + '?')]
         deploy:
             echo deployed
-      "#,
+      ",
     )
     .arg("--dump")
     .stdout(
-      "target := \"production\"\n\n[confirm(\"Deploy to \" + target + \"?\")]\ndeploy:\n    echo deployed\n",
+      "
+        target := 'production'
+
+        [confirm('Deploy to ' + target + '?')]
+        deploy:
+            echo deployed
+      ",
     )
     .success();
 }

--- a/tests/confirm.rs
+++ b/tests/confirm.rs
@@ -125,13 +125,13 @@ fn confirm_recipe_with_prompt_too_many_args() {
       ",
     )
     .stderr(
-      r#"
+      "
         error: Attribute `confirm` got 2 arguments but takes at most 1 argument
          ——▶ justfile:1:2
           │
         1 │ [confirm('A', 'B')]
           │  ^^^^^^^
-      "#,
+      ",
     )
     .failure();
 }

--- a/tests/confirm.rs
+++ b/tests/confirm.rs
@@ -118,28 +118,6 @@ fn confirm_recipe_with_prompt() {
 }
 
 #[test]
-fn confirm_recipe_with_prompt_too_many_args() {
-  Test::new()
-    .justfile(
-      r#"
-        [confirm("PROMPT","EXTRA")]
-        requires_confirmation:
-            echo confirmed
-      "#,
-    )
-    .stderr(
-      r#"
-        error: Attribute `confirm` got 2 arguments but takes at most 1 argument
-         ——▶ justfile:1:2
-          │
-        1 │ [confirm("PROMPT","EXTRA")]
-          │  ^^^^^^^
-      "#,
-    )
-    .failure();
-}
-
-#[test]
 fn confirm_attribute_is_formatted_correctly() {
   Test::new()
     .justfile(
@@ -150,5 +128,113 @@ fn confirm_attribute_is_formatted_correctly() {
     )
     .arg("--dump")
     .stdout("[confirm('prompt')]\nfoo:\n")
+    .success();
+}
+
+#[test]
+fn confirm_with_variable() {
+  Test::new()
+    .justfile(
+      r#"
+        target := "production"
+
+        [confirm(target)]
+        deploy:
+            echo deployed
+      "#,
+    )
+    .stdin("y")
+    .stderr("production echo deployed\n")
+    .stdout("deployed\n")
+    .success();
+}
+
+#[test]
+fn confirm_with_concatenation() {
+  Test::new()
+    .justfile(
+      r#"
+        target := "production"
+
+        [confirm("Deploy to " + target + "?")]
+        deploy:
+            echo deployed
+      "#,
+    )
+    .stdin("y")
+    .stderr("Deploy to production? echo deployed\n")
+    .stdout("deployed\n")
+    .success();
+}
+
+#[test]
+fn confirm_with_expression_and_yes_flag() {
+  Test::new()
+    .justfile(
+      r#"
+        target := "production"
+
+        [confirm("Deploy to " + target + "?")]
+        deploy:
+            echo deployed
+      "#,
+    )
+    .arg("--yes")
+    .stderr("echo deployed\n")
+    .stdout("deployed\n")
+    .success();
+}
+
+#[test]
+fn confirm_with_recipe_parameter() {
+  Test::new()
+    .justfile(
+      r#"
+        [confirm("Deploy to " + target + "?")]
+        deploy target:
+            echo "deployed to {{target}}"
+      "#,
+    )
+    .args(["deploy", "staging"])
+    .stdin("y")
+    .stderr("Deploy to staging? echo \"deployed to staging\"\n")
+    .stdout("deployed to staging\n")
+    .success();
+}
+
+#[test]
+fn confirm_with_function_call() {
+  Test::new()
+    .justfile(
+      r#"
+        target := "production"
+
+        [confirm("Deploy to " + uppercase(target) + "?")]
+        deploy:
+            echo deployed
+      "#,
+    )
+    .stdin("y")
+    .stderr("Deploy to PRODUCTION? echo deployed\n")
+    .stdout("deployed\n")
+    .success();
+}
+
+#[test]
+fn confirm_expression_dump() {
+  Test::new()
+    .justfile(
+      r#"
+        target := "production"
+
+        [confirm("Deploy to " + target + "?")]
+        deploy:
+            echo deployed
+      "#,
+    )
+    .arg("--dump")
+    .stdout(
+      "target := \"production\"\n\n[confirm(\"Deploy to \" + target + \"?\")]\ndeploy:\n    echo deployed\n",
+    )
     .success();
 }

--- a/tests/confirm.rs
+++ b/tests/confirm.rs
@@ -17,28 +17,6 @@ fn confirm_recipe_arg() {
 }
 
 #[test]
-fn confirm_recipe_with_prompt_too_many_args() {
-  Test::new()
-    .justfile(
-      r#"
-        [confirm("PROMPT","EXTRA")]
-        requires_confirmation:
-            echo confirmed
-      "#,
-    )
-    .stderr(
-      r#"
-        error: Attribute `confirm` got 2 arguments but takes at most 1 argument
-         ——▶ justfile:1:2
-          │
-        1 │ [confirm("PROMPT","EXTRA")]
-          │  ^^^^^^^
-      "#,
-    )
-    .failure();
-}
-
-#[test]
 fn recipe_with_confirm_recipe_dependency_arg() {
   Test::new()
     .arg("--yes")
@@ -137,6 +115,28 @@ fn confirm_recipe_with_prompt() {
     .stdout("confirmed\n")
     .stdin("y")
     .success();
+}
+
+#[test]
+fn confirm_recipe_with_prompt_too_many_args() {
+  Test::new()
+    .justfile(
+      r#"
+        [confirm("PROMPT","EXTRA")]
+        requires_confirmation:
+            echo confirmed
+      "#,
+    )
+    .stderr(
+      r#"
+        error: Attribute `confirm` got 2 arguments but takes at most 1 argument
+         ——▶ justfile:1:2
+          │
+        1 │ [confirm("PROMPT","EXTRA")]
+          │  ^^^^^^^
+      "#,
+    )
+    .failure();
 }
 
 #[test]

--- a/tests/confirm.rs
+++ b/tests/confirm.rs
@@ -1,6 +1,22 @@
 use super::*;
 
 #[test]
+fn confirm_recipe_arg() {
+  Test::new()
+    .arg("--yes")
+    .justfile(
+      "
+        [confirm]
+        requires_confirmation:
+            echo confirmed
+        ",
+    )
+    .stderr("echo confirmed\n")
+    .stdout("confirmed\n")
+    .success();
+}
+
+#[test]
 fn confirm_recipe_with_prompt_too_many_args() {
   Test::new()
     .justfile(
@@ -20,22 +36,6 @@ fn confirm_recipe_with_prompt_too_many_args() {
       "#,
     )
     .failure();
-}
-
-#[test]
-fn confirm_recipe_arg() {
-  Test::new()
-    .arg("--yes")
-    .justfile(
-      "
-        [confirm]
-        requires_confirmation:
-            echo confirmed
-        ",
-    )
-    .stderr("echo confirmed\n")
-    .stdout("confirmed\n")
-    .success();
 }
 
 #[test]

--- a/tests/undefined_variables.rs
+++ b/tests/undefined_variables.rs
@@ -6,12 +6,12 @@ fn parameter_default_unknown_variable_in_expression() {
     .justfile("foo a=(b+''):")
     .stderr(
       "
-      error: Variable `b` not defined
-       ——▶ justfile:1:8
-        │
-      1 │ foo a=(b+''):
-        │        ^
-    ",
+        error: Variable `b` not defined
+         ——▶ justfile:1:8
+          │
+        1 │ foo a=(b+''):
+          │        ^
+      ",
     )
     .failure();
 }
@@ -21,16 +21,16 @@ fn unknown_variable_in_unary_call() {
   Test::new()
     .justfile(
       "
-    foo x=env_var(a):
-  ",
+        foo x=env_var(a):
+      ",
     )
     .stderr(
       "
-      error: Variable `a` not defined
-       ——▶ justfile:1:15
-        │
-      1 │ foo x=env_var(a):
-        │               ^
+        error: Variable `a` not defined
+         ——▶ justfile:1:15
+          │
+        1 │ foo x=env_var(a):
+          │               ^
       ",
     )
     .failure();
@@ -41,16 +41,16 @@ fn unknown_first_variable_in_binary_call() {
   Test::new()
     .justfile(
       "
-    foo x=env_var_or_default(a, b):
-  ",
+        foo x=env_var_or_default(a, b):
+      ",
     )
     .stderr(
       "
-      error: Variable `a` not defined
-       ——▶ justfile:1:26
-        │
-      1 │ foo x=env_var_or_default(a, b):
-        │                          ^
+        error: Variable `a` not defined
+         ——▶ justfile:1:26
+          │
+        1 │ foo x=env_var_or_default(a, b):
+          │                          ^
       ",
     )
     .failure();
@@ -61,16 +61,16 @@ fn unknown_second_variable_in_binary_call() {
   Test::new()
     .justfile(
       "
-    foo x=env_var_or_default('', b):
-  ",
+        foo x=env_var_or_default('', b):
+      ",
     )
     .stderr(
       "
-      error: Variable `b` not defined
-       ——▶ justfile:1:30
-        │
-      1 │ foo x=env_var_or_default('', b):
-        │                              ^
+        error: Variable `b` not defined
+         ——▶ justfile:1:30
+          │
+        1 │ foo x=env_var_or_default('', b):
+          │                              ^
       ",
     )
     .failure();
@@ -81,16 +81,16 @@ fn unknown_variable_in_ternary_call() {
   Test::new()
     .justfile(
       "
-    foo x=replace(a, b, c):
-  ",
+        foo x=replace(a, b, c):
+      ",
     )
     .stderr(
       "
-      error: Variable `a` not defined
-       ——▶ justfile:1:15
-        │
-      1 │ foo x=replace(a, b, c):
-        │               ^
+        error: Variable `a` not defined
+         ——▶ justfile:1:15
+          │
+        1 │ foo x=replace(a, b, c):
+          │               ^
       ",
     )
     .failure();

--- a/tests/undefined_variables.rs
+++ b/tests/undefined_variables.rs
@@ -1,27 +1,6 @@
 use super::*;
 
 #[test]
-fn undefined_variable_in_confirm_expression() {
-  Test::new()
-    .justfile(
-      "
-    [confirm(x)]
-    foo:
-  ",
-    )
-    .stderr(
-      "
-      error: Variable `x` not defined
-       ——▶ justfile:1:10
-        │
-      1 │ [confirm(x)]
-        │          ^
-      ",
-    )
-    .failure();
-}
-
-#[test]
 fn parameter_default_unknown_variable_in_expression() {
   Test::new()
     .justfile("foo a=(b+''):")
@@ -112,6 +91,27 @@ fn unknown_variable_in_ternary_call() {
         │
       1 │ foo x=replace(a, b, c):
         │               ^
+      ",
+    )
+    .failure();
+}
+
+#[test]
+fn undefined_variable_in_confirm_expression() {
+  Test::new()
+    .justfile(
+      "
+        [confirm(x)]
+        foo:
+      ",
+    )
+    .stderr(
+      "
+        error: Variable `x` not defined
+         ——▶ justfile:1:10
+          │
+        1 │ [confirm(x)]
+          │          ^
       ",
     )
     .failure();

--- a/tests/undefined_variables.rs
+++ b/tests/undefined_variables.rs
@@ -1,6 +1,27 @@
 use super::*;
 
 #[test]
+fn undefined_variable_in_confirm_expression() {
+  Test::new()
+    .justfile(
+      "
+    [confirm(x)]
+    foo:
+  ",
+    )
+    .stderr(
+      "
+      error: Variable `x` not defined
+       ——▶ justfile:1:10
+        │
+      1 │ [confirm(x)]
+        │          ^
+      ",
+    )
+    .failure();
+}
+
+#[test]
 fn parameter_default_unknown_variable_in_expression() {
   Test::new()
     .justfile("foo a=(b+''):")


### PR DESCRIPTION
The confirmation prompt accepts any expression, so you can use variables,
concatenation, and function calls:

```just
target := "production"
[confirm("Deploy to " + target + "?")]
deploy:
  echo 'Deploying...'
```

Recipe parameters can also be used in confirmation prompts:

```just
[confirm("Deploy to " + env + "?")]
deploy env:
  echo 'Deploying to {{env}}...'
```