### PR TITLE
Release 1.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,47 @@
 Changelog
 =========
 
+[1.49.0](https://github.com/casey/just/releases/tag/1.49.0) - 2026-04-04
+------------------------------------------------------------------------
+
+### Added
+- Add `--time` to print recipe execution time ([#3099](https://github.com/casey/just/pull/3099) by [GeorgeLS](https://github.com/GeorgeLS))
+- Add user-defined functions ([#3247](https://github.com/casey/just/pull/3247) by [casey](https://github.com/casey))
+- Add just skill for agents ([#3241](https://github.com/casey/just/pull/3241) by [casey](https://github.com/casey))
+- Allow expressions in confirm attribute ([#3238](https://github.com/casey/just/pull/3238) by [begoon](https://github.com/begoon))
+- Add `--complete-aliases` ([#3235](https://github.com/casey/just/pull/3235) by [casey](https://github.com/casey))
+- Add `--justfile-name` to configure justfile filename ([#3234](https://github.com/casey/just/pull/3234) by [casey](https://github.com/casey))
+- Add `runtime_directory()` function ([#3226](https://github.com/casey/just/pull/3226) by [barskern](https://github.com/barskern))
+- Add `--evaluate-format` ([#3221](https://github.com/casey/just/pull/3221) by [casey](https://github.com/casey))
+- Allow passing variable and module paths to `--evaluate` ([#3219](https://github.com/casey/just/pull/3219) by [casey](https://github.com/casey))
+- Add `--indentation` ([#3215](https://github.com/casey/just/pull/3215) by [casey](https://github.com/casey))
+- Add `module_file()` and `module_directory()` to readme ([#2965](https://github.com/casey/just/pull/2965) by [cspotcode](https://github.com/cspotcode))
+- Add Nix flake ([#2972](https://github.com/casey/just/pull/2972) by [neunenak](https://github.com/neunenak))
+
+### Fixed
+- Allow reading `.env` from special files ([#3250](https://github.com/casey/just/pull/3250) by [casey](https://github.com/casey))
+- Load environment files in submodules ([#3243](https://github.com/casey/just/pull/3243) by [casey](https://github.com/casey))
+- Avoid process substitution in bash completion script ([#3217](https://github.com/casey/just/pull/3217) by [casey](https://github.com/casey))
+- Dont pass shell name to powershell ([#3209](https://github.com/casey/just/pull/3209) by [casey](https://github.com/casey))
+
+### Misc
+- Add just implementation of rule110 ([#3249](https://github.com/casey/just/pull/3249) by [casey](https://github.com/casey))
+- Add instructions for skill to readme ([#3245](https://github.com/casey/just/pull/3245) by [casey](https://github.com/casey))
+- Remove comma in readme ([#3244](https://github.com/casey/just/pull/3244) by [casey](https://github.com/casey))
+- Move bash completion registration script into etc/ ([#3242](https://github.com/casey/just/pull/3242) by [casey](https://github.com/casey))
+- Avoid to_string_lossy in directory function tests ([#3232](https://github.com/casey/just/pull/3232) by [casey](https://github.com/casey))
+- Add installation overview ([#3231](https://github.com/casey/just/pull/3231) by [casey](https://github.com/casey))
+- Warn if invocation directory or justfile path is not Unicode ([#3230](https://github.com/casey/just/pull/3230) by [casey](https://github.com/casey))
+- Don't use make syntax highlighting in vim ([#2906](https://github.com/casey/just/pull/2906) by [alerque](https://github.com/alerque))
+- Fix Name Display impl to pad correctly ([#3222](https://github.com/casey/just/pull/3222) by [casey](https://github.com/casey))
+- Rename `evaluate_target` to `evaluation_target` ([#3220](https://github.com/casey/just/pull/3220) by [casey](https://github.com/casey))
+- Include recipe path in verbose output ([#3213](https://github.com/casey/just/pull/3213) by [behnam-oneschema](https://github.com/behnam-oneschema))
+- Move recipe methods onto resolved recipe ([#3214](https://github.com/casey/just/pull/3214) by [casey](https://github.com/casey))
+- Document that `semver_matches()` returns strings ([#3212](https://github.com/casey/just/pull/3212) by [casey](https://github.com/casey))
+- Build riscv64 release binaries ([#3210](https://github.com/casey/just/pull/3210) by [gounthar](https://github.com/gounthar))
+- Include shell name in I/O error messages ([#3208](https://github.com/casey/just/pull/3208) by [casey](https://github.com/casey))
+- Don't print signal error message if recipe has `[no-exit-message]` ([#3200](https://github.com/casey/just/pull/3200) by [imp-joshi](https://github.com/imp-joshi))
+
 [1.48.1](https://github.com/casey/just/releases/tag/1.48.1) - 2026-03-27
 ------------------------------------------------------------------------
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,16 +122,16 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "memmap2",
  "rayon-core",
 ]
@@ -185,9 +185,9 @@ checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
 name = "find-msvc-tools"
@@ -586,9 +586,9 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -619,9 +619,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "just"
-version = "1.48.1"
+version = "1.49.0"
 dependencies = [
  "ansi_term",
  "blake3",
@@ -684,9 +684,9 @@ checksum = "441225017b106b9f902e97947a6d31e44ebcf274b91bdbfb51e5c477fcd468e5"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libredox"
@@ -961,9 +961,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "roff"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf2048e0e979efb2ca7b91c4f1a8d77c91853e9b987c94c555668a8994915ad"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rustix"
@@ -992,9 +992,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1080,9 +1080,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "26d0b06eba54f0ca0770f970a3e89823e766ca638dd940f8469fa0fa50c75396"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -1332,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1345,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1355,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1368,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "just"
-version = "1.48.1"
+version = "1.49.0"
 authors = ["Casey Rodarmor <casey@rodarmor.com>"]
 autotests = false
 categories = ["command-line-utilities", "development-tools"]
@@ -42,7 +42,7 @@ serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = "1.0.68"
 sha2 = "0.10.9"
 shellexpand = "3.1.0"
-similar = { version = "2.1.0", features = ["unicode"] }
+similar = { version = "3.0.0", features = ["unicode"] }
 snafu = "0.9.0"
 strum = { version = "0.28.0", features = ["derive"] }
 target = "2.0.0"

--- a/README.md
+++ b/README.md
@@ -1173,7 +1173,7 @@ Starting server with database localhost:6379 on port 1337…
 Variables in environment files loaded in parent modules are inherited by
 submodules.
 
-Environment files are loaded in submodules<sup>master<sup> and may override
+Environment files are loaded in submodules<sup>1.49.0<sup> and may override
 variable defined in parent module environment files.
 
 #### Export
@@ -1455,7 +1455,7 @@ hello
 ```
 
 All variables in a submodule or a single variable in a submodule may be printed
-with a path to the submodule or variable<sup>master</sup>:
+with a path to the submodule or variable<sup>1.49.0</sup>:
 
 ```console
 $ just --evaluate bob::bar
@@ -1466,7 +1466,7 @@ hello
 ```
 
 The format of exported variables may be controlled with
-`--evaluate-format`<sup>master</sup>:
+`--evaluate-format`<sup>1.49.0</sup>:
 
 ```console
 $ just --evaluate --evaluate-format shell
@@ -2226,7 +2226,7 @@ xdg_config_dir := if env('XDG_CONFIG_HOME', '') =~ '^/' {
 
 ### User-defined functions
 
-New functions may be defined<sup>master</sup>:
+New functions may be defined<sup>1.49.0</sup>:
 
 ```just
 set unstable
@@ -2454,7 +2454,7 @@ delete-everything:
   rm -rf *
 ```
 
-The confirmation prompt may also be an expression<sup>master</sup> which may
+The confirmation prompt may also be an expression<sup>1.49.0</sup> which may
 reference assignments or recipe arguments:
 
 ```just


### PR DESCRIPTION
- Bump version: 1.48.1 → 1.49.0
- Update changelog
- Update changelog contributor credits
- Update dependencies
- Update readme version references