### PR TITLE
Ignore trailing `::` on last argument in invocation

### DIFF
--- a/src/invocation_parser.rs
+++ b/src/invocation_parser.rs
@@ -50,8 +50,13 @@ impl<'src: 'run, 'run> InvocationParser<'src, 'run> {
   fn parse_invocation(&mut self) -> RunResult<'src, Invocation<'src, 'run>> {
     let recipe = if let Some(next) = self.next() {
       if next.contains(':') {
+        let path = if self.next + 1 == self.arguments.len() {
+          next.strip_suffix("::").unwrap_or(next)
+        } else {
+          next
+        };
         let modulepath =
-          Modulepath::try_from([next].as_slice()).map_err(|()| Error::UnknownRecipe {
+          Modulepath::try_from([path].as_slice()).map_err(|()| Error::UnknownRecipe {
             recipe: next.into(),
             suggestion: None,
           })?;
@@ -618,6 +623,51 @@ foo baz qux='qux' bar='bar':
     assert_eq!(
       invocations[0].arguments,
       vec![vec![String::from("--bar")], Vec::new(), Vec::new()]
+    );
+  }
+
+  #[test]
+  fn trailing_separator_runs_default_recipe() {
+    let tempdir = tempfile::tempdir().unwrap();
+    tempdir.write("justfile", "mod foo");
+    tempdir.write("foo.just", "bar:");
+
+    let loader = Loader::new();
+    let compilation = Compiler::compile(
+      &Config::new().unwrap(),
+      &loader,
+      &tempdir.path().join("justfile"),
+    )
+    .unwrap();
+
+    let invocations =
+      InvocationParser::parse_invocations(&compilation.justfile, &["foo::"]).unwrap();
+
+    assert_eq!(invocations.len(), 1);
+    assert_eq!(invocations[0].recipe.recipe_path().to_string(), "foo::bar");
+    assert!(invocations[0].arguments.is_empty());
+  }
+
+  #[test]
+  fn trailing_separator_not_last_argument() {
+    let tempdir = tempfile::tempdir().unwrap();
+    tempdir.write("justfile", "mod foo");
+    tempdir.write("foo.just", "bar:");
+
+    let loader = Loader::new();
+    let compilation = Compiler::compile(
+      &Config::new().unwrap(),
+      &loader,
+      &tempdir.path().join("justfile"),
+    )
+    .unwrap();
+
+    assert_matches!(
+      InvocationParser::parse_invocations(&compilation.justfile, &["foo::", "bar"]).unwrap_err(),
+      Error::UnknownRecipe {
+        recipe,
+        suggestion: None
+      } if recipe == "foo::",
     );
   }
 }

--- a/tests/modules.rs
+++ b/tests/modules.rs
@@ -1226,3 +1226,61 @@ fn verbose_message_includes_module_path() {
     .stdout("BAR\n")
     .success();
 }
+
+#[test]
+fn trailing_separator_runs_default_recipe() {
+  Test::new()
+    .write("foo.just", "@bar:\n echo FOO")
+    .justfile(
+      "
+        mod foo
+      ",
+    )
+    .arg("foo::")
+    .stdout("FOO\n")
+    .success();
+}
+
+#[test]
+fn nested_trailing_separator_runs_default_recipe() {
+  Test::new()
+    .write("foo.just", "mod bar")
+    .write("bar.just", "@baz:\n echo BAZ")
+    .justfile(
+      "
+        mod foo
+      ",
+    )
+    .arg("foo::bar::")
+    .stdout("BAZ\n")
+    .success();
+}
+
+#[test]
+fn trailing_separator_no_default_recipe() {
+  Test::new()
+    .write("foo.just", "import 'bar.just'")
+    .write("bar.just", "bar:\n @echo BAR")
+    .justfile(
+      "
+        mod foo
+      ",
+    )
+    .arg("foo::")
+    .stderr("error: Justfile contains no default recipe.\n")
+    .failure();
+}
+
+#[test]
+fn trailing_separator_not_last_argument() {
+  Test::new()
+    .write("foo.just", "bar:\n @echo BAR")
+    .justfile(
+      "
+        mod foo
+      ",
+    )
+    .args(["foo::", "bar"])
+    .stderr("error: Justfile does not contain recipe `foo::`\n")
+    .failure();
+}


### PR DESCRIPTION
Fixes #2744.