### PR TITLE
Surround interoplation expressions with spaces when formatting

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ run:
 
 # only run tests matching `PATTERN`
 [group: 'test']
-filter PATTERN: (watch f'ltest --tests --all --all-targets {{PATTERN}}')
+filter PATTERN: (watch f'ltest --tests --all --all-targets {{ PATTERN }}')
 
 [group: 'misc']
 build:

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -202,7 +202,7 @@ impl Display for Expression<'_> {
         write!(f, "{start}")?;
 
         for (expression, string) in expressions {
-          write!(f, "{expression}{string}")?;
+          write!(f, " {expression} {string}")?;
         }
 
         Ok(())

--- a/tests/format_string.rs
+++ b/tests/format_string.rs
@@ -254,9 +254,18 @@ fn dump() {
   case("f''''''");
   case(r#"f"""#);
   case(r#"f"""""""#);
-  case("f'{{'a'}}b{{'c'}}d'");
-  case("f'''{{'a'}}b{{'c'}}d'''");
-  case(r#"f"""{{'a'}}b{{'c'}}d""""#);
+  case("f'{{ 'a' }}b{{ 'c' }}d'");
+  case("f'''{{ 'a' }}b{{ 'c' }}d'''");
+  case(r#"f"""{{ 'a' }}b{{ 'c' }}d""""#);
+}
+
+#[test]
+fn interpolation_expressions_are_formatted_with_spaces() {
+  Test::new()
+    .justfile("foo := f'{{'a'}}'")
+    .arg("--dump")
+    .stdout("foo := f'{{ 'a' }}'\n")
+    .success();
 }
 
 #[test]


### PR DESCRIPTION
Fixes #3334.